### PR TITLE
feat(protocol): implement reflector client

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,1 +1,0 @@
-package liblbry

--- a/errors/common.go
+++ b/errors/common.go
@@ -9,6 +9,7 @@ import (
 // Common errors
 var (
 	ErrBlobNotFound     = errors.New("blob not found")
+	ErrBlobExists       = errors.New("blob already exists on server")
 	ErrInvalidHash      = errors.New("invalid hash")
 	ErrInvalidSize      = errors.New("invalid size")
 	ErrStreamCorrupted  = errors.New("stream corrupted")
@@ -24,6 +25,7 @@ var (
 	ErrBlobProtected    = errors.New("requested blob is protected")
 	ErrNoBlobData       = errors.New("no blob data received")
 	ErrAlreadyConnected = errors.New("already connected")
+	ErrServerValidation = errors.New("server validation error")
 )
 
 // IsBlobNotFoundError checks if an error represents a blob not found condition
@@ -39,6 +41,7 @@ func IsBlobNotFoundError(err error) bool {
 // IsKnownErrorType checks if an error is a known protocol error that shouldn't be wrapped
 func IsKnownErrorType(err error) bool {
 	return err == ErrBlobNotFound ||
+		err == ErrBlobExists ||
 		err == ErrInvalidHash ||
 		err == ErrInvalidSize ||
 		err == ErrStreamCorrupted ||
@@ -57,6 +60,8 @@ func DetectErrorType(errorMsg string) error {
 	switch errorMsg {
 	case ErrBlobNotFound.Error():
 		return ErrBlobNotFound
+	case ErrBlobExists.Error():
+		return ErrBlobExists
 	case ErrAccessDenied.Error():
 		return ErrAccessDenied
 	case ErrInvalidHash.Error():

--- a/protocol/e2e/client_peer_test.go
+++ b/protocol/e2e/client_peer_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"errors"
-	"net"
 	"os"
 	"strings"
 	"testing"
@@ -12,105 +11,19 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/liblbry/blob"
-	liblbryerrors "go.lumeweb.com/liblbry/errors"
-	internaltesting "go.lumeweb.com/liblbry/internal/testing"
+	lbrytesting "go.lumeweb.com/liblbry/internal/testing"
 	"go.lumeweb.com/liblbry/protocol"
 	"go.uber.org/zap/zaptest"
 )
 
 const (
-	defaultPeerAddr = "s1.lbry.network:5567"
-	knownSDHash     = "acc6adf8b4f10dcddffc5c2ca87dbd9cb3a2664564695ac7aaab038193ff14a280cc3d4ebae55c71d0b885a7316d0137"
-	invalidHash     = "invalidhash"
-	nonExistentHash = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-	malformedHash   = "xyz123"
-	emptyHash       = ""
+	defaultPeerAddr         = "s1.lbry.network:5567"
+	knownSDHash             = "acc6adf8b4f10dcddffc5c2ca87dbd9cb3a2664564695ac7aaab038193ff14a280cc3d4ebae55c71d0b885a7316d0137"
+	invalidDownloadHash     = "invalidhash"
+	nonExistentDownloadHash = "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+	malformedDownloadHash   = "xyz123"
+	emptyDownloadHash       = ""
 )
-
-// errorContains checks if an error contains any of the given substrings
-func errorContains(err error, indicators []string) bool {
-	if err == nil {
-		return false
-	}
-
-	errStr := err.Error()
-
-	for _, indicator := range indicators {
-		if containsIgnoreCase(errStr, indicator) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// isBlobNotFoundError checks if an error indicates a blob was not found
-func isBlobNotFoundError(err error) bool {
-	// First check if it's a context/timeout error - those aren't "not found" errors
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-		return false
-	}
-
-	notFoundIndicators := []string{
-		"not found",
-		liblbryerrors.ErrBlobNotFound.Error(),
-	}
-
-	// Check if it's a wrapped liblbry not found error
-	if liblbryerrors.Is(err, liblbryerrors.ErrBlobNotFound) {
-		return true
-	}
-
-	return errorContains(err, notFoundIndicators)
-}
-
-// isNetworkError checks if an error is a network-related error
-func isNetworkError(err error) bool {
-	// Check for context/timeout errors first
-	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
-		return true
-	}
-
-	networkErrorIndicators := []string{
-		"i/o timeout",
-		"connection refused",
-		"connection reset",
-		"network is unreachable",
-		"no route to host",
-		"not connected",
-		"no such host",
-		"timeout",
-		"deadline exceeded",
-	}
-
-	// Check for wrapped network errors
-	var netErr net.Error
-	if errors.As(err, &netErr) {
-		return true
-	}
-
-	return errorContains(err, networkErrorIndicators)
-}
-
-// isValidationError checks if an error is due to invalid input validation
-func isValidationError(err error) bool {
-	// Check for wrapped validation errors
-	if liblbryerrors.Is(err, liblbryerrors.ErrInvalidHashLen) {
-		return true
-	}
-
-	validationIndicators := []string{
-		"invalid request",
-		"malformed",
-	}
-
-	return errorContains(err, validationIndicators)
-}
-
-// containsIgnoreCase checks if a string contains a substring ignoring case
-func containsIgnoreCase(s, substr string) bool {
-	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
-}
 
 // createTestClient creates a new PeerClient with standard configuration
 func createTestClient(t *testing.T, timeout time.Duration) protocol.PeerClient {
@@ -130,15 +43,15 @@ func createTestClient(t *testing.T, timeout time.Duration) protocol.PeerClient {
 func createConnectedClient(t *testing.T, timeout time.Duration) protocol.PeerClient {
 	t.Helper()
 	client := createTestClient(t, timeout)
-	connectToReflector(t, client)
+	connectToPeer(t, client)
 	return client
 }
 
-// connectToReflector connects a client to the public reflector server.
+// connectToPeer connects a client to the public peer server.
 // These are end-to-end integration tests that require network access to
 // s1.lbry.network:5567 (configurable via LIBLBRY_E2E_PEER_ADDR env var).
 // Tests may fail if the reflector service is unavailable.
-func connectToReflector(t *testing.T, client protocol.PeerClient) {
+func connectToPeer(t *testing.T, client protocol.PeerClient) {
 	t.Helper()
 	addr := defaultPeerAddr
 	if v := strings.TrimSpace(os.Getenv("LIBLBRY_E2E_PEER_ADDR")); v != "" {
@@ -150,26 +63,6 @@ func connectToReflector(t *testing.T, client protocol.PeerClient) {
 	require.NoError(t, err, "Failed to connect to reflector server")
 }
 
-// assertValidationError checks that an error is a validation error
-func assertValidationError(t *testing.T, err error, msg string) {
-	t.Helper()
-	require.Error(t, err, msg)
-	require.True(t, isValidationError(err), "Expected validation error, got: %v", err)
-}
-
-// assertBlobNotFoundError checks that an error indicates a blob was not found
-func assertBlobNotFoundError(t *testing.T, err error, msg string) {
-	t.Helper()
-	require.Error(t, err, msg)
-	require.True(t, isBlobNotFoundError(err), "Expected blob not found error, got: %v", err)
-}
-
-// assertNetworkError checks that an error is a network-related error
-func assertNetworkError(t *testing.T, err error, msg string) {
-	t.Helper()
-	require.Error(t, err, msg)
-	require.True(t, isNetworkError(err), "Expected network error, got: %v", err)
-}
 func TestPeerClientIntegration(t *testing.T) {
 	ctx := context.Background()
 
@@ -216,27 +109,27 @@ func TestPeerClientIntegration(t *testing.T) {
 
 		// Test HasBlob with invalid hash
 		t.Run("HasBlobInvalidHash", func(t *testing.T) {
-			has, err := client.HasBlob(ctx, invalidHash)
-			assertValidationError(t, err, "Should return validation error for invalid hash")
+			has, err := client.HasBlob(ctx, invalidDownloadHash)
+			assertUploadValidationError(t, err, "Should return validation error for invalid hash")
 			require.False(t, has, "Invalid hash should not be found")
 		})
 
 		// Test HasBlob with non-existent valid hash
 		t.Run("HasBlobNonExistent", func(t *testing.T) {
-			has, err := client.HasBlob(ctx, nonExistentHash)
+			has, err := client.HasBlob(ctx, nonExistentDownloadHash)
 			require.NoError(t, err)
 			require.False(t, has, "Non-existent hash should not be found")
 		})
 
 		// Test GetBlob error handling with invalid hash
 		t.Run("GetBlobInvalidHash", func(t *testing.T) {
-			_, err := client.GetBlob(ctx, invalidHash)
-			assertValidationError(t, err, "Should return validation error for invalid hash")
+			_, err := client.GetBlob(ctx, invalidDownloadHash)
+			assertUploadValidationError(t, err, "Should return validation error for invalid hash")
 		})
 
 		// Test GetBlob error handling with non-existent hash
 		t.Run("GetBlobNonExistent", func(t *testing.T) {
-			_, err := client.GetBlob(ctx, nonExistentHash)
+			_, err := client.GetBlob(ctx, nonExistentDownloadHash)
 			if isNetworkError(err) {
 				t.Skipf("Skipping test due to network error (likely timeout): %v", err)
 			}
@@ -293,13 +186,13 @@ func TestPeerClientIntegration(t *testing.T) {
 	// Concurrent access tests
 	t.Run("ConcurrentAccess", func(t *testing.T) {
 		// Create multiple independent client instances to exercise true parallel IO
-		createAdapter := func() internaltesting.StoreOperations {
+		createAdapter := func() lbrytesting.StoreOperations {
 			client := createConnectedClient(t, 30*time.Second)
 			return &PeerClientAdapter{client: client}
 		}
 
 		// Test concurrent Has operations using multiple client instances
-		internaltesting.TestConcurrentHasMultiple(t, createAdapter, knownSDHash, true, 10, 5)
+		lbrytesting.TestConcurrentHasMultiple(t, createAdapter, knownSDHash, true, 10, 5)
 	})
 
 	// Context cancellation handling
@@ -358,22 +251,22 @@ func TestPeerClientIntegration(t *testing.T) {
 
 		// Test with empty hash
 		t.Run("EmptyHash", func(t *testing.T) {
-			has, err := client.HasBlob(ctx, emptyHash)
-			assertValidationError(t, err, "Should return validation error for empty hash")
+			has, err := client.HasBlob(ctx, emptyDownloadHash)
+			assertUploadValidationError(t, err, "Should return validation error for empty hash")
 			require.False(t, has, "Empty hash should not be found")
 
-			_, err = client.GetBlob(ctx, emptyHash)
-			assertValidationError(t, err, "Should return validation error for empty hash")
+			_, err = client.GetBlob(ctx, emptyDownloadHash)
+			assertUploadValidationError(t, err, "Should return validation error for empty hash")
 		})
 
 		// Test with malformed hex hash
 		t.Run("MalformedHexHash", func(t *testing.T) {
-			has, err := client.HasBlob(ctx, malformedHash)
-			assertValidationError(t, err, "Should return validation error for malformed hex hash")
+			has, err := client.HasBlob(ctx, malformedDownloadHash)
+			assertUploadValidationError(t, err, "Should return validation error for malformed hex hash")
 			require.False(t, has, "Malformed hex hash should not be found")
 
-			_, err = client.GetBlob(ctx, malformedHash)
-			assertValidationError(t, err, "Should return validation error for malformed hex hash")
+			_, err = client.GetBlob(ctx, malformedDownloadHash)
+			assertUploadValidationError(t, err, "Should return validation error for malformed hex hash")
 		})
 	})
 
@@ -402,13 +295,13 @@ func TestPeerClientIntegration(t *testing.T) {
 		client := createConnectedClient(t, 30*time.Second)
 
 		// Test with empty string as hash
-		has, err := client.HasBlob(ctx, emptyHash)
-		assertValidationError(t, err, "Should return validation error for empty hash")
+		has, err := client.HasBlob(ctx, emptyDownloadHash)
+		assertUploadValidationError(t, err, "Should return validation error for empty hash")
 		require.False(t, has, "Empty hash should not be found")
 
 		// Test fetching empty hash
-		_, err = client.GetBlob(ctx, emptyHash)
-		assertValidationError(t, err, "Should return validation error for empty hash")
+		_, err = client.GetBlob(ctx, emptyDownloadHash)
+		assertUploadValidationError(t, err, "Should return validation error for empty hash")
 	})
 }
 

--- a/protocol/e2e/client_peer_test.go
+++ b/protocol/e2e/client_peer_test.go
@@ -110,7 +110,7 @@ func TestPeerClientIntegration(t *testing.T) {
 		// Test HasBlob with invalid hash
 		t.Run("HasBlobInvalidHash", func(t *testing.T) {
 			has, err := client.HasBlob(ctx, invalidDownloadHash)
-			assertUploadValidationError(t, err, "Should return validation error for invalid hash")
+			assertValidationError(t, err, "Should return validation error for invalid hash")
 			require.False(t, has, "Invalid hash should not be found")
 		})
 
@@ -124,7 +124,7 @@ func TestPeerClientIntegration(t *testing.T) {
 		// Test GetBlob error handling with invalid hash
 		t.Run("GetBlobInvalidHash", func(t *testing.T) {
 			_, err := client.GetBlob(ctx, invalidDownloadHash)
-			assertUploadValidationError(t, err, "Should return validation error for invalid hash")
+			assertValidationError(t, err, "Should return validation error for invalid hash")
 		})
 
 		// Test GetBlob error handling with non-existent hash
@@ -252,21 +252,21 @@ func TestPeerClientIntegration(t *testing.T) {
 		// Test with empty hash
 		t.Run("EmptyHash", func(t *testing.T) {
 			has, err := client.HasBlob(ctx, emptyDownloadHash)
-			assertUploadValidationError(t, err, "Should return validation error for empty hash")
+			assertValidationError(t, err, "Should return validation error for empty hash")
 			require.False(t, has, "Empty hash should not be found")
 
 			_, err = client.GetBlob(ctx, emptyDownloadHash)
-			assertUploadValidationError(t, err, "Should return validation error for empty hash")
+			assertValidationError(t, err, "Should return validation error for empty hash")
 		})
 
 		// Test with malformed hex hash
 		t.Run("MalformedHexHash", func(t *testing.T) {
 			has, err := client.HasBlob(ctx, malformedDownloadHash)
-			assertUploadValidationError(t, err, "Should return validation error for malformed hex hash")
+			assertValidationError(t, err, "Should return validation error for malformed hex hash")
 			require.False(t, has, "Malformed hex hash should not be found")
 
 			_, err = client.GetBlob(ctx, malformedDownloadHash)
-			assertUploadValidationError(t, err, "Should return validation error for malformed hex hash")
+			assertValidationError(t, err, "Should return validation error for malformed hex hash")
 		})
 	})
 
@@ -296,12 +296,12 @@ func TestPeerClientIntegration(t *testing.T) {
 
 		// Test with empty string as hash
 		has, err := client.HasBlob(ctx, emptyDownloadHash)
-		assertUploadValidationError(t, err, "Should return validation error for empty hash")
+		assertValidationError(t, err, "Should return validation error for empty hash")
 		require.False(t, has, "Empty hash should not be found")
 
 		// Test fetching empty hash
 		_, err = client.GetBlob(ctx, emptyDownloadHash)
-		assertUploadValidationError(t, err, "Should return validation error for empty hash")
+		assertValidationError(t, err, "Should return validation error for empty hash")
 	})
 }
 

--- a/protocol/e2e/client_reflector_test.go
+++ b/protocol/e2e/client_reflector_test.go
@@ -2,10 +2,10 @@ package e2e
 
 import (
 	"crypto/rand"
-	"errors"
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -120,7 +120,6 @@ func TestReflectorClientUpload(t *testing.T) {
 	})
 }
 
-
 // TestReflectorClientConnectionManagement tests connection management features
 func TestReflectorClientConnectionManagement(t *testing.T) {
 	if testing.Short() {
@@ -207,11 +206,11 @@ func TestReflectorClientErrorHandling(t *testing.T) {
 
 		// Test with empty hash
 		err := client.SendBlob(emptyUploadHash, []byte("data"))
-		assertUploadValidationError(t, err, "Should return validation error for empty hash")
+		assertValidationError(t, err, "Should return validation error for empty hash")
 
 		// Test with malformed hex hash
 		err = client.SendBlob(malformedUploadHash, []byte("data"))
-		assertUploadValidationError(t, err, "Should return validation error for malformed hex hash")
+		assertValidationError(t, err, "Should return validation error for malformed hex hash")
 	})
 }
 
@@ -238,10 +237,13 @@ func TestReflectorClientConcurrentUploads(t *testing.T) {
 	}
 
 	// Upload blobs concurrently
+	var wg sync.WaitGroup
+	wg.Add(len(clients))
 	for i, client := range clients {
 		i := i // Capture loop variable
 		client := client
 		go func() {
+			defer wg.Done()
 			err := client.SendBlob(blobHashes[i], testBlobs[i].ToBytes())
 			if err != nil {
 				// Expected to get blob exists errors for some
@@ -252,8 +254,7 @@ func TestReflectorClientConcurrentUploads(t *testing.T) {
 		}()
 	}
 
-	// Give uploads time to complete
-	time.Sleep(2 * time.Second)
+	wg.Wait()
 }
 
 // TestReflectorClientLargeBlobHandling tests handling of large blobs
@@ -264,7 +265,7 @@ func TestReflectorClientLargeBlobHandling(t *testing.T) {
 
 	client := createConnectedReflectorClient(t, 30*time.Second)
 
-	// Create large test data (接近2MB限制)
+	// Create large test data (close to 2MB limit)
 	largeData := make([]byte, blob.MaxBlobSize-1000)
 	for i := range largeData {
 		largeData[i] = byte(i % 256)
@@ -290,26 +291,4 @@ func getReflectorAddr() string {
 		return defaultReflectorAddr
 	}
 	return addr
-}
-
-// ReflectorClientAdapter implements the StoreOperations interface for ReflectorClient
-// Note: Get and Has methods are not supported by ReflectorClient for upload tests and will return an error
-type ReflectorClientAdapter struct {
-	client protocol.ReflectorClient
-}
-
-// ErrGetHasNotSupported is returned when attempting to use Get or Has operations
-// which are not supported by ReflectorClient in this test context
-var ErrGetHasNotSupported = errors.New("Get/Has operations not supported by ReflectorClient adapter")
-
-func (a *ReflectorClientAdapter) Has(hash string) (bool, error) {
-	return false, ErrGetHasNotSupported
-}
-
-func (a *ReflectorClientAdapter) Get(hash string) ([]byte, error) {
-	return nil, ErrGetHasNotSupported
-}
-
-func (a *ReflectorClientAdapter) Put(hash string, data []byte) error {
-	return a.client.SendBlob(hash, data)
 }

--- a/protocol/e2e/client_reflector_test.go
+++ b/protocol/e2e/client_reflector_test.go
@@ -1,0 +1,328 @@
+package e2e
+
+import (
+	"crypto/rand"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/liblbry/blob"
+	"go.lumeweb.com/liblbry/protocol"
+	"go.uber.org/zap/zaptest"
+)
+
+const (
+	defaultReflectorAddr = "s1.lbry.network:5566"
+	malformedUploadHash  = "xyz123"
+	emptyUploadHash      = ""
+)
+
+// createTestReflectorClient creates a new ReflectorClient with standard configuration
+func createTestReflectorClient(t *testing.T, timeout time.Duration) protocol.ReflectorClient {
+	t.Helper()
+	logger := zaptest.NewLogger(t)
+	client := protocol.NewReflectorClient(
+		protocol.WithReflectorClientLogger(logger),
+		protocol.WithReflectorClientTimeout(timeout),
+	)
+	t.Cleanup(func() {
+		require.NoError(t, client.Close())
+	})
+	return client
+}
+
+// createConnectedReflectorClient creates a new ReflectorClient connected to the reflector
+func createConnectedReflectorClient(t *testing.T, timeout time.Duration) protocol.ReflectorClient {
+	t.Helper()
+	client := createTestReflectorClient(t, timeout)
+	connectToReflectorUpload(t, client)
+	return client
+}
+
+// connectToReflectorUpload connects a client to the public reflector server.
+// These are end-to-end integration tests that require network access to
+// s1.lbry.network:5566 (configurable via LIBLBRY_E2E_REFLECTOR_ADDR env var).
+// Tests may fail if the reflector service is unavailable.
+func connectToReflectorUpload(t *testing.T, client protocol.ReflectorClient) {
+	t.Helper()
+	addr := defaultReflectorAddr
+	if v := strings.TrimSpace(os.Getenv("LIBLBRY_E2E_REFLECTOR_ADDR")); v != "" {
+		addr = v
+	}
+	t.Logf("Connecting to reflector server at %s", addr)
+	err := client.Connect(addr)
+	require.NoError(t, err, "Failed to connect to reflector server")
+}
+
+// createTestBlob creates a blob with test data
+func createTestBlob(t *testing.T, testData []byte) (blob.Blob, string, []byte, []byte) {
+	key := make([]byte, 16)
+	iv := make([]byte, 16)
+	_, err := io.ReadFull(rand.Reader, key)
+	require.NoError(t, err)
+	_, err = io.ReadFull(rand.Reader, iv)
+	require.NoError(t, err)
+
+	testBlob, err := blob.NewBlob(testData, key, iv)
+	require.NoError(t, err)
+
+	blobHash := testBlob.HashHex()
+	return testBlob, blobHash, key, iv
+}
+
+// TestReflectorClientUpload tests basic blob upload functionality
+func TestReflectorClientUpload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	// Test regular blob upload
+	t.Run("SendBlob", func(t *testing.T) {
+		client := createConnectedReflectorClient(t, 30*time.Second)
+
+		testData := []byte("test blob data for e2e reflector")
+		// Add a random number to make the test data unique for each run
+		testData = append(testData, []byte(time.Now().String())...)
+		testBlob, blobHash, _, _ := createTestBlob(t, testData)
+
+		// Test SendBlob - this will likely return "blob already exists" error
+		// since we're using a public reflector
+		err := client.SendBlob(blobHash, testBlob.ToBytes())
+		if err != nil {
+			// If we get an error, it should be a blob exists error or nil (success)
+			if !strings.Contains(err.Error(), "blob already exists") &&
+				!strings.Contains(err.Error(), "duplicate blob") {
+				t.Logf("SendBlob failed with unexpected error: %v", err)
+			}
+		} else {
+			// Upload succeeded
+			t.Logf("Successfully uploaded blob %s", blobHash)
+		}
+	})
+
+	// Test SD blob upload
+	t.Run("SendSDBlob", func(t *testing.T) {
+		client := createConnectedReflectorClient(t, 30*time.Second)
+
+		// Create SD blob data (JSON format)
+		sdData := []byte(`{"stream_type": "video", "blobs": []}`)
+		sdBlob, sdBlobHash, _, _ := createTestBlob(t, sdData)
+
+		// Test SendSDBlob
+		err := client.SendSDBlob(sdBlobHash, sdBlob.ToBytes())
+		if err != nil {
+			// If we get an error, it should be a blob exists error
+			if !strings.Contains(err.Error(), "blob already exists") &&
+				!strings.Contains(err.Error(), "duplicate blob") {
+				t.Errorf("SendSDBlob failed with unexpected error: %v", err)
+			}
+		} else {
+			// Upload succeeded
+			t.Logf("Successfully uploaded SD blob %s", sdBlobHash)
+		}
+	})
+}
+
+
+// TestReflectorClientConnectionManagement tests connection management features
+func TestReflectorClientConnectionManagement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	client := createTestReflectorClient(t, 30*time.Second)
+
+	// Connect client to reflector
+	err := client.Connect(getReflectorAddr())
+	require.NoError(t, err)
+
+	// Test that we can't connect again
+	err = client.Connect(getReflectorAddr())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection already established")
+
+	// Close connection
+	err = client.Close()
+	require.NoError(t, err)
+
+	// Test operations after close
+	err = client.SendBlob("somehash", []byte("data"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestReflectorClientTimeoutHandling tests timeout scenarios
+func TestReflectorClientTimeoutHandling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	// Create client with short timeout
+	client := createTestReflectorClient(t, 1*time.Millisecond)
+
+	// This should timeout quickly
+	err := client.Connect(getReflectorAddr())
+	if err != nil {
+		// Expected to timeout
+		assertNetworkError(t, err, "Expected network timeout error")
+	} else {
+		// If it connected, close it
+		_ = client.Close()
+	}
+}
+
+// TestReflectorClientErrorHandling tests various error scenarios for upload operations
+func TestReflectorClientErrorHandling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	// Test upload without connection
+	t.Run("SendWithoutConnection", func(t *testing.T) {
+		client := protocol.NewReflectorClient()
+
+		err := client.SendBlob("hash", []byte("data"))
+		if err == nil || !strings.Contains(err.Error(), "not connected") {
+			t.Errorf("expected 'not connected' error, got %v", err)
+		}
+
+		err = client.SendSDBlob("hash", []byte("data"))
+		if err == nil || !strings.Contains(err.Error(), "not connected") {
+			t.Errorf("expected 'not connected' error, got %v", err)
+		}
+	})
+
+	// Test blob too large
+	t.Run("BlobTooLarge", func(t *testing.T) {
+		client := createConnectedReflectorClient(t, 30*time.Second)
+
+		largeBlob := make([]byte, blob.MaxBlobSize+1)
+		err := client.SendBlob("hash", largeBlob)
+		if err == nil || !strings.Contains(err.Error(), "exceeds maximum size") {
+			t.Errorf("expected size error, got %v", err)
+		}
+	})
+
+	// Test invalid hash handling
+	t.Run("InvalidHashHandling", func(t *testing.T) {
+		client := createConnectedReflectorClient(t, 30*time.Second)
+
+		// Test with empty hash
+		err := client.SendBlob(emptyUploadHash, []byte("data"))
+		assertUploadValidationError(t, err, "Should return validation error for empty hash")
+
+		// Test with malformed hex hash
+		err = client.SendBlob(malformedUploadHash, []byte("data"))
+		assertUploadValidationError(t, err, "Should return validation error for malformed hex hash")
+	})
+}
+
+// TestReflectorClientConcurrentUploads tests multiple concurrent uploads
+func TestReflectorClientConcurrentUploads(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	// Create multiple clients for concurrent uploads
+	clients := make([]protocol.ReflectorClient, 5)
+	for i := range clients {
+		clients[i] = createConnectedReflectorClient(t, 30*time.Second)
+	}
+
+	// Create test blobs
+	testBlobs := make([]blob.Blob, 5)
+	blobHashes := make([]string, 5)
+	for i := range testBlobs {
+		testData := []byte("concurrent test blob data " + string(rune(i+'0')))
+		testBlob, blobHash, _, _ := createTestBlob(t, testData)
+		testBlobs[i] = testBlob
+		blobHashes[i] = blobHash
+	}
+
+	// Upload blobs concurrently
+	for i, client := range clients {
+		i := i // Capture loop variable
+		client := client
+		go func() {
+			err := client.SendBlob(blobHashes[i], testBlobs[i].ToBytes())
+			if err != nil {
+				// Expected to get blob exists errors for some
+				if !strings.Contains(err.Error(), "blob already exists") &&
+					!strings.Contains(err.Error(), "duplicate blob") {
+					t.Errorf("Concurrent upload failed with unexpected error: %v", err)
+				}
+			} else {
+				t.Logf("Successfully uploaded blob %s concurrently", blobHashes[i])
+			}
+		}()
+	}
+
+	// Give uploads time to complete
+	time.Sleep(2 * time.Second)
+}
+
+// TestReflectorClientLargeBlobHandling tests handling of large blobs
+func TestReflectorClientLargeBlobHandling(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e test in short mode")
+	}
+
+	client := createConnectedReflectorClient(t, 30*time.Second)
+
+	// Create large test data (接近2MB限制)
+	largeData := make([]byte, blob.MaxBlobSize-1000)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+
+	largeBlob, blobHash, _, _ := createTestBlob(t, largeData)
+
+	// Test SendBlob with large blob
+	err := client.SendBlob(blobHash, largeBlob.ToBytes())
+	if err != nil {
+		// If we get an error, it should be a blob exists error
+		if !strings.Contains(err.Error(), "blob already exists") &&
+			!strings.Contains(err.Error(), "duplicate blob") {
+			t.Errorf("Large blob upload failed with unexpected error: %v", err)
+		}
+	} else {
+		// Upload succeeded
+		t.Logf("Successfully uploaded large blob %s", blobHash)
+	}
+}
+
+// getReflectorAddr returns the reflector address from environment variable or default
+func getReflectorAddr() string {
+	addr := os.Getenv("LIBLBRY_E2E_REFLECTOR_ADDR")
+	if addr == "" {
+		return defaultReflectorAddr
+	}
+	return addr
+}
+
+// ReflectorClientAdapter implements the StoreOperations interface for ReflectorClient
+// Note: Get and Has methods are not supported by ReflectorClient for upload tests and will return an error
+type ReflectorClientAdapter struct {
+	client protocol.ReflectorClient
+}
+
+// ErrGetHasNotSupported is returned when attempting to use Get or Has operations
+// which are not supported by ReflectorClient in this test context
+var ErrGetHasNotSupported = errors.New("Get/Has operations not supported by ReflectorClient adapter")
+
+func (a *ReflectorClientAdapter) Has(hash string) (bool, error) {
+	return false, ErrGetHasNotSupported
+}
+
+func (a *ReflectorClientAdapter) Get(hash string) ([]byte, error) {
+	return nil, ErrGetHasNotSupported
+}
+
+func (a *ReflectorClientAdapter) Put(hash string, data []byte) error {
+	return a.client.SendBlob(hash, data)
+}

--- a/protocol/e2e/client_reflector_test.go
+++ b/protocol/e2e/client_reflector_test.go
@@ -94,11 +94,7 @@ func TestReflectorClientUpload(t *testing.T) {
 		// since we're using a public reflector
 		err := client.SendBlob(blobHash, testBlob.ToBytes())
 		if err != nil {
-			// If we get an error, it should be a blob exists error or nil (success)
-			if !strings.Contains(err.Error(), "blob already exists") &&
-				!strings.Contains(err.Error(), "duplicate blob") {
-				t.Logf("SendBlob failed with unexpected error: %v", err)
-			}
+			assertBlobExistsError(t, err, "SendBlob should return blob exists error or succeed")
 		} else {
 			// Upload succeeded
 			t.Logf("Successfully uploaded blob %s", blobHash)
@@ -116,11 +112,7 @@ func TestReflectorClientUpload(t *testing.T) {
 		// Test SendSDBlob
 		err := client.SendSDBlob(sdBlobHash, sdBlob.ToBytes())
 		if err != nil {
-			// If we get an error, it should be a blob exists error
-			if !strings.Contains(err.Error(), "blob already exists") &&
-				!strings.Contains(err.Error(), "duplicate blob") {
-				t.Errorf("SendSDBlob failed with unexpected error: %v", err)
-			}
+			assertBlobExistsError(t, err, "SendSDBlob should return blob exists error or succeed")
 		} else {
 			// Upload succeeded
 			t.Logf("Successfully uploaded SD blob %s", sdBlobHash)
@@ -171,8 +163,9 @@ func TestReflectorClientTimeoutHandling(t *testing.T) {
 		// Expected to timeout
 		assertNetworkError(t, err, "Expected network timeout error")
 	} else {
-		// If it connected, close it
+		// If it connected, this is a test failure - we expected a timeout
 		_ = client.Close()
+		t.Fatalf("expected timeout but connected")
 	}
 }
 
@@ -252,10 +245,7 @@ func TestReflectorClientConcurrentUploads(t *testing.T) {
 			err := client.SendBlob(blobHashes[i], testBlobs[i].ToBytes())
 			if err != nil {
 				// Expected to get blob exists errors for some
-				if !strings.Contains(err.Error(), "blob already exists") &&
-					!strings.Contains(err.Error(), "duplicate blob") {
-					t.Errorf("Concurrent upload failed with unexpected error: %v", err)
-				}
+				assertBlobExistsError(t, err, "Concurrent upload should return blob exists error or succeed")
 			} else {
 				t.Logf("Successfully uploaded blob %s concurrently", blobHashes[i])
 			}
@@ -286,10 +276,7 @@ func TestReflectorClientLargeBlobHandling(t *testing.T) {
 	err := client.SendBlob(blobHash, largeBlob.ToBytes())
 	if err != nil {
 		// If we get an error, it should be a blob exists error
-		if !strings.Contains(err.Error(), "blob already exists") &&
-			!strings.Contains(err.Error(), "duplicate blob") {
-			t.Errorf("Large blob upload failed with unexpected error: %v", err)
-		}
+		assertBlobExistsError(t, err, "Large blob upload should return blob exists error or succeed")
 	} else {
 		// Upload succeeded
 		t.Logf("Successfully uploaded large blob %s", blobHash)

--- a/protocol/e2e/common_test.go
+++ b/protocol/e2e/common_test.go
@@ -1,0 +1,137 @@
+package e2e
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	liblbryerrors "go.lumeweb.com/liblbry/errors"
+)
+
+// errorContains checks if an error contains any of the given substrings
+func errorContains(err error, indicators []string) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+
+	for _, indicator := range indicators {
+		if containsIgnoreCase(errStr, indicator) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// containsIgnoreCase checks if a string contains a substring ignoring case
+func containsIgnoreCase(s, substr string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}
+
+// isNetworkError checks if an error is a network-related error
+func isNetworkError(err error) bool {
+	// Check for context/timeout errors first
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+
+	networkErrorIndicators := []string{
+		"i/o timeout",
+		"connection refused",
+		"connection reset",
+		"network is unreachable",
+		"no route to host",
+		"not connected",
+		"no such host",
+		"timeout",
+		"deadline exceeded",
+	}
+
+	// Check for wrapped network errors
+	var netErr net.Error
+	if errors.As(err, &netErr) {
+		return true
+	}
+
+	return errorContains(err, networkErrorIndicators)
+}
+
+// isValidationError checks if an error is due to invalid input validation
+func isValidationError(err error) bool {
+	// Check for wrapped validation errors
+	if liblbryerrors.Is(err, liblbryerrors.ErrInvalidHashLen) {
+		return true
+	}
+
+	// Check for server validation errors (when server closes connection due to validation)
+	if liblbryerrors.Is(err, liblbryerrors.ErrServerValidation) {
+		return true
+	}
+
+	validationIndicators := []string{
+		"invalid request",
+		"malformed",
+	}
+
+	return errorContains(err, validationIndicators)
+}
+
+// isBlobNotFoundError checks if an error indicates a blob was not found
+func isBlobNotFoundError(err error) bool {
+	// First check if it's a context/timeout error - those aren't "not found" errors
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	notFoundIndicators := []string{
+		"not found",
+		liblbryerrors.ErrBlobNotFound.Error(),
+	}
+
+	// Check if it's a wrapped liblbry not found error
+	if liblbryerrors.Is(err, liblbryerrors.ErrBlobNotFound) {
+		return true
+	}
+
+	return errorContains(err, notFoundIndicators)
+}
+
+// assertValidationError checks that an error is a validation error
+func assertValidationError(t *testing.T, err error, msg string) {
+	t.Helper()
+	require.Error(t, err, msg)
+	require.True(t, isValidationError(err), "Expected validation error, got: %v", err)
+}
+
+// assertBlobNotFoundError checks that an error indicates a blob was not found
+func assertBlobNotFoundError(t *testing.T, err error, msg string) {
+	t.Helper()
+	require.Error(t, err, msg)
+	require.True(t, isBlobNotFoundError(err), "Expected blob not found error, got: %v", err)
+}
+
+// assertNetworkError checks that an error is a network-related error
+func assertNetworkError(t *testing.T, err error, msg string) {
+	t.Helper()
+	require.Error(t, err, msg)
+	require.True(t, isNetworkError(err), "Expected network error, got: %v", err)
+}
+
+// assertUploadValidationError checks that an error is a validation error
+func assertUploadValidationError(t *testing.T, err error, msg string) {
+	t.Helper()
+	require.Error(t, err, msg)
+	require.True(t, isValidationError(err), "Expected validation error, got: %v", err)
+}
+
+// assertUploadNetworkError checks that an error is a network-related error
+func assertUploadNetworkError(t *testing.T, err error, msg string) {
+	t.Helper()
+	require.Error(t, err, msg)
+	require.True(t, isNetworkError(err), "Expected network error, got: %v", err)
+}

--- a/protocol/e2e/common_test.go
+++ b/protocol/e2e/common_test.go
@@ -149,17 +149,3 @@ func assertNetworkError(t *testing.T, err error, msg string) {
 	require.Error(t, err, msg)
 	require.True(t, isNetworkError(err), "Expected network error, got: %v", err)
 }
-
-// assertUploadValidationError checks that an error is a validation error
-func assertUploadValidationError(t *testing.T, err error, msg string) {
-	t.Helper()
-	require.Error(t, err, msg)
-	require.True(t, isValidationError(err), "Expected validation error, got: %v", err)
-}
-
-// assertUploadNetworkError checks that an error is a network-related error
-func assertUploadNetworkError(t *testing.T, err error, msg string) {
-	t.Helper()
-	require.Error(t, err, msg)
-	require.True(t, isNetworkError(err), "Expected network error, got: %v", err)
-}

--- a/protocol/e2e/common_test.go
+++ b/protocol/e2e/common_test.go
@@ -101,6 +101,27 @@ func isBlobNotFoundError(err error) bool {
 	return errorContains(err, notFoundIndicators)
 }
 
+// isBlobExistsError checks if an error indicates a blob already exists
+func isBlobExistsError(err error) bool {
+	// First check if it's a context/timeout error - those aren't "blob exists" errors
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return false
+	}
+
+	blobExistsIndicators := []string{
+		"blob already exists",
+		"duplicate blob",
+		liblbryerrors.ErrBlobExists.Error(),
+	}
+
+	// Check if it's a wrapped liblbry blob exists error
+	if liblbryerrors.Is(err, liblbryerrors.ErrBlobExists) {
+		return true
+	}
+
+	return errorContains(err, blobExistsIndicators)
+}
+
 // assertValidationError checks that an error is a validation error
 func assertValidationError(t *testing.T, err error, msg string) {
 	t.Helper()
@@ -113,6 +134,13 @@ func assertBlobNotFoundError(t *testing.T, err error, msg string) {
 	t.Helper()
 	require.Error(t, err, msg)
 	require.True(t, isBlobNotFoundError(err), "Expected blob not found error, got: %v", err)
+}
+
+// assertBlobExistsError checks that an error indicates a blob already exists
+func assertBlobExistsError(t *testing.T, err error, msg string) {
+	t.Helper()
+	require.Error(t, err, msg)
+	require.True(t, isBlobExistsError(err), "Expected blob exists error, got: %v", err)
 }
 
 // assertNetworkError checks that an error is a network-related error

--- a/protocol/peer.go
+++ b/protocol/peer.go
@@ -71,26 +71,6 @@ var (
 	ErrAccessDenied   = liblbryerrors.ErrAccessDenied
 )
 
-// CompositeRequest represents a composite protocol message
-type CompositeRequest struct {
-	RequestedBlobs      []string `json:"requested_blobs,omitempty"`
-	BlobDataPaymentRate *float64 `json:"blob_data_payment_rate,omitempty"`
-	RequestedBlob       string   `json:"requested_blob,omitempty"`
-}
-
-// CompositeResponse represents a composite protocol response
-type CompositeResponse struct {
-	AvailableBlobs      []string      `json:"available_blobs"`
-	BlobDataPaymentRate string        `json:"blob_data_payment_rate,omitempty"`
-	IncomingBlob        *IncomingBlob `json:"incoming_blob,omitempty"`
-}
-
-// IncomingBlob represents blob data being transferred
-type IncomingBlob struct {
-	Error    string `json:"error,omitempty"`
-	BlobHash string `json:"blob_hash"`
-	Length   int    `json:"length"`
-}
 
 // DefaultPeerServer implements the PeerServer interface
 type DefaultPeerServer struct {

--- a/protocol/peer_client.go
+++ b/protocol/peer_client.go
@@ -190,12 +190,12 @@ func (c *DefaultPeerClient) Close() error {
 	c.connected = false
 	c.conn = nil
 	c.reader = nil
-	
+
 	if err != nil {
 		c.logger.Debug("error closing peer connection", zap.Error(err))
 		return liblbryerrors.Err(err)
 	}
-	
+
 	c.logger.Debug("peer connection closed successfully")
 	return nil
 }
@@ -345,7 +345,7 @@ func (c *DefaultPeerClient) HasBlob(ctx context.Context, hash string) (bool, err
 // GetStream retrieves and reconstructs a stream from the peer server
 func (c *DefaultPeerClient) GetStream(ctx context.Context, sdHash string) (stream.Stream, error) {
 	c.logger.Debug("retrieving stream", zap.String("sd_hash", sdHash))
-	
+
 	// Validate SD blob hash length
 	if len(sdHash) != blob.BlobHashHexLength {
 		c.logger.Debug("invalid SD blob hash length", zap.String("sd_hash", sdHash), zap.Int("length", len(sdHash)))
@@ -512,7 +512,7 @@ func (c *DefaultPeerClient) sendRequest(ctx context.Context, request CompositeRe
 func (c *DefaultPeerClient) readResponse(ctx context.Context) (CompositeResponse, []byte, error) {
 	// Set read deadline to the minimum of context deadline and timeout
 	deadline := c.minDeadline(ctx, c.timeout)
-	
+
 	if err := c.conn.SetReadDeadline(deadline); err != nil {
 		return CompositeResponse{}, nil, c.wrapContextError(err)
 	}
@@ -525,7 +525,7 @@ func (c *DefaultPeerClient) readResponse(ctx context.Context) (CompositeResponse
 
 	// Parse response
 	var response CompositeResponse
-	
+
 	if err := json.Unmarshal(message, &response); err != nil {
 		return CompositeResponse{}, nil, c.wrapContextError(err)
 	}

--- a/protocol/peer_client_integration_test.go
+++ b/protocol/peer_client_integration_test.go
@@ -24,8 +24,8 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-// setupIntegrationTestServer starts a peer server on a random port and returns the address
-func setupIntegrationTestServer(t *testing.T, server PeerServer) string {
+// setupPeerIntegrationTestServer starts a peer server on a random port and returns the address
+func setupPeerIntegrationTestServer(t *testing.T, server PeerServer) string {
 	// Start server on random port
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -61,25 +61,25 @@ func setupIntegrationTestServer(t *testing.T, server PeerServer) string {
 	}()
 
 	addr := listener.Addr().String()
-	
+
 	// Register cleanup function to close listener when test completes
 	t.Cleanup(func() {
 		_ = listener.Close()
 	})
-	
+
 	return addr
 }
 
-// testSetup creates common test components
-func testSetup(t *testing.T) (*memory.MemoryStore, *zap.Logger, PeerServer) {
+// testPeerSetup creates common test components
+func testPeerSetup(t *testing.T) (*memory.MemoryStore, *zap.Logger, PeerServer) {
 	store := memory.NewMemoryStore()
 	logger := zaptest.NewLogger(t)
 	server := NewPeerServer(store, WithPeerLogger(logger))
 	return store, logger, server
 }
 
-// testClientSetup creates a test client and connects it to the server
-func testClientSetup(t *testing.T, addr string, logger *zap.Logger, timeout ...time.Duration) (PeerClient, context.Context) {
+// testPeerClientSetup creates a test client and connects it to the server
+func testPeerClientSetup(t *testing.T, addr string, logger *zap.Logger, timeout ...time.Duration) (PeerClient, context.Context) {
 	var client PeerClient
 	if len(timeout) > 0 {
 		client = NewPeerClient(WithClientLogger(logger), WithClientTimeout(timeout[0]))
@@ -94,28 +94,28 @@ func testClientSetup(t *testing.T, addr string, logger *zap.Logger, timeout ...t
 	return client, ctx
 }
 
-// setupIntegrationTest creates a complete integration test setup
-func setupIntegrationTest(t *testing.T, opts ...ServerOption) (*memory.MemoryStore, *zap.Logger, PeerServer, string) {
-	store, logger, server := testSetup(t)
+// setupPeerIntegrationTest creates a complete integration test setup
+func setupPeerIntegrationTest(t *testing.T, opts ...ServerOption) (*memory.MemoryStore, *zap.Logger, PeerServer, string) {
+	store, logger, server := testPeerSetup(t)
 
 	// Apply additional server options
 	serverOpts := []ServerOption{WithPeerLogger(logger)}
 	serverOpts = append(serverOpts, opts...)
 	server = NewPeerServer(store, serverOpts...)
 
-	addr := setupIntegrationTestServer(t, server)
+	addr := setupPeerIntegrationTestServer(t, server)
 	return store, logger, server, addr
 }
 
-// setupTestClient creates a test client with automatic cleanup
-func setupTestClient(t *testing.T, addr string, logger *zap.Logger, timeout ...time.Duration) PeerClient {
-	client, _ := testClientSetup(t, addr, logger, timeout...)
+// setupPeerTestClient creates a test client with automatic cleanup
+func setupPeerTestClient(t *testing.T, addr string, logger *zap.Logger, timeout ...time.Duration) PeerClient {
+	client, _ := testPeerClientSetup(t, addr, logger, timeout...)
 	return client
 }
 
 // createAndStoreTestBlob creates a blob and stores it in the memory store
 func createAndStoreTestBlob(t *testing.T, store *memory.MemoryStore, testData []byte) (blob.Blob, string) {
-	testBlob, blobHash, _, _ := createTestBlob(t, testData)
+	testBlob, blobHash, _, _ := createPeerTestBlob(t, testData)
 	err := store.Put(blobHash, testBlob)
 	require.NoError(t, err)
 	return testBlob, blobHash
@@ -145,8 +145,8 @@ func testPaymentRate(t *testing.T, client PeerClient, blobHash string, rate floa
 	assert.Equal(t, expectedResponse, response.BlobDataPaymentRate)
 }
 
-// createTestBlob creates a blob with test data
-func createTestBlob(t *testing.T, testData []byte) (blob.Blob, string, []byte, []byte) {
+// createPeerTestBlob creates a blob with test data
+func createPeerTestBlob(t *testing.T, testData []byte) (blob.Blob, string, []byte, []byte) {
 	key := make([]byte, 16)
 	iv := make([]byte, 16)
 	_, err := io.ReadFull(rand.Reader, key)
@@ -162,12 +162,12 @@ func createTestBlob(t *testing.T, testData []byte) (blob.Blob, string, []byte, [
 }
 
 // TestBlobOperations tests basic blob operations through the peer protocol
-func TestBlobOperations(t *testing.T) {
-	store, logger, _, addr := setupIntegrationTest(t)
-	
+func TestPeerBlobOperations(t *testing.T) {
+	store, logger, _, addr := setupPeerIntegrationTest(t)
+
 	testData := []byte("This is a test blob for integration testing")
 	_, blobHash := createAndStoreTestBlob(t, store, testData)
-	client := setupTestClient(t, addr, logger)
+	client := setupPeerTestClient(t, addr, logger)
 	defer func(client PeerClient) {
 		_ = client.Close()
 	}(client)
@@ -198,8 +198,8 @@ func TestBlobOperations(t *testing.T) {
 }
 
 // TestStreamOperations tests stream creation and retrieval through the peer protocol
-func TestStreamOperations(t *testing.T) {
-	store, logger, _, addr := setupIntegrationTest(t)
+func TestPeerStreamOperations(t *testing.T) {
+	store, logger, _, addr := setupPeerIntegrationTest(t)
 
 	// Test stream data - adjusted size to ensure exactly 3 blobs (SD + 2 content)
 	testData := strings.Repeat("A", 2*1024*1024) // 2MB of data
@@ -226,7 +226,7 @@ func TestStreamOperations(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	client := setupTestClient(t, addr, logger)
+	client := setupPeerTestClient(t, addr, logger)
 	defer func(client PeerClient) {
 		_ = client.Close()
 	}(client)
@@ -255,12 +255,12 @@ func TestStreamOperations(t *testing.T) {
 }
 
 // TestPaymentRateNegotiation tests payment rate negotiation through the peer protocol
-func TestPaymentRateNegotiation(t *testing.T) {
-	store, logger, _, addr := setupIntegrationTest(t)
-	
+func TestPeerPaymentRateNegotiation(t *testing.T) {
+	store, logger, _, addr := setupPeerIntegrationTest(t)
+
 	testData := []byte("This is a test blob for payment rate negotiation")
 	_, blobHash := createAndStoreTestBlob(t, store, testData)
-	client := setupTestClient(t, addr, logger)
+	client := setupPeerTestClient(t, addr, logger)
 	defer func(client PeerClient) {
 		_ = client.Close()
 	}(client)
@@ -271,14 +271,14 @@ func TestPaymentRateNegotiation(t *testing.T) {
 }
 
 // TestAccessControlIntegration tests access control integration
-func TestAccessControlIntegration(t *testing.T) {
+func TestPeerAccessControlIntegration(t *testing.T) {
 	accessControl := &allowAllAccessControl{}
-	store, logger, _, addr := setupIntegrationTest(t, WithPeerAccessControl(accessControl))
+	store, logger, _, addr := setupPeerIntegrationTest(t, WithPeerAccessControl(accessControl))
 
 	testData := []byte("This is a test blob for access control")
 	testBlob, blobHash := createAndStoreTestBlob(t, store, testData)
 
-	client := setupTestClient(t, addr, logger)
+	client := setupPeerTestClient(t, addr, logger)
 	defer func(client PeerClient) {
 		_ = client.Close()
 	}(client)
@@ -296,10 +296,10 @@ func TestAccessControlIntegration(t *testing.T) {
 }
 
 // TestIntegrationTimeoutHandling tests timeout handling in client-server communication
-func TestIntegrationTimeoutHandling(t *testing.T) {
-	_, logger, _, addr := setupIntegrationTest(t, WithPeerTimeout(100*time.Millisecond))
-	
-	client := setupTestClient(t, addr, logger, 100*time.Millisecond)
+func TestPeerIntegrationTimeoutHandling(t *testing.T) {
+	_, logger, _, addr := setupPeerIntegrationTest(t, WithPeerTimeout(100*time.Millisecond))
+
+	client := setupPeerTestClient(t, addr, logger, 100*time.Millisecond)
 	defer func(client PeerClient) {
 		_ = client.Close()
 	}(client)
@@ -310,9 +310,9 @@ func TestIntegrationTimeoutHandling(t *testing.T) {
 	require.Error(t, err)
 }
 
-// TestConcurrentClients tests multiple concurrent clients accessing the server
-func TestConcurrentClients(t *testing.T) {
-	store, logger, _, addr := setupIntegrationTest(t)
+// TestPeerConcurrentClients tests multiple concurrent clients accessing the server
+func TestPeerConcurrentClients(t *testing.T) {
+	store, logger, _, addr := setupPeerIntegrationTest(t)
 
 	testData := []byte("This is a test blob for concurrent access")
 	testBlob, blobHash := createAndStoreTestBlob(t, store, testData)
@@ -362,9 +362,9 @@ func TestConcurrentClients(t *testing.T) {
 	liblbrytesting.RunConcurrentTasks(t, 5, tasks)
 }
 
-// TestLargeBlobHandling tests handling of large blobs
-func TestLargeBlobHandling(t *testing.T) {
-	store, logger, _, addr := setupIntegrationTest(t)
+// TestPeerLargeBlobHandling tests handling of large blobs
+func TestPeerLargeBlobHandling(t *testing.T) {
+	store, logger, _, addr := setupPeerIntegrationTest(t)
 
 	// Create large test data (接近2MB限制)
 	largeData := make([]byte, blob.MaxBlobSize-1000)
@@ -377,7 +377,7 @@ func TestLargeBlobHandling(t *testing.T) {
 	// Verify blob size is within limits
 	assert.Less(t, len(largeBlob), blob.MaxBlobSize)
 
-	client := setupTestClient(t, addr, logger)
+	client := setupPeerTestClient(t, addr, logger)
 	defer func(client PeerClient) {
 		_ = client.Close()
 	}(client)
@@ -394,10 +394,10 @@ func TestLargeBlobHandling(t *testing.T) {
 	assert.Equal(t, []byte(largeBlob), retrievedData)
 }
 
-// TestConnectionManagement tests connection management features
-func TestConnectionManagement(t *testing.T) {
-	_, logger, _, addr := setupIntegrationTest(t)
-	
+// TestPeerConnectionManagement tests connection management features
+func TestPeerConnectionManagement(t *testing.T) {
+	_, logger, _, addr := setupPeerIntegrationTest(t)
+
 	client := NewPeerClient(WithClientLogger(logger))
 	defer func(client PeerClient) {
 		_ = client.Close()
@@ -428,9 +428,9 @@ func TestConnectionManagement(t *testing.T) {
 }
 
 // TestErrorScenarios tests various error scenarios
-func TestErrorScenarios(t *testing.T) {
-	_, logger, _, addr := setupIntegrationTest(t)
-	
+func TestPeerErrorScenarios(t *testing.T) {
+	_, logger, _, addr := setupPeerIntegrationTest(t)
+
 	client := NewPeerClient(WithClientLogger(logger))
 	defer func(client PeerClient) {
 		_ = client.Close()
@@ -467,13 +467,13 @@ func TestErrorScenarios(t *testing.T) {
 	assert.True(t, liblbryerrors.Is(err, liblbryerrors.ErrBlobNotFound))
 }
 
-// TestNetworkFailureRecovery tests client behavior when connection drops mid-operation
-func TestNetworkFailureRecovery(t *testing.T) {
-	store, logger, _, addr := setupIntegrationTest(t)
-	
+// TestPeerNetworkFailureRecovery tests client behavior when connection drops mid-operation
+func TestPeerNetworkFailureRecovery(t *testing.T) {
+	store, logger, _, addr := setupPeerIntegrationTest(t)
+
 	testData := []byte("This is a test blob for network failure recovery")
 	_, blobHash := createAndStoreTestBlob(t, store, testData)
-	client := setupTestClient(t, addr, logger)
+	client := setupPeerTestClient(t, addr, logger)
 	defer func(client PeerClient) {
 		_ = client.Close()
 	}(client)
@@ -511,12 +511,12 @@ func TestNetworkFailureRecovery(t *testing.T) {
 }
 
 // TestMalformedRequests tests handling of invalid JSON and malformed requests
-func TestMalformedRequests(t *testing.T) {
-	_, logger, server := testSetup(t)
-	addr := setupIntegrationTestServer(t, server)
+func TestPeerMalformedRequests(t *testing.T) {
+	_, logger, server := testPeerSetup(t)
+	addr := setupPeerIntegrationTestServer(t, server)
 
 	t.Run("Test malformed JSON", func(t *testing.T) {
-		client := setupTestClient(t, addr, logger)
+		client := setupPeerTestClient(t, addr, logger)
 		defer func(client PeerClient) {
 			_ = client.Close()
 		}(client)
@@ -553,7 +553,7 @@ func TestMalformedRequests(t *testing.T) {
 
 	t.Run("Test empty request", func(t *testing.T) {
 		// Create a new client for better isolation
-		client2 := setupTestClient(t, addr, logger)
+		client2 := setupPeerTestClient(t, addr, logger)
 		defer func(client PeerClient) {
 			_ = client.Close()
 		}(client2)
@@ -580,17 +580,17 @@ func TestMalformedRequests(t *testing.T) {
 }
 
 // TestEmptyBlobHandling tests handling of zero-size blobs
-func TestEmptyBlobHandling(t *testing.T) {
-	store, logger, _, addr := setupIntegrationTest(t)
+func TestPeerEmptyBlobHandling(t *testing.T) {
+	store, logger, _, addr := setupPeerIntegrationTest(t)
 
 	// Test data - use minimal non-empty data that works properly with AES PKCS#7 padding
 	testData := make([]byte, 1)
 	testData[0] = 0x00
-	testBlob, blobHash, key, iv := createTestBlob(t, testData)
+	testBlob, blobHash, key, iv := createPeerTestBlob(t, testData)
 	err := store.Put(blobHash, testBlob)
 	require.NoError(t, err)
 
-	client := setupTestClient(t, addr, logger)
+	client := setupPeerTestClient(t, addr, logger)
 	defer func(client PeerClient) {
 		_ = client.Close()
 	}(client)
@@ -617,13 +617,13 @@ func TestEmptyBlobHandling(t *testing.T) {
 }
 
 // TestRestrictedAccessControl tests deny-by-default access control
-func TestRestrictedAccessControl(t *testing.T) {
+func TestPeerRestrictedAccessControl(t *testing.T) {
 	accessControl := &denyAllAccessControl{}
-	store, logger, _, addr := setupIntegrationTest(t, WithPeerAccessControl(accessControl))
-	
+	store, logger, _, addr := setupPeerIntegrationTest(t, WithPeerAccessControl(accessControl))
+
 	testData := []byte("This is a test blob for restricted access")
 	_, blobHash := createAndStoreTestBlob(t, store, testData)
-	client := setupTestClient(t, addr, logger)
+	client := setupPeerTestClient(t, addr, logger)
 	defer func(client PeerClient) {
 		_ = client.Close()
 	}(client)
@@ -640,25 +640,25 @@ func TestRestrictedAccessControl(t *testing.T) {
 	assert.True(t, liblbryerrors.Is(err, liblbryerrors.ErrAccessDenied))
 }
 
-// stallConn is a connection wrapper that simulates network interruption
+// peerStallConn is a connection wrapper that simulates network interruption
 // by failing writes immediately
-type stallConn struct {
+type peerStallConn struct {
 	net.Conn
 }
 
-func (s *stallConn) Read(p []byte) (int, error) {
+func (s *peerStallConn) Read(p []byte) (int, error) {
 	// For this test, reads should work normally
 	return s.Conn.Read(p)
 }
 
-func (s *stallConn) Write(p []byte) (int, error) {
+func (s *peerStallConn) Write(p []byte) (int, error) {
 	// Fail immediately with a network error
 	return 0, errors.New("network interruption")
 }
 
-// TestPartialBlobTransfer tests interrupted blob transfers
-func TestPartialBlobTransfer(t *testing.T) {
-	store, logger, _, addr := setupIntegrationTest(t)
+// TestPeerPartialBlobTransfer tests interrupted blob transfers
+func TestPeerPartialBlobTransfer(t *testing.T) {
+	store, logger, _, addr := setupPeerIntegrationTest(t)
 
 	// Create test data
 	testData := []byte("This is a test blob for partial transfer")
@@ -678,8 +678,8 @@ func TestPartialBlobTransfer(t *testing.T) {
 			return nil, err
 		}
 		// Wrap it in our stall connection that fails writes
-		return &stallConn{
-			Conn:   realConn,
+		return &peerStallConn{
+			Conn: realConn,
 		}, nil
 	}
 
@@ -703,7 +703,7 @@ func TestPartialBlobTransfer(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a new client with normal connection for reconnection test
-	clientWithNormalConn := setupTestClient(t, addr, logger)
+	clientWithNormalConn := setupPeerTestClient(t, addr, logger)
 	defer func(client PeerClient) {
 		_ = client.Close()
 	}(clientWithNormalConn)
@@ -727,3 +727,4 @@ type denyAllAccessControl struct{}
 func (d *denyAllAccessControl) Allow(hash string, peerIP string) bool {
 	return false
 }
+

--- a/protocol/peer_messages.go
+++ b/protocol/peer_messages.go
@@ -1,0 +1,42 @@
+package protocol
+
+// CompositeRequest represents a request to a peer in the LBRY peer protocol.
+// It can request either a single blob (RequestedBlob) or check availability of
+// multiple blobs (RequestedBlobs). The BlobDataPaymentRate field is optional
+// and can be used to negotiate payment terms.
+type CompositeRequest struct {
+	// List of blob hashes to check availability for
+	RequestedBlobs []string `json:"requested_blobs,omitempty"`
+
+	// Optional payment rate for blob data (in LBC/byte)
+	BlobDataPaymentRate *float64 `json:"blob_data_payment_rate,omitempty"`
+
+	// Single blob hash being requested for download
+	RequestedBlob string `json:"requested_blob,omitempty"`
+}
+
+// CompositeResponse represents a response from a peer in the LBRY peer protocol.
+// It contains either a list of available blobs or an incoming blob transfer.
+type CompositeResponse struct {
+	// List of blob hashes that are available from this peer
+	AvailableBlobs []string `json:"available_blobs"`
+
+	// Optional payment rate for blob data (in LBC/byte)
+	BlobDataPaymentRate string `json:"blob_data_payment_rate,omitempty"`
+
+	// Details about an incoming blob transfer, if any
+	IncomingBlob *IncomingBlob `json:"incoming_blob,omitempty"`
+}
+
+// IncomingBlob contains information about a blob being transferred from a peer.
+// If there was an error, it will be in the Error field.
+type IncomingBlob struct {
+	// Error message if something went wrong with the transfer
+	Error string `json:"error,omitempty"`
+
+	// Hash of the blob being transferred
+	BlobHash string `json:"blob_hash"`
+
+	// Size of the blob in bytes
+	Length int `json:"length"`
+}

--- a/protocol/peer_test.go
+++ b/protocol/peer_test.go
@@ -490,7 +490,7 @@ func TestRequestFromConnection(t *testing.T) {
 	}
 }
 
-func TestTimeoutHandling(t *testing.T) {
+func TestPeerServerTimeoutHandling(t *testing.T) {
 	mockStore, listener := setupTestListener(t, false)
 	defer func() {
 		if err := listener.Close(); err != nil {

--- a/protocol/reflector.go
+++ b/protocol/reflector.go
@@ -61,40 +61,6 @@ var (
 	ErrNegativeBlobSize   = errors.New("negative blob size received")
 )
 
-// HandshakeRequestResponse represents the handshake message
-type HandshakeRequestResponse struct {
-	Version *int `json:"version"`
-}
-
-// SendBlobRequest represents a blob upload request
-type SendBlobRequest struct {
-	BlobHash   string `json:"blob_hash,omitempty"`
-	BlobSize   int    `json:"blob_size,omitempty"`
-	SdBlobHash string `json:"sd_blob_hash,omitempty"`
-	SdBlobSize int    `json:"sd_blob_size,omitempty"`
-}
-
-// SendBlobResponse represents a response to a regular blob request
-type SendBlobResponse struct {
-	SendBlob bool `json:"send_blob"`
-}
-
-// SendSDBlobResponse represents a response to an SD blob request
-type SendSDBlobResponse struct {
-	SendSdBlob  bool     `json:"send_sd_blob"`
-	NeededBlobs []string `json:"needed_blobs,omitempty"`
-}
-
-// BlobTransferResponse represents a response after blob transfer
-type BlobTransferResponse struct {
-	ReceivedBlob bool `json:"received_blob"`
-}
-
-// SDBlobTransferResponse represents a response after SD blob transfer
-type SDBlobTransferResponse struct {
-	ReceivedSdBlob bool `json:"received_sd_blob"`
-}
-
 // DefaultReflectorServer implements the ReflectorServer interface
 type DefaultReflectorServer struct {
 	store             liblbry.BlobStore

--- a/protocol/reflector_client.go
+++ b/protocol/reflector_client.go
@@ -1,0 +1,313 @@
+package protocol
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"time"
+
+	"go.lumeweb.com/liblbry/blob"
+	liblbryerrors "go.lumeweb.com/liblbry/errors"
+	"go.uber.org/zap"
+)
+
+// ReflectorClient defines the interface for interacting with LBRY reflector servers
+type ReflectorClient interface {
+	// Connect establishes a connection to the reflector server
+	Connect(address string) error
+	// Close terminates the connection to the reflector server
+	Close() error
+	// SendBlob uploads a regular blob to the reflector server
+	SendBlob(hash string, data []byte) error
+	// SendSDBlob uploads an SD blob to the reflector server
+	SendSDBlob(hash string, data []byte) error
+}
+
+// DefaultReflectorClient implements the ReflectorClient interface
+type DefaultReflectorClient struct {
+	conn            net.Conn
+	mutex           sync.Mutex
+	logger          *zap.Logger
+	timeout         time.Duration
+	version         int
+	dialContextFunc func(ctx context.Context, network, address string) (net.Conn, error)
+}
+
+// ReflectorClientOption configures the reflector client
+type ReflectorClientOption func(*DefaultReflectorClient)
+
+// NewReflectorClient creates a new reflector client instance
+func NewReflectorClient(options ...ReflectorClientOption) ReflectorClient {
+	client := &DefaultReflectorClient{
+		logger:  zap.NewNop(),
+		timeout: 30 * time.Second,
+		version: 1, // Default to protocol version 1
+	}
+
+	for _, option := range options {
+		option(client)
+	}
+
+	return client
+}
+
+// WithReflectorClientLogger sets the zap logger for the client
+func WithReflectorClientLogger(logger *zap.Logger) ReflectorClientOption {
+	return func(c *DefaultReflectorClient) {
+		c.logger = logger
+	}
+}
+
+// WithReflectorClientTimeout sets the connection timeout
+func WithReflectorClientTimeout(timeout time.Duration) ReflectorClientOption {
+	return func(c *DefaultReflectorClient) {
+		c.timeout = timeout
+	}
+}
+
+// WithReflectorClientVersion sets the protocol version
+func WithReflectorClientVersion(version int) ReflectorClientOption {
+	return func(c *DefaultReflectorClient) {
+		c.version = version
+	}
+}
+
+// WithReflectorClientDialContext sets a custom dial function for the client
+func WithReflectorClientDialContext(dialFunc func(ctx context.Context, network, address string) (net.Conn, error)) ReflectorClientOption {
+	return func(c *DefaultReflectorClient) {
+		c.dialContextFunc = dialFunc
+	}
+}
+
+// Connect establishes a connection to the reflector server
+func (c *DefaultReflectorClient) Connect(address string) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.conn != nil {
+		return errors.New("connection already established")
+	}
+
+	var conn net.Conn
+	var err error
+
+	if c.dialContextFunc != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), c.timeout)
+		defer cancel()
+		conn, err = c.dialContextFunc(ctx, "tcp", address)
+	} else {
+		conn, err = net.DialTimeout("tcp", address, c.timeout)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to connect: %w", err)
+	}
+
+	c.conn = conn
+
+	// Perform handshake
+	if err := c.doHandshake(); err != nil {
+		c.conn.Close()
+		c.conn = nil
+		return fmt.Errorf("handshake failed: %w", err)
+	}
+
+	return nil
+}
+
+// Close terminates the connection
+func (c *DefaultReflectorClient) Close() error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.conn == nil {
+		return nil
+	}
+
+	err := c.conn.Close()
+	c.conn = nil
+	return err
+}
+
+// SendBlob uploads a regular blob to the reflector server
+func (c *DefaultReflectorClient) SendBlob(hash string, data []byte) error {
+	return c.sendBlob(hash, data, false)
+}
+
+// SendSDBlob uploads an SD blob to the reflector server
+func (c *DefaultReflectorClient) SendSDBlob(hash string, data []byte) error {
+	return c.sendBlob(hash, data, true)
+}
+
+// sendBlob handles the common blob upload logic
+func (c *DefaultReflectorClient) sendBlob(hash string, data []byte, isSdBlob bool) error {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
+	if c.conn == nil {
+		return errors.New("not connected")
+	}
+
+	if len(data) > blob.MaxBlobSize {
+		return fmt.Errorf("blob exceeds maximum size of %d bytes", blob.MaxBlobSize)
+	}
+
+	// Send blob request
+	if err := c.sendBlobRequest(hash, len(data), isSdBlob); err != nil {
+		return fmt.Errorf("failed to send blob request: %w", err)
+	}
+
+	// Read blob response
+	shouldSend, err := c.readBlobResponse(isSdBlob)
+	if err != nil {
+		return fmt.Errorf("failed to read blob response: %w", err)
+	}
+	if !shouldSend {
+		return liblbryerrors.ErrBlobExists // Server doesn't want this blob
+	}
+
+	// Send blob data
+	if err := c.sendBlobData(data); err != nil {
+		return fmt.Errorf("failed to send blob data: %w", err)
+	}
+
+	// Read transfer response
+	received, err := c.readTransferResponse(isSdBlob)
+	if err != nil {
+		return fmt.Errorf("failed to read transfer response: %w", err)
+	}
+	if !received {
+		return errors.New("server failed to receive blob")
+	}
+
+	return nil
+}
+
+// doHandshake performs the protocol handshake
+func (c *DefaultReflectorClient) doHandshake() error {
+	// Send handshake
+	handshake := HandshakeRequestResponse{Version: &c.version}
+	if err := c.writeJSON(handshake); err != nil {
+		return err
+	}
+
+	// Read response
+	var response HandshakeRequestResponse
+	if err := c.readJSON(&response); err != nil {
+		return err
+	}
+
+	if response.Version == nil {
+		return errors.New("invalid handshake response: missing version")
+	}
+
+	if *response.Version != c.version {
+		return fmt.Errorf("protocol version mismatch: server=%d client=%d", *response.Version, c.version)
+	}
+
+	return nil
+}
+
+// sendBlobRequest sends a blob upload request
+func (c *DefaultReflectorClient) sendBlobRequest(hash string, size int, isSdBlob bool) error {
+	var request interface{}
+	if isSdBlob {
+		request = SendBlobRequest{SdBlobHash: hash, SdBlobSize: size}
+	} else {
+		request = SendBlobRequest{BlobHash: hash, BlobSize: size}
+	}
+	return c.writeJSON(request)
+}
+
+// readBlobResponse reads the server's response to a blob request
+func (c *DefaultReflectorClient) readBlobResponse(isSdBlob bool) (bool, error) {
+	if isSdBlob {
+		var response SendSDBlobResponse
+		if err := c.readJSON(&response); err != nil {
+			// EOF errors from readJSON during blob response indicate validation errors
+			// (the reference server closes connection on validation errors)
+			if errors.Is(err, io.EOF) {
+				return false, liblbryerrors.ErrServerValidation
+			}
+			return false, err
+		}
+		return response.SendSdBlob, nil
+	}
+
+	var response SendBlobResponse
+	if err := c.readJSON(&response); err != nil {
+		// EOF errors from readJSON during blob response indicate validation errors
+		// (the reference server closes connection on validation errors)
+		if errors.Is(err, io.EOF) {
+			return false, liblbryerrors.ErrServerValidation
+		}
+		return false, err
+	}
+	return response.SendBlob, nil
+}
+
+// sendBlobData sends the raw blob data
+func (c *DefaultReflectorClient) sendBlobData(data []byte) error {
+	if err := c.conn.SetWriteDeadline(time.Now().Add(c.timeout)); err != nil {
+		return err
+	}
+
+	_, err := c.conn.Write(data)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// readTransferResponse reads the server's confirmation after blob transfer
+func (c *DefaultReflectorClient) readTransferResponse(isSdBlob bool) (bool, error) {
+	if isSdBlob {
+		var response SDBlobTransferResponse
+		if err := c.readJSON(&response); err != nil {
+			return false, err
+		}
+		return response.ReceivedSdBlob, nil
+	}
+
+	var response BlobTransferResponse
+	if err := c.readJSON(&response); err != nil {
+		return false, err
+	}
+	return response.ReceivedBlob, nil
+}
+
+// writeJSON writes a JSON message to the connection
+func (c *DefaultReflectorClient) writeJSON(v interface{}) error {
+	if err := c.conn.SetWriteDeadline(time.Now().Add(c.timeout)); err != nil {
+		return err
+	}
+
+	// First encode the interface{} to JSON bytes
+	jsonData, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	// Then write those bytes directly to the connection
+	_, err = c.conn.Write(jsonData)
+	return err
+}
+
+// readJSON reads a JSON message from the connection
+func (c *DefaultReflectorClient) readJSON(v interface{}) error {
+	if err := c.conn.SetReadDeadline(time.Now().Add(c.timeout)); err != nil {
+		return err
+	}
+
+	dec := json.NewDecoder(c.conn)
+	return dec.Decode(v)
+}
+// containsIgnoreCase checks if a string contains a substring ignoring case
+func containsIgnoreCase(s, substr string) bool {
+	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
+}

--- a/protocol/reflector_client.go
+++ b/protocol/reflector_client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"sync"
 	"time"
 
@@ -306,8 +305,4 @@ func (c *DefaultReflectorClient) readJSON(v interface{}) error {
 
 	dec := json.NewDecoder(c.conn)
 	return dec.Decode(v)
-}
-// containsIgnoreCase checks if a string contains a substring ignoring case
-func containsIgnoreCase(s, substr string) bool {
-	return strings.Contains(strings.ToLower(s), strings.ToLower(substr))
 }

--- a/protocol/reflector_client_test.go
+++ b/protocol/reflector_client_test.go
@@ -1,0 +1,566 @@
+package protocol
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/liblbry/blob"
+	liblbryerrors "go.lumeweb.com/liblbry/errors"
+	liblbrytesting "go.lumeweb.com/liblbry/internal/testing"
+	"go.lumeweb.com/liblbry/storage/memory"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+// setupReflectorIntegrationTestServer starts a reflector server on a random port and returns the address
+func setupReflectorIntegrationTestServer(t *testing.T, server ReflectorServer) string {
+	// Start server on random port
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	// Server goroutine
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err != nil {
+				// Check if the listener was closed intentionally
+				if netErr, ok := err.(net.Error); ok && netErr.Temporary() {
+					// Temporary error, continue listening
+					continue
+				}
+				// Listener closed or permanent error, exit goroutine
+				return
+			}
+
+			// Handle connection in a separate goroutine
+			go func(conn net.Conn) {
+				defer func() {
+					if r := recover(); r != nil {
+						// Log panic recovery
+					}
+					if err := conn.Close(); err != nil {
+						// Log the error but don't fail the test since this is cleanup
+					}
+				}()
+
+				server.HandleConnection(conn)
+			}(conn)
+		}
+	}()
+
+	addr := listener.Addr().String()
+
+	// Register cleanup function to close listener when test completes
+	t.Cleanup(func() {
+		_ = listener.Close()
+	})
+
+	return addr
+}
+
+// testReflectorSetup creates common test components
+func testReflectorSetup(t *testing.T) (*memory.MemoryStore, *zap.Logger, ReflectorServer) {
+	store := memory.NewMemoryStore()
+	logger := zaptest.NewLogger(t)
+	server := NewReflectorServer(store, WithReflectorLogger(logger))
+	return store, logger, server
+}
+
+// testReflectorClientSetup creates a test client and connects it to the server
+func testReflectorClientSetup(t *testing.T, addr string, logger *zap.Logger, timeout ...time.Duration) (ReflectorClient, context.Context) {
+	var client ReflectorClient
+	if len(timeout) > 0 {
+		client = NewReflectorClient(WithReflectorClientLogger(logger), WithReflectorClientTimeout(timeout[0]))
+	} else {
+		client = NewReflectorClient(WithReflectorClientLogger(logger))
+	}
+
+	ctx := context.Background()
+	err := client.Connect(addr)
+	require.NoError(t, err)
+
+	return client, ctx
+}
+
+// setupReflectorIntegrationTest creates a complete integration test setup
+func setupReflectorIntegrationTest(t *testing.T, opts ...ReflectorServerOption) (*memory.MemoryStore, *zap.Logger, ReflectorServer, string) {
+	store, logger, server := testReflectorSetup(t)
+
+	// Apply additional server options
+	serverOpts := []ReflectorServerOption{WithReflectorLogger(logger)}
+	serverOpts = append(serverOpts, opts...)
+	server = NewReflectorServer(store, serverOpts...)
+
+	addr := setupReflectorIntegrationTestServer(t, server)
+	return store, logger, server, addr
+}
+
+// setupReflectorTestClient creates a test client with automatic cleanup
+func setupReflectorTestClient(t *testing.T, addr string, logger *zap.Logger, timeout ...time.Duration) ReflectorClient {
+	client, _ := testReflectorClientSetup(t, addr, logger, timeout...)
+	return client
+}
+
+// createReflectorTestBlob creates a blob with test data
+func createReflectorTestBlob(t *testing.T, testData []byte) (blob.Blob, string, []byte, []byte) {
+	key := make([]byte, 16)
+	iv := make([]byte, 16)
+	_, err := io.ReadFull(rand.Reader, key)
+	require.NoError(t, err)
+	_, err = io.ReadFull(rand.Reader, iv)
+	require.NoError(t, err)
+
+	testBlob, err := blob.NewBlob(testData, key, iv)
+	require.NoError(t, err)
+
+	blobHash := testBlob.HashHex()
+	return testBlob, blobHash, key, iv
+}
+
+// TestReflectorClientNew tests reflector client creation with different options
+func TestReflectorClientNew(t *testing.T) {
+	tests := []struct {
+		name    string
+		options []ReflectorClientOption
+		verify  func(t *testing.T, c *DefaultReflectorClient)
+	}{
+		{
+			name:    "default options",
+			options: nil,
+			verify: func(t *testing.T, c *DefaultReflectorClient) {
+				if c.logger == nil {
+					t.Error("expected default logger")
+				}
+				if c.timeout != 30*time.Second {
+					t.Errorf("expected default timeout, got %v", c.timeout)
+				}
+				if c.version != 1 {
+					t.Errorf("expected default version 1, got %d", c.version)
+				}
+			},
+		},
+		{
+			name: "with options",
+			options: []ReflectorClientOption{
+				WithReflectorClientLogger(zaptest.NewLogger(t)),
+				WithReflectorClientTimeout(10 * time.Second),
+				WithReflectorClientVersion(2),
+			},
+			verify: func(t *testing.T, c *DefaultReflectorClient) {
+				if c.logger == nil {
+					t.Error("expected logger")
+				}
+				if c.timeout != 10*time.Second {
+					t.Errorf("expected 10s timeout, got %v", c.timeout)
+				}
+				if c.version != 2 {
+					t.Errorf("expected version 2, got %d", c.version)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := NewReflectorClient(tt.options...)
+			if dc, ok := client.(*DefaultReflectorClient); ok {
+				tt.verify(t, dc)
+			} else {
+				t.Error("expected *DefaultReflectorClient")
+			}
+		})
+	}
+}
+
+// TestReflectorClientConnectAndClose tests connection establishment and closing
+func TestReflectorClientConnectAndClose(t *testing.T) {
+	store, logger, _, addr := setupReflectorIntegrationTest(t)
+
+	client := setupReflectorTestClient(t, addr, logger)
+	if dc, ok := client.(*DefaultReflectorClient); ok {
+		if dc.conn == nil {
+			t.Error("expected connection to be set")
+		}
+
+		err := client.Close()
+		if err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	} else {
+		t.Error("expected *DefaultReflectorClient")
+	}
+
+	// Add blob to store to test upload
+	testData := []byte("test blob data")
+	testBlob, blobHash, _, _ := createReflectorTestBlob(t, testData)
+	err := store.Put(blobHash, testBlob)
+	require.NoError(t, err)
+}
+
+// TestReflectorClientSendBlob tests blob sending functionality
+func TestReflectorClientSendBlob(t *testing.T) {
+	store, logger, _, addr := setupReflectorIntegrationTest(t)
+
+	testData := []byte("test blob data")
+	testBlob, blobHash, _, _ := createReflectorTestBlob(t, testData)
+	
+	client := setupReflectorTestClient(t, addr, logger)
+	defer func(client ReflectorClient) {
+		_ = client.Close()
+	}(client)
+
+	// First upload should succeed
+	err := client.SendBlob(blobHash, testBlob.ToBytes())
+	require.NoError(t, err)
+
+	// Store blob to test duplicate handling
+	err = store.Put(blobHash, testBlob)
+	require.NoError(t, err)
+
+	// Second upload should return ErrBlobExists
+	err = client.SendBlob(blobHash, testBlob.ToBytes())
+	if err == nil {
+		t.Error("expected error but got nil")
+	} else if err.Error() != liblbryerrors.ErrBlobExists.Error() {
+		t.Errorf("expected ErrBlobExists message, got %v", err.Error())
+	}
+
+	// Create a fresh server for SD blob test to avoid conflicts
+	sdStore, logger2, _, sdAddr := setupReflectorIntegrationTest(t)
+	
+	// Test SendSDBlob with different data
+	sdBlobData := []byte("test sd blob data")
+	sdTestBlob, sdBlobHash, _, _ := createReflectorTestBlob(t, sdBlobData)
+	
+	sdClient := setupReflectorTestClient(t, sdAddr, logger2)
+	defer func(client ReflectorClient) {
+		_ = client.Close()
+	}(sdClient)
+
+	err = sdClient.SendSDBlob(sdBlobHash, sdTestBlob.ToBytes())
+	require.NoError(t, err)
+
+	// Store SD blob to test duplicate handling
+	err = sdStore.Put(sdBlobHash, sdTestBlob)
+	require.NoError(t, err)
+
+	// Second SD blob upload should return ErrBlobExists
+	err = sdClient.SendSDBlob(sdBlobHash, sdTestBlob.ToBytes())
+	if err == nil {
+		t.Error("expected error but got nil")
+	} else if err.Error() != liblbryerrors.ErrBlobExists.Error() {
+		t.Errorf("expected ErrBlobExists message, got %v", err.Error())
+	}
+}
+
+// TestReflectorClientErrorHandling tests various error scenarios
+func TestReflectorClientErrorHandling(t *testing.T) {
+	tests := []struct {
+		name        string
+		setup       func() ReflectorClient
+		operation   func(c ReflectorClient) error
+		expectError string
+	}{
+		{
+			name: "send without connection",
+			setup: func() ReflectorClient {
+				return NewReflectorClient()
+			},
+			operation: func(c ReflectorClient) error {
+				return c.SendBlob("hash", []byte("data"))
+			},
+			expectError: "not connected",
+		},
+		{
+			name: "blob too large",
+			setup: func() ReflectorClient {
+				client := NewReflectorClient()
+				// Create a fake connection to bypass the "not connected" check
+				client.(*DefaultReflectorClient).conn = &fakeConn{}
+				return client
+			},
+			operation: func(c ReflectorClient) error {
+				largeBlob := make([]byte, blob.MaxBlobSize+1)
+				return c.SendBlob("hash", largeBlob)
+			},
+			expectError: "exceeds maximum size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := tt.setup()
+			err := tt.operation(client)
+			if err == nil || !strings.Contains(err.Error(), tt.expectError) {
+				t.Errorf("expected error containing %q, got %v", tt.expectError, err)
+			}
+		})
+	}
+}
+
+// TestReflectorClientTimeoutHandling tests timeout scenarios
+func TestReflectorClientTimeoutHandling(t *testing.T) {
+	_, logger, _, addr := setupReflectorIntegrationTest(t, WithReflectorTimeout(100*time.Millisecond))
+
+	client := setupReflectorTestClient(t, addr, logger, 100*time.Millisecond)
+	defer func(client ReflectorClient) {
+		_ = client.Close()
+	}(client)
+
+	// Test send with timeout
+	testData := []byte("test data")
+	err := client.SendBlob("hash", testData)
+	if err == nil {
+		t.Error("expected timeout error")
+	}
+}
+
+// TestReflectorClientConcurrentClients tests multiple concurrent clients accessing the server
+func TestReflectorClientConcurrentClients(t *testing.T) {
+	// Create one server for all clients to connect to
+	store, logger, _, addr := setupReflectorIntegrationTest(t)
+	
+	// Create ONE blob that all clients will try to upload
+	testData := []byte("This is test blob data for concurrent access")
+	testBlob, blobHash, _, _ := createReflectorTestBlob(t, testData)
+	err := store.Put(blobHash, testBlob)
+	require.NoError(t, err)
+
+	// Create tasks for concurrent execution
+	tasks := make([]func() error, 10)
+
+	for i := 0; i < 10; i++ {
+		tasks[i] = func() error {
+			// Create client
+			client := NewReflectorClient(WithReflectorClientLogger(logger))
+			defer func(client ReflectorClient) {
+				_ = client.Close()
+			}(client)
+
+			// Connect client to the SAME server
+			err := client.Connect(addr)
+			if err != nil {
+				return err
+			}
+
+			// Test SendBlob - should return ErrBlobExists for all clients 
+			// since they're all trying to upload the same blob
+			err = client.SendBlob(blobHash, testBlob.ToBytes())
+			if err != nil {
+				// Check if it's the expected "blob already exists" error
+				if err.Error() != liblbryerrors.ErrBlobExists.Error() {
+					return err // Return unexpected errors
+				}
+				// ErrBlobExists is expected, so this is success
+				return nil
+			}
+			
+			// If no error, this was the first client to upload successfully
+			return nil
+		}
+	}
+
+	// Execute tasks concurrently using the testing utility
+	liblbrytesting.RunConcurrentTasks(t, 5, tasks)
+}
+
+// TestReflectorClientLargeBlobHandling tests handling of large blobs
+func TestReflectorClientLargeBlobHandling(t *testing.T) {
+	store, logger, _, addr := setupReflectorIntegrationTest(t)
+
+	// Create large test data (接近2MB限制)
+	largeData := make([]byte, blob.MaxBlobSize-1000)
+	for i := range largeData {
+		largeData[i] = byte(i % 256)
+	}
+
+	largeBlob, blobHash, _, _ := createReflectorTestBlob(t, largeData)
+
+	client := setupReflectorTestClient(t, addr, logger)
+	defer func(client ReflectorClient) {
+		_ = client.Close()
+	}(client)
+
+	// Test SendBlob with large blob - first upload should succeed
+	err := client.SendBlob(blobHash, largeBlob.ToBytes())
+	require.NoError(t, err)
+
+	// NOW put the blob in the store to test duplicate handling
+	err = store.Put(blobHash, largeBlob)
+	require.NoError(t, err)
+
+	// Create a fresh client and server for testing duplicate upload
+	store2, logger2, _, addr2 := setupReflectorIntegrationTest(t)
+	
+	// Put the same blob in the new store
+	err = store2.Put(blobHash, largeBlob)
+	require.NoError(t, err)
+	
+	client2 := setupReflectorTestClient(t, addr2, logger2)
+	defer func(client ReflectorClient) {
+		_ = client.Close()
+	}(client2)
+
+	// Test SendBlob with large blob - second upload should return ErrBlobExists
+	err = client2.SendBlob(blobHash, largeBlob.ToBytes())
+	require.Error(t, err)
+	assert.True(t, liblbryerrors.Is(err, liblbryerrors.ErrBlobExists))
+}
+
+// TestReflectorClientConnectionManagement tests connection management features
+func TestReflectorClientConnectionManagement(t *testing.T) {
+	_, logger, _, addr := setupReflectorIntegrationTest(t)
+
+	client := NewReflectorClient(WithReflectorClientLogger(logger))
+	defer func(client ReflectorClient) {
+		_ = client.Close()
+	}(client)
+
+	// Connect client to server
+	err := client.Connect(addr)
+	require.NoError(t, err)
+
+	// Test that we can't connect again
+	err = client.Connect(addr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connection already established")
+
+	// Close connection
+	err = client.Close()
+	require.NoError(t, err)
+
+	// Verify we're no longer connected
+	assert.Nil(t, client.(*DefaultReflectorClient).conn)
+
+	// Test operations after close
+	err = client.SendBlob("somehash", []byte("data"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+}
+
+// TestReflectorClientNetworkFailureRecovery tests client behavior when connection drops mid-operation
+func TestReflectorClientNetworkFailureRecovery(t *testing.T) {
+	store, logger, _, addr := setupReflectorIntegrationTest(t)
+
+	testData := []byte("This is a test blob for network failure recovery")
+	testBlob, blobHash, _, _ := createReflectorTestBlob(t, testData)
+
+	client := setupReflectorTestClient(t, addr, logger)
+	defer func(client ReflectorClient) {
+		_ = client.Close()
+	}(client)
+
+	// Test normal operation first
+	err := client.SendBlob(blobHash, testBlob.ToBytes())
+	require.NoError(t, err)
+
+	// Now put the blob in the store to test duplicate handling after recovery
+	err = store.Put(blobHash, testBlob)
+	require.NoError(t, err)
+
+	// Simulate network failure by closing connection
+	err = client.Close()
+	require.NoError(t, err)
+
+	// Operations should now fail
+	err = client.SendBlob(blobHash, testBlob.ToBytes())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not connected")
+
+	// Reconnect to the same server (should still work)
+	err = client.Connect(addr)
+	require.NoError(t, err)
+
+	// Operations should work again, but blob already exists so expect ErrBlobExists
+	err = client.SendBlob(blobHash, testBlob.ToBytes())
+	require.Error(t, err)
+	assert.True(t, liblbryerrors.Is(err, liblbryerrors.ErrBlobExists))
+}
+
+// fakeConn is a fake connection for testing error cases
+type fakeConn struct{}
+
+func (f *fakeConn) Read(b []byte) (n int, err error)  { return 0, errors.New("read error") }
+func (f *fakeConn) Write(b []byte) (n int, err error) { return 0, errors.New("write error") }
+func (f *fakeConn) Close() error                      { return nil }
+func (f *fakeConn) LocalAddr() net.Addr               { return nil }
+func (f *fakeConn) RemoteAddr() net.Addr              { return nil }
+func (f *fakeConn) SetDeadline(t time.Time) error     { return nil }
+func (f *fakeConn) SetReadDeadline(t time.Time) error { return nil }
+func (f *fakeConn) SetWriteDeadline(t time.Time) error {
+	return nil
+}
+
+// reflectorStallConn is a connection wrapper that simulates network interruption
+// by failing writes immediately
+type reflectorStallConn struct {
+	net.Conn
+}
+
+func (s *reflectorStallConn) Read(p []byte) (int, error) {
+	// For this test, reads should work normally
+	return s.Conn.Read(p)
+}
+
+func (s *reflectorStallConn) Write(p []byte) (int, error) {
+	// Fail immediately with a network error
+	return 0, errors.New("network interruption")
+}
+
+// TestReflectorClientPartialBlobTransfer tests interrupted blob transfers
+func TestReflectorClientPartialBlobTransfer(t *testing.T) {
+	store, logger, _, addr := setupReflectorIntegrationTest(t)
+
+	// Create test data
+	testData := []byte("This is a test blob for partial transfer")
+	testBlob, blobHash, _, _ := createReflectorTestBlob(t, testData)
+	err := store.Put(blobHash, testBlob)
+	require.NoError(t, err)
+
+	// Set up a custom dial function that returns our stall connection
+	stallDialer := func(ctx context.Context, network, address string) (net.Conn, error) {
+		// First establish a real connection
+		realConn, err := (&net.Dialer{}).DialContext(ctx, network, address)
+		if err != nil {
+			return nil, err
+		}
+		// Wrap it in our stall connection that fails writes
+		return &reflectorStallConn{
+			Conn: realConn,
+		}, nil
+	}
+
+	// Create a client with a stall connection using the custom dialer
+	client := NewReflectorClient(WithReflectorClientLogger(logger), WithReflectorClientDialContext(stallDialer))
+	defer func(client ReflectorClient) {
+		_ = client.Close()
+	}(client)
+
+	// This should fail during handshake due to the stall connection
+	err = client.Connect(addr)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "network interruption")
+
+	// Close connection properly
+	err = client.Close()
+	require.NoError(t, err)
+
+	// Create a new client with normal connection for reconnection test
+	clientWithNormalConn := setupReflectorTestClient(t, addr, logger)
+	defer func(client ReflectorClient) {
+		_ = client.Close()
+	}(clientWithNormalConn)
+
+	// Should work now with new client, but blob already exists so expect ErrBlobExists
+	err = clientWithNormalConn.SendBlob(blobHash, testBlob.ToBytes())
+	require.Error(t, err)
+	assert.True(t, liblbryerrors.Is(err, liblbryerrors.ErrBlobExists))
+}

--- a/protocol/reflector_messages.go
+++ b/protocol/reflector_messages.go
@@ -1,0 +1,37 @@
+package protocol
+
+// Protocol message types for LBRY reflector protocol
+
+// HandshakeRequestResponse represents the handshake message
+type HandshakeRequestResponse struct {
+	Version *int `json:"version"`
+}
+
+// SendBlobRequest represents a blob upload request
+type SendBlobRequest struct {
+	BlobHash   string `json:"blob_hash,omitempty"`
+	BlobSize   int    `json:"blob_size,omitempty"`
+	SdBlobHash string `json:"sd_blob_hash,omitempty"`
+	SdBlobSize int    `json:"sd_blob_size,omitempty"`
+}
+
+// SendBlobResponse represents a response to a regular blob request
+type SendBlobResponse struct {
+	SendBlob bool `json:"send_blob"`
+}
+
+// SendSDBlobResponse represents a response to an SD blob request
+type SendSDBlobResponse struct {
+	SendSdBlob  bool     `json:"send_sd_blob"`
+	NeededBlobs []string `json:"needed_blobs,omitempty"`
+}
+
+// BlobTransferResponse represents a response after blob transfer
+type BlobTransferResponse struct {
+	ReceivedBlob bool `json:"received_blob"`
+}
+
+// SDBlobTransferResponse represents a response after SD blob transfer
+type SDBlobTransferResponse struct {
+	ReceivedSdBlob bool `json:"received_sd_blob"`
+}


### PR DESCRIPTION
* Add new ReflectorClient interface and DefaultReflectorClient implementation for uploading blobs to LBRY reflector servers
* Split peer protocol and reflector protocol into separate files (peer_messages.go, reflector_messages.go)
* Move peer client implementation to peer_client.go and rename client.go to peer_client.go
* Add new end-to-end tests for reflector client functionality
* Add ErrBlobExists and ErrServerValidation to common errors
* Update error handling and validation logic in both peer and reflector protocols
* Refactor test utilities and move common test functions to separate files

---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reflector client for uploading blobs with handshake, timeouts, configuration, and retry/connection management.

* **Bug Fixes / Errors**
  * New public error types for clearer upload/validation feedback, including blob-exists and server-validation.

* **Tests**
  * Extensive end-to-end and unit tests for reflector and peer flows: concurrency, timeouts, large blobs, network failures, and helpers.

* **Refactor**
  * Reorganized protocol message types and standardized peer/test naming.

* **Chores**
  * Removed legacy client code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->