### PR TITLE
fix(server): correct DHT blob announcement hash format and improve configuration

### DIFF
--- a/protocol/dht.go
+++ b/protocol/dht.go
@@ -10,6 +10,9 @@ import (
 	"go.uber.org/zap"
 )
 
+// DefaultDHTAddress is the default address for DHT nodes
+const DefaultDHTAddress = "127.0.0.1:4444"
+
 // DHT abstracts the underlying dht.DHT implementation
 type DHT interface {
 	// Start begins listening for DHT connections
@@ -121,7 +124,7 @@ func validateDHTConfig(c *DHTConfig) error {
 // NewDHTConfig creates a default DHT configuration
 func NewDHTConfig() (*DHTConfig, error) {
 	cfg := &DHTConfig{
-		Address:          "0.0.0.0:4444",
+		Address:          DefaultDHTAddress,
 		SeedNodes:        []string{"lbrynet1.lbry.com:4444", "lbrynet2.lbry.com:4444", "lbrynet3.lbry.com:4444", "lbrynet4.lbry.com:4444"},
 		PeerProtocolPort: 3333,
 		ReannounceTime:   50 * time.Minute,

--- a/protocol/dht.go
+++ b/protocol/dht.go
@@ -11,6 +11,8 @@ import (
 )
 
 // DefaultDHTAddress is the default address for DHT nodes
+// Uses 127.0.0.1 (localhost) by default because 0.0.0.0 cannot be used for DHT broadcasting.
+// Production deployments must explicitly set their external IP using WithDHTAddress().
 const DefaultDHTAddress = "127.0.0.1:4444"
 
 // DHT abstracts the underlying dht.DHT implementation
@@ -68,7 +70,7 @@ type DHTNode interface {
 	// State Management
 	IsJoined() bool
 	GetRoutingTableInfo() string
-	
+
 	// Restart restarts a stopped DHT node
 	Restart() error
 }

--- a/protocol/dht_test.go
+++ b/protocol/dht_test.go
@@ -16,8 +16,8 @@ func TestNewDHTConfig(t *testing.T) {
 	cfg, err := NewDHTConfig()
 	require.NoError(t, err, "Failed to create DHT config")
 
-	if cfg.Address != "0.0.0.0:4444" {
-		t.Errorf("Expected default address '0.0.0.0:4444', got '%s'", cfg.Address)
+	if cfg.Address != "127.0.0.1:4444" {
+		t.Errorf("Expected default address '127.0.0.1:4444', got '%s'", cfg.Address)
 	}
 
 	if len(cfg.SeedNodes) != 4 {

--- a/server/builder.go
+++ b/server/builder.go
@@ -53,6 +53,30 @@ func (b *ServerBuilder) WithAccessControl(ac storage.AccessControl) *ServerBuild
 	return b
 }
 
+// getOrCreateDHTConfig retrieves the existing DHT config or creates a new one with default values
+func (b *ServerBuilder) getOrCreateDHTConfig() *DHTConfig {
+	// Check if DHT protocol config already exists
+	dhtConfig, exists := b.protocols[ProtocolDHT]
+	
+	if exists {
+		// If it exists, return the existing config
+		if dhtCfg, ok := dhtConfig.(*DHTConfig); ok {
+			return dhtCfg
+		}
+		// If it's not the right type, create a new one (shouldn't happen in practice)
+	}
+	
+	// If it doesn't exist, create new config with default values
+	newConfig := &DHTConfig{
+		Port:      DefaultDHTPort,
+		Address:   "",
+		SeedNodes: []string{}, // Empty slice instead of nil
+	}
+	b.protocols[ProtocolDHT] = newConfig
+	
+	return newConfig
+}
+
 // withProtocolConfig adds a protocol configuration with the specified port and default.
 // If multiple ports are provided, only the first is used.
 func (b *ServerBuilder) withProtocolConfig(protocolName string, defaultPort int, port []int, configFactory func(int) any) *ServerBuilder {
@@ -86,25 +110,11 @@ func (b *ServerBuilder) WithDHT(port ...int) *ServerBuilder {
 		p = port[0]
 	}
 	
-	// Check if DHT protocol config already exists
-	dhtConfig, exists := b.protocols[ProtocolDHT]
+	// Get or create DHT config
+	dhtConfig := b.getOrCreateDHTConfig()
 	
-	if exists {
-		// If it exists, preserve the SeedNodes and only update the Port
-		if dhtCfg, ok := dhtConfig.(*DHTConfig); ok {
-			seedNodes := dhtCfg.SeedNodes // Preserve existing seed nodes
-			b.protocols[ProtocolDHT] = &DHTConfig{
-				Port:      p,
-				SeedNodes: seedNodes,
-			}
-		}
-	} else {
-		// If it doesn't exist, create new config with empty seed nodes
-		b.protocols[ProtocolDHT] = &DHTConfig{
-			Port:      p,
-			SeedNodes: []string{}, // Empty slice instead of nil
-		}
-	}
+	// Update the port while preserving existing values
+	dhtConfig.Port = p
 	
 	return b
 }
@@ -116,22 +126,22 @@ func (b *ServerBuilder) WithDHTSeedNodes(seedNodes ...string) *ServerBuilder {
 		seedNodes = []string{}
 	}
 	
-	// Check if DHT protocol config exists
-	dhtConfig, exists := b.protocols[ProtocolDHT]
+	// Get or create DHT config
+	dhtConfig := b.getOrCreateDHTConfig()
 	
-	if !exists {
-		// Create a new DHTConfig with default port if it doesn't exist
-		dhtConfig = &DHTConfig{
-			Port:      DefaultDHTPort,
-			SeedNodes: seedNodes,
-		}
-		b.protocols[ProtocolDHT] = dhtConfig
-	} else {
-		// Update existing DHT config's seed nodes
-		if dhtCfg, ok := dhtConfig.(*DHTConfig); ok {
-			dhtCfg.SeedNodes = seedNodes
-		}
-	}
+	// Update seed nodes
+	dhtConfig.SeedNodes = seedNodes
+	
+	return b
+}
+
+// WithDHTAddress sets the DHT address
+func (b *ServerBuilder) WithDHTAddress(address string) *ServerBuilder {
+	// Get or create DHT config
+	dhtConfig := b.getOrCreateDHTConfig()
+	
+	// Update address
+	dhtConfig.Address = address
 	
 	return b
 }

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/liblbry/mocks"
 	storageMocks "go.lumeweb.com/liblbry/storage/mocks"
+	"go.lumeweb.com/liblbry/storage/memory"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
@@ -516,6 +517,47 @@ func TestServerBuilder_WithDHTSeedNodesAfterWithDHT(t *testing.T) {
 	// Verify seed nodes were set correctly
 	dhtConfig = builder.protocols[ProtocolDHT].(*DHTConfig)
 	assert.Equal(t, seedNodes, dhtConfig.SeedNodes)
+}
+
+// TestServerBuilder_WithDHTAddress verifies that WithDHTAddress correctly sets the DHT address
+func TestServerBuilder_WithDHTAddress(t *testing.T) {
+	// Test with custom DHT address
+	builder := NewServerBuilder().
+		WithStorage(memory.NewMemoryStore()).
+		WithDHT()
+	
+	// Configure DHT with custom address
+	result := builder.WithDHTAddress("192.168.1.100:4444")
+	
+	// Verify builder returns same instance
+	assertBuilderReturnsSame(t, builder, result)
+	
+	// Verify DHT config exists and has correct address
+	assert.Contains(t, builder.protocols, ProtocolDHT)
+	
+	dhtConfig := builder.protocols[ProtocolDHT].(*DHTConfig)
+	assert.Equal(t, "192.168.1.100:4444", dhtConfig.Address, "DHT address should match custom address")
+	
+	// Test default behavior (no custom address)
+	builder2 := NewServerBuilder().
+		WithStorage(memory.NewMemoryStore()).
+		WithDHT()
+	
+	// Build without setting address - should use default empty string
+	server2, err := builder2.Build()
+	assert.NoError(t, err)
+	assert.NotNil(t, server2)
+	
+	// Verify default DHT address is empty (will be set to default in startDHT)
+	dhtConfig2, exists2 := builder2.protocols[ProtocolDHT]
+	assert.True(t, exists2, "DHT protocol should be configured")
+	
+	if dhtConfig2 != nil {
+		dhtCfg2, ok := dhtConfig2.(*DHTConfig)
+		assert.True(t, ok, "DHT config should be of correct type")
+		// Default address should be empty string
+		assert.Equal(t, "", dhtCfg2.Address, "DHT address should be empty by default")
+	}
 }
 
 // TestServerBuilder_WithDHTSeedNodesMultipleCalls verifies that calling WithDHTSeedNodes multiple times overwrites previous values

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -12,7 +13,7 @@ import (
 	liblbryerrors "go.lumeweb.com/liblbry/errors"
 	"go.lumeweb.com/liblbry/protocol"
 	"go.lumeweb.com/liblbry/storage"
-	"go.lumeweb.com/liblbry/stream"
+
 	"go.uber.org/zap"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -66,6 +67,7 @@ type ReflectorConfig struct {
 // DHTConfig contains configuration for DHT protocol
 type DHTConfig struct {
 	Port      int
+	Address   string
 	SeedNodes []string
 }
 
@@ -216,12 +218,20 @@ func (s *DefaultServer) startDHT(config *DHTConfig) error {
 
 	// Build options slice dynamically
 	var opts []protocol.DHTOption
+	
+	// Determine the address to use
+	address := config.Address
+	if address == "" {
+		// Use default host with specified port
+		address = fmt.Sprintf("%s:%d", strings.Split(protocol.DefaultDHTAddress, ":")[0], config.Port)
+	}
+	
 	opts = append(opts,
-		protocol.WithDHTAddress(fmt.Sprintf("0.0.0.0:%d", config.Port)),
+		protocol.WithDHTAddress(address),
 		protocol.WithDHTPeerProtocolPort(peerProtocolPort),
 		protocol.WithDHTLogger(s.logger.Named("dht")),
 	)
-	
+
 	// Conditionally add seed nodes if they exist
 	if len(config.SeedNodes) > 0 {
 		opts = append(opts, protocol.WithDHTSeedNodes(config.SeedNodes))
@@ -308,21 +318,11 @@ func (s *DefaultServer) announceBlobsToDHT(workerCount int, batchSize int) {
 			globalIndex := offset + i
 
 			pool.Submit(func() {
-				// Convert LBRY hash to multihash for DHT announcement
-				multihash, err := stream.ToMultihash(hash)
-				if err != nil {
-					s.logger.Warn("Failed to convert blob hash to multihash for DHT announcement",
-						zap.String("hash", hash),
-						zap.Error(err),
-						zap.Int("global_index", globalIndex))
-					return
-				}
-
-				// Announce to DHT
-				err = s.dhtAnnouncer.AnnounceBlob(multihash)
+				// Announce to DHT using the LBRY hash directly
+				// The DHT announcer expects LBRY hash format, not multihash
+				err := s.dhtAnnouncer.AnnounceBlob(hash)
 				if err != nil {
 					s.logger.Warn("Failed to announce blob to DHT",
-						zap.String("multihash", multihash),
 						zap.String("hash", hash),
 						zap.Error(err),
 						zap.Int("global_index", globalIndex))
@@ -332,7 +332,6 @@ func (s *DefaultServer) announceBlobsToDHT(workerCount int, batchSize int) {
 				// Log successful announcement every BlobAnnouncementLogInterval blobs
 				if globalIndex%BlobAnnouncementLogInterval == 0 {
 					s.logger.Debug("Announced blob to DHT",
-						zap.String("multihash", multihash),
 						zap.String("hash", hash),
 						zap.Int("global_index", globalIndex))
 				}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -756,3 +756,44 @@ func TestDefaultServer_ConcurrentBlobOperations(t *testing.T) {
 		t.Errorf("Concurrent blob operation error: %v", err)
 	}
 }
+
+// TestDefaultServer_announceBlobsToDHT_UsesLBRYHash tests that DHT blob announcements
+// use LBRY hash format directly, not multihash format. This is a regression test
+// for a bug where LBRY hashes were incorrectly converted to multihash before
+// being passed to the DHT announcer, causing "invalid hash format" errors.
+func TestDefaultServer_announceBlobsToDHT_UsesLBRYHash(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	// Create a mock DHT announcer to capture the hash format
+	mockDHTAnnouncer := protocolMocks.NewMockDHTAnnouncer(t)
+	server.dhtAnnouncer = mockDHTAnnouncer
+
+	// Test blob hashes (valid LBRY SHA-384 hashes)
+	testBlobHashes := []string{
+		"68c0ff52fca66bc20c736e49967760d6378ce73aaf4b0a870f1c2142455629ab50dc49dae0b03c56a9bff7f270a2edf3",
+		"e28ce752b41c8434050f1f5181c8781ac817c975afc918b73eb0b3d8a90d0a06161f53048153b2c2b1029a4007477c26",
+		"38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
+	}
+
+	// Set up mock expectations for storage List calls
+	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return(testBlobHashes, nil)
+	testMocks.storage.EXPECT().List(len(testBlobHashes), DefaultDHTAnnouncementBatchSize).Return([]string{}, nil)
+
+	// Set up mock expectations for DHT announcer - expect LBRY hashes, not multihashes
+	for _, hash := range testBlobHashes {
+		mockDHTAnnouncer.EXPECT().AnnounceBlob(hash).Return(nil)
+	}
+
+	// Set batch size to ensure all blobs are processed in one batch
+	server.dhtBatchSize = DefaultDHTAnnouncementBatchSize
+
+	// Call announceBlobsToDHT with default worker count and batch size
+	server.announceBlobsToDHT(DefaultDHTAnnouncerWorkers, DefaultDHTAnnouncementBatchSize)
+
+	// Verify all mock expectations were met
+	// This ensures that LBRY hashes were passed directly to AnnounceBlob,
+	// not converted to multihash format first
+}


### PR DESCRIPTION
- Fix DHT blob announcements to use LBRY hash format directly instead of converting to multihash
- Improve DHT startup logic to properly handle address configuration
- Add `WithDHTAddress` method to server builder for explicit DHT address setting
- Refactor DHT config management in server builder for better maintainability
- Update tests to verify correct hash format usage in DHT announcements
---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a builder option to set a custom DHT address.

* **Improvements**
  * Default DHT bind address changed from 0.0.0.0:4444 to 127.0.0.1:4444.
  * DHT initialization and address resolution streamlined.
  * DHT blob announcements now use the raw LBRY hash format for simpler, more direct announcements.

* **Tests**
  * Added tests covering custom DHT address behavior and raw-hash DHT announcements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->