### PR TITLE
feat(server): add DHT seed nodes support and improve configuration handling

### DIFF
--- a/server/builder.go
+++ b/server/builder.go
@@ -80,9 +80,60 @@ func (b *ServerBuilder) WithReflector(port ...int) *ServerBuilder {
 
 // WithDHT adds a DHT protocol handler on the specified port
 func (b *ServerBuilder) WithDHT(port ...int) *ServerBuilder {
-	return b.withProtocolConfig(ProtocolDHT, DefaultDHTPort, port, func(p int) any {
-		return &DHTConfig{Port: p}
-	})
+	// Get the port to use
+	p := DefaultDHTPort
+	if len(port) > 0 {
+		p = port[0]
+	}
+	
+	// Check if DHT protocol config already exists
+	dhtConfig, exists := b.protocols[ProtocolDHT]
+	
+	if exists {
+		// If it exists, preserve the SeedNodes and only update the Port
+		if dhtCfg, ok := dhtConfig.(*DHTConfig); ok {
+			seedNodes := dhtCfg.SeedNodes // Preserve existing seed nodes
+			b.protocols[ProtocolDHT] = &DHTConfig{
+				Port:      p,
+				SeedNodes: seedNodes,
+			}
+		}
+	} else {
+		// If it doesn't exist, create new config with empty seed nodes
+		b.protocols[ProtocolDHT] = &DHTConfig{
+			Port:      p,
+			SeedNodes: []string{}, // Empty slice instead of nil
+		}
+	}
+	
+	return b
+}
+
+// WithDHTSeedNodes sets seed nodes for the DHT protocol
+func (b *ServerBuilder) WithDHTSeedNodes(seedNodes ...string) *ServerBuilder {
+	// Handle nil seedNodes by converting to empty slice
+	if seedNodes == nil {
+		seedNodes = []string{}
+	}
+	
+	// Check if DHT protocol config exists
+	dhtConfig, exists := b.protocols[ProtocolDHT]
+	
+	if !exists {
+		// Create a new DHTConfig with default port if it doesn't exist
+		dhtConfig = &DHTConfig{
+			Port:      DefaultDHTPort,
+			SeedNodes: seedNodes,
+		}
+		b.protocols[ProtocolDHT] = dhtConfig
+	} else {
+		// Update existing DHT config's seed nodes
+		if dhtCfg, ok := dhtConfig.(*DHTConfig); ok {
+			dhtCfg.SeedNodes = seedNodes
+		}
+	}
+	
+	return b
 }
 
 // WithLogger sets the logger for the server

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -420,3 +420,130 @@ func TestServerBuilder_DefaultLogger(t *testing.T) {
 	// The default logger should be a no-op logger
 	assert.Equal(t, zap.NewNop(), builder.logger)
 }
+
+// TestServerBuilder_WithDHTSeedNodes verifies that WithDHTSeedNodes correctly sets seed nodes on the DHT config
+func TestServerBuilder_WithDHTSeedNodes(t *testing.T) {
+	tests := []struct {
+		name           string
+		seedNodes      []string
+		expectedSeedNodes []string
+	}{
+		{
+			name:           "SingleSeedNode",
+			seedNodes:      []string{"/ip4/127.0.0.1/tcp/4444/p2p/QmSeedNode1"},
+			expectedSeedNodes: []string{"/ip4/127.0.0.1/tcp/4444/p2p/QmSeedNode1"},
+		},
+		{
+			name:           "MultipleSeedNodes",
+			seedNodes:      []string{"/ip4/127.0.0.1/tcp/4444/p2p/QmSeedNode1", "/ip4/127.0.0.1/tcp/4445/p2p/QmSeedNode2"},
+			expectedSeedNodes: []string{"/ip4/127.0.0.1/tcp/4444/p2p/QmSeedNode1", "/ip4/127.0.0.1/tcp/4445/p2p/QmSeedNode2"},
+		},
+		{
+			name:           "EmptySeedNodes",
+			seedNodes:      []string{},
+			expectedSeedNodes: []string{},
+		},
+		{
+			name:           "NilSeedNodes",
+			seedNodes:      nil,
+			expectedSeedNodes: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewServerBuilder()
+			
+			// Configure DHT with seed nodes
+			result := builder.WithDHTSeedNodes(tt.seedNodes...)
+			
+			// Verify builder returns same instance
+			assertBuilderReturnsSame(t, builder, result)
+			
+			// Verify DHT config exists and has correct seed nodes
+			assert.Contains(t, builder.protocols, ProtocolDHT)
+			
+			dhtConfig := builder.protocols[ProtocolDHT].(*DHTConfig)
+			assert.Equal(t, tt.expectedSeedNodes, dhtConfig.SeedNodes)
+		})
+	}
+}
+
+// TestServerBuilder_WithDHTSeedNodesBeforeWithDHT verifies that calling WithDHTSeedNodes before WithDHT works correctly
+func TestServerBuilder_WithDHTSeedNodesBeforeWithDHT(t *testing.T) {
+	builder := NewServerBuilder()
+	
+	// Call WithDHTSeedNodes before WithDHT - should not crash
+	seedNodes := []string{"/ip4/127.0.0.1/tcp/4444/p2p/QmSeedNode1"}
+	result := builder.WithDHTSeedNodes(seedNodes...)
+	
+	// Verify builder returns same instance
+	assertBuilderReturnsSame(t, builder, result)
+	
+	// Verify DHT config exists and has correct seed nodes
+	assert.Contains(t, builder.protocols, ProtocolDHT)
+	
+	dhtConfig := builder.protocols[ProtocolDHT].(*DHTConfig)
+	assert.Equal(t, seedNodes, dhtConfig.SeedNodes)
+	
+	// Now configure DHT - should not overwrite seed nodes
+	builder.WithDHT()
+	
+	// Verify seed nodes are still there
+	dhtConfig = builder.protocols[ProtocolDHT].(*DHTConfig)
+	assert.Equal(t, seedNodes, dhtConfig.SeedNodes)
+}
+
+// TestServerBuilder_WithDHTSeedNodesAfterWithDHT verifies that calling WithDHTSeedNodes after WithDHT works correctly
+func TestServerBuilder_WithDHTSeedNodesAfterWithDHT(t *testing.T) {
+	builder := NewServerBuilder()
+	
+	// First configure DHT
+	builder.WithDHT()
+	
+	// Verify DHT config exists with empty seed nodes initially
+	assert.Contains(t, builder.protocols, ProtocolDHT)
+	dhtConfig := builder.protocols[ProtocolDHT].(*DHTConfig)
+	assert.Empty(t, dhtConfig.SeedNodes)
+	
+	// Then set seed nodes
+	seedNodes := []string{"/ip4/127.0.0.1/tcp/4444/p2p/QmSeedNode1"}
+	result := builder.WithDHTSeedNodes(seedNodes...)
+	
+	// Verify builder returns same instance
+	assertBuilderReturnsSame(t, builder, result)
+	
+	// Verify seed nodes were set correctly
+	dhtConfig = builder.protocols[ProtocolDHT].(*DHTConfig)
+	assert.Equal(t, seedNodes, dhtConfig.SeedNodes)
+}
+
+// TestServerBuilder_WithDHTSeedNodesMultipleCalls verifies that calling WithDHTSeedNodes multiple times overwrites previous values
+func TestServerBuilder_WithDHTSeedNodesMultipleCalls(t *testing.T) {
+	builder := NewServerBuilder()
+	
+	// First call
+	seedNodes1 := []string{"/ip4/127.0.0.1/tcp/4444/p2p/QmSeedNode1"}
+	builder.WithDHTSeedNodes(seedNodes1...)
+	
+	// Verify first seed nodes
+	assert.Contains(t, builder.protocols, ProtocolDHT)
+	dhtConfig := builder.protocols[ProtocolDHT].(*DHTConfig)
+	assert.Equal(t, seedNodes1, dhtConfig.SeedNodes)
+	
+	// Second call - should overwrite
+	seedNodes2 := []string{"/ip4/127.0.0.1/tcp/4445/p2p/QmSeedNode2"}
+	builder.WithDHTSeedNodes(seedNodes2...)
+	
+	// Verify second seed nodes
+	dhtConfig = builder.protocols[ProtocolDHT].(*DHTConfig)
+	assert.Equal(t, seedNodes2, dhtConfig.SeedNodes)
+	
+	// Third call - should overwrite again
+	seedNodes3 := []string{"/ip4/127.0.0.1/tcp/4446/p2p/QmSeedNode3"}
+	builder.WithDHTSeedNodes(seedNodes3...)
+	
+	// Verify third seed nodes
+	dhtConfig = builder.protocols[ProtocolDHT].(*DHTConfig)
+	assert.Equal(t, seedNodes3, dhtConfig.SeedNodes)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -65,7 +65,8 @@ type ReflectorConfig struct {
 
 // DHTConfig contains configuration for DHT protocol
 type DHTConfig struct {
-	Port int
+	Port      int
+	SeedNodes []string
 }
 
 // DefaultServer implements the Server interface
@@ -213,12 +214,21 @@ func (s *DefaultServer) startDHT(config *DHTConfig) error {
 		peerProtocolPort = DefaultPeerPort
 	}
 
-	// Create DHT node with configuration
-	dhtNode, err := protocol.NewDHTNodeWithDefaults(
+	// Build options slice dynamically
+	var opts []protocol.DHTOption
+	opts = append(opts,
 		protocol.WithDHTAddress(fmt.Sprintf("0.0.0.0:%d", config.Port)),
 		protocol.WithDHTPeerProtocolPort(peerProtocolPort),
 		protocol.WithDHTLogger(s.logger.Named("dht")),
 	)
+	
+	// Conditionally add seed nodes if they exist
+	if len(config.SeedNodes) > 0 {
+		opts = append(opts, protocol.WithDHTSeedNodes(config.SeedNodes))
+	}
+
+	// Create DHT node with all options at once
+	dhtNode, err := protocol.NewDHTNodeWithDefaults(opts...)
 	if err != nil {
 		return fmt.Errorf("failed to create DHT node: %w", err)
 	}


### PR DESCRIPTION
- Introduce `WithDHTSeedNodes` method to set seed nodes for DHT protocol
- Enhance `WithDHT` method to preserve existing seed nodes when updating DHT config
- Update `DHTConfig` to include `SeedNodes` field
- Modify DHT node creation to conditionally include seed nodes via new options
- Add comprehensive tests for `WithDHTSeedNodes` functionality including edge cases
---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring DHT seed nodes during server initialization, enabling explicit specification of bootstrap nodes for enhanced network connectivity and discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->