### PR TITLE
feat(crypto): add HashReader method for streaming hash computation

### DIFF
--- a/crypto/hasher.go
+++ b/crypto/hasher.go
@@ -3,6 +3,7 @@ package crypto
 import (
 	"crypto/sha512"
 	"encoding/hex"
+	"io"
 )
 
 const (
@@ -13,6 +14,7 @@ const (
 // Hasher interface defines the methods for hashing and validation
 type Hasher interface {
 	Hash(data []byte) string
+	HashReader(reader io.Reader) (string, error)
 	IsValid(hash string) bool
 }
 
@@ -27,7 +29,28 @@ func NewHasher() Hasher {
 // Hash computes the SHA-384 hash of the given data
 func (h *SHA384Hasher) Hash(data []byte) string {
 	hash := sha512.Sum384(data)
-	return hex.EncodeToString(hash[:])
+	return h.encodeHash(hash[:])
+}
+
+// HashReader computes the SHA-384 hash of the data read from the reader
+func (h *SHA384Hasher) HashReader(reader io.Reader) (string, error) {
+	// Create a new SHA-384 hasher
+	hasher := sha512.New384()
+	
+	// Copy data from reader to hasher in chunks to avoid loading everything into memory
+	_, err := io.Copy(hasher, reader)
+	if err != nil {
+		return "", err
+	}
+	
+	// Get the final hash
+	hash := hasher.Sum(nil)
+	return h.encodeHash(hash), nil
+}
+
+// encodeHash converts a byte slice to a hexadecimal string
+func (h *SHA384Hasher) encodeHash(hash []byte) string {
+	return hex.EncodeToString(hash)
 }
 
 // IsValid checks if the given hash is a valid SHA-384 hash

--- a/crypto/hasher_test.go
+++ b/crypto/hasher_test.go
@@ -1,6 +1,9 @@
 package crypto
 
 import (
+	"bytes"
+	"io"
+	"strings"
 	"testing"
 )
 
@@ -36,6 +39,101 @@ func TestSHA384Hasher_Hash(t *testing.T) {
 				t.Errorf("Hash() = %v, expected %v", result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestSHA384Hasher_HashReader(t *testing.T) {
+	hasher := NewHasher()
+
+	tests := []struct {
+		name     string
+		reader   io.Reader
+		expected string
+		hasError bool
+	}{
+		{
+			name:     "string reader",
+			reader:   strings.NewReader("hello world"),
+			expected: "fdbd8e75a67f29f701a4e040385e2e23986303ea10239211af907fcbb83578b3e417cb71ce646efd0819dd8c088de1bd",
+		},
+		{
+			name:     "bytes buffer",
+			reader:   bytes.NewBufferString("hello world"),
+			expected: "fdbd8e75a67f29f701a4e040385e2e23986303ea10239211af907fcbb83578b3e417cb71ce646efd0819dd8c088de1bd",
+		},
+		{
+			name:     "empty reader",
+			reader:   strings.NewReader(""),
+			expected: "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
+		},
+		{
+			name:     "large data",
+			reader:   strings.NewReader(strings.Repeat("a", 10000)),
+			expected: "2bca3b131bb7e922bcd1de98c44786d32e6b6b2993e69c4987edf9dd49711eb501f0e98ad248d839f6bf9e116e25a97c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := hasher.HashReader(tt.reader)
+			if tt.hasError {
+				if err == nil {
+					t.Errorf("HashReader() expected error but got none")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("HashReader() unexpected error: %v", err)
+				}
+				if result != tt.expected {
+					t.Errorf("HashReader() = %v, expected %v", result, tt.expected)
+				}
+			}
+		})
+	}
+}
+
+func TestSHA384Hasher_HashReader_ErrorHandling(t *testing.T) {
+	hasher := NewHasher()
+
+	// Test with a reader that always returns an error
+	errorReader := &errorReader{}
+	
+	_, err := hasher.HashReader(errorReader)
+	if err == nil {
+		t.Error("HashReader() expected error but got none")
+	}
+}
+
+func TestSHA384Hasher_Comparison(t *testing.T) {
+	hasher := NewHasher()
+	
+	// Test that HashReader produces the same result as Hash for the same data
+	testData := []byte("hello world")
+	
+	// Hash the data directly
+	hashResult := hasher.Hash(testData)
+	
+	// Hash the data via reader
+	readerResult, err := hasher.HashReader(bytes.NewReader(testData))
+	if err != nil {
+		t.Fatalf("HashReader() failed: %v", err)
+	}
+	
+	// Compare results
+	if hashResult != readerResult {
+		t.Errorf("Hash() and HashReader() produced different results: %v vs %v", hashResult, readerResult)
+	}
+	
+	// Test with empty data
+	emptyData := []byte{}
+	emptyHashResult := hasher.Hash(emptyData)
+	emptyReaderResult, err := hasher.HashReader(bytes.NewReader(emptyData))
+	if err != nil {
+		t.Fatalf("HashReader() failed for empty data: %v", err)
+	}
+	
+	if emptyHashResult != emptyReaderResult {
+		t.Errorf("Hash() and HashReader() produced different results for empty data: %v vs %v", emptyHashResult, emptyReaderResult)
 	}
 }
 
@@ -87,4 +185,11 @@ func TestSHA384Hasher_IsValid(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Helper type for testing error conditions
+type errorReader struct{}
+
+func (r *errorReader) Read(p []byte) (n int, err error) {
+	return 0, io.ErrUnexpectedEOF
 }

--- a/crypto/hasher_test.go
+++ b/crypto/hasher_test.go
@@ -49,7 +49,6 @@ func TestSHA384Hasher_HashReader(t *testing.T) {
 		name     string
 		reader   io.Reader
 		expected string
-		hasError bool
 	}{
 		{
 			name:     "string reader",
@@ -76,17 +75,11 @@ func TestSHA384Hasher_HashReader(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result, err := hasher.HashReader(tt.reader)
-			if tt.hasError {
-				if err == nil {
-					t.Errorf("HashReader() expected error but got none")
-				}
-			} else {
-				if err != nil {
-					t.Errorf("HashReader() unexpected error: %v", err)
-				}
-				if result != tt.expected {
-					t.Errorf("HashReader() = %v, expected %v", result, tt.expected)
-				}
+			if err != nil {
+				t.Errorf("HashReader() unexpected error: %v", err)
+			}
+			if result != tt.expected {
+				t.Errorf("HashReader() = %v, expected %v", result, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
- Introduces `HashReader` method to `Hasher` interface for computing SHA-384 hashes from `io.Reader` inputs
- Implements streaming hash computation using `io.Copy` to avoid loading large data into memory
- Adds helper `encodeHash` method for consistent hexadecimal encoding
- Includes comprehensive test coverage for `HashReader` functionality
- Adds error handling for reader failures
- Ensures `HashReader` produces identical results to direct `Hash` method for same data

---

* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming SHA-384 hash computation added for memory-efficient processing of large inputs.

* **Refactor**
  * Hash encoding logic simplified to centralize output formatting.

* **Tests**
  * Added comprehensive tests for streaming hashing: varied inputs, large/empty cases, error handling, and parity with existing hash behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->