### PR TITLE
feat(server): add support for storing SD blobs with validation and notifications

### DIFF
--- a/crypto/mocks/Hasher.go
+++ b/crypto/mocks/Hasher.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	"io"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -82,6 +84,66 @@ func (_c *MockHasher_Hash_Call) Return(s string) *MockHasher_Hash_Call {
 }
 
 func (_c *MockHasher_Hash_Call) RunAndReturn(run func(data []byte) string) *MockHasher_Hash_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// HashReader provides a mock function for the type MockHasher
+func (_mock *MockHasher) HashReader(reader io.Reader) (string, error) {
+	ret := _mock.Called(reader)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HashReader")
+	}
+
+	var r0 string
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(io.Reader) (string, error)); ok {
+		return returnFunc(reader)
+	}
+	if returnFunc, ok := ret.Get(0).(func(io.Reader) string); ok {
+		r0 = returnFunc(reader)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+	if returnFunc, ok := ret.Get(1).(func(io.Reader) error); ok {
+		r1 = returnFunc(reader)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockHasher_HashReader_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HashReader'
+type MockHasher_HashReader_Call struct {
+	*mock.Call
+}
+
+// HashReader is a helper method to define mock.On call
+//   - reader io.Reader
+func (_e *MockHasher_Expecter) HashReader(reader interface{}) *MockHasher_HashReader_Call {
+	return &MockHasher_HashReader_Call{Call: _e.mock.On("HashReader", reader)}
+}
+
+func (_c *MockHasher_HashReader_Call) Run(run func(reader io.Reader)) *MockHasher_HashReader_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 io.Reader
+		if args[0] != nil {
+			arg0 = args[0].(io.Reader)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockHasher_HashReader_Call) Return(s string, err error) *MockHasher_HashReader_Call {
+	_c.Call.Return(s, err)
+	return _c
+}
+
+func (_c *MockHasher_HashReader_Call) RunAndReturn(run func(reader io.Reader) (string, error)) *MockHasher_HashReader_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/mocks/BlobManager.go
+++ b/server/mocks/BlobManager.go
@@ -92,6 +92,63 @@ func (_c *MockBlobManager_AddBlob_Call) RunAndReturn(run func(hash string, data 
 	return _c
 }
 
+// AddSDBlob provides a mock function for the type MockBlobManager
+func (_mock *MockBlobManager) AddSDBlob(hash string, data []byte) error {
+	ret := _mock.Called(hash, data)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AddSDBlob")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
+		r0 = returnFunc(hash, data)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockBlobManager_AddSDBlob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AddSDBlob'
+type MockBlobManager_AddSDBlob_Call struct {
+	*mock.Call
+}
+
+// AddSDBlob is a helper method to define mock.On call
+//   - hash string
+//   - data []byte
+func (_e *MockBlobManager_Expecter) AddSDBlob(hash interface{}, data interface{}) *MockBlobManager_AddSDBlob_Call {
+	return &MockBlobManager_AddSDBlob_Call{Call: _e.mock.On("AddSDBlob", hash, data)}
+}
+
+func (_c *MockBlobManager_AddSDBlob_Call) Run(run func(hash string, data []byte)) *MockBlobManager_AddSDBlob_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		var arg1 []byte
+		if args[1] != nil {
+			arg1 = args[1].([]byte)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBlobManager_AddSDBlob_Call) Return(err error) *MockBlobManager_AddSDBlob_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockBlobManager_AddSDBlob_Call) RunAndReturn(run func(hash string, data []byte) error) *MockBlobManager_AddSDBlob_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveBlob provides a mock function for the type MockBlobManager
 func (_mock *MockBlobManager) RemoveBlob(hash string) error {
 	ret := _mock.Called(hash)

--- a/server/server.go
+++ b/server/server.go
@@ -468,10 +468,18 @@ func (s *DefaultServer) announceBlobsToDHT(workerCount int, batchSize int) {
 	s.logger.Debug("Completed DHT blob announcement process", zap.Int("total_announced", totalAnnounced))
 }
 
-// validateBlobInput performs common validation for blob hash and data
-func (s *DefaultServer) validateBlobInput(hash string, data []byte) error {
+// validateHash performs common validation for blob hash
+func validateHash(hash string) error {
 	if hash == "" {
 		return fmt.Errorf("hash cannot be empty")
+	}
+	return nil
+}
+
+// validateBlobInput performs common validation for blob hash and data
+func validateBlobInput(hash string, data []byte) error {
+	if err := validateHash(hash); err != nil {
+		return err
 	}
 	if len(data) == 0 {
 		return fmt.Errorf("blob data cannot be empty")
@@ -482,7 +490,7 @@ func (s *DefaultServer) validateBlobInput(hash string, data []byte) error {
 // AddBlob stores a blob and notifies about the addition
 func (s *DefaultServer) AddBlob(hash string, data []byte) error {
 	// Validate input
-	if err := s.validateBlobInput(hash, data); err != nil {
+	if err := validateBlobInput(hash, data); err != nil {
 		return err
 	}
 
@@ -506,7 +514,7 @@ func (s *DefaultServer) AddBlob(hash string, data []byte) error {
 // AddSDBlob stores an SD blob and notifies about the addition
 func (s *DefaultServer) AddSDBlob(hash string, data []byte) error {
 	// Validate input
-	if err := s.validateBlobInput(hash, data); err != nil {
+	if err := validateBlobInput(hash, data); err != nil {
 		return err
 	}
 
@@ -530,8 +538,8 @@ func (s *DefaultServer) AddSDBlob(hash string, data []byte) error {
 // RemoveBlob deletes a blob and notifies about the removal
 func (s *DefaultServer) RemoveBlob(hash string) error {
 	// Validate hash
-	if hash == "" {
-		return fmt.Errorf("hash cannot be empty")
+	if err := validateHash(hash); err != nil {
+		return err
 	}
 
 	// Delete the blob from storage

--- a/server/server.go
+++ b/server/server.go
@@ -44,6 +44,8 @@ const (
 type BlobManager interface {
 	// AddBlob stores a blob and notifies about the addition
 	AddBlob(hash string, data []byte) error
+	// AddSDBlob stores an SD blob and notifies about the addition
+	AddSDBlob(hash string, data []byte) error
 	// RemoveBlob deletes a blob and notifies about the removal
 	RemoveBlob(hash string) error
 }
@@ -61,7 +63,7 @@ type Server interface {
 type PeerConfig struct {
 	// Port specifies the main peer protocol port to listen on.
 	Port int
-	
+
 	// FixedPort specifies an optional fixed port for peer content.
 	// When set to 0, the fixed port feature is disabled.
 	// When set to a non-zero value, a separate peer server will be started on that port.
@@ -466,14 +468,22 @@ func (s *DefaultServer) announceBlobsToDHT(workerCount int, batchSize int) {
 	s.logger.Debug("Completed DHT blob announcement process", zap.Int("total_announced", totalAnnounced))
 }
 
-// AddBlob stores a blob and notifies about the addition
-func (s *DefaultServer) AddBlob(hash string, data []byte) error {
-	// Validate hash
+// validateBlobInput performs common validation for blob hash and data
+func (s *DefaultServer) validateBlobInput(hash string, data []byte) error {
 	if hash == "" {
 		return fmt.Errorf("hash cannot be empty")
 	}
 	if len(data) == 0 {
 		return fmt.Errorf("blob data cannot be empty")
+	}
+	return nil
+}
+
+// AddBlob stores a blob and notifies about the addition
+func (s *DefaultServer) AddBlob(hash string, data []byte) error {
+	// Validate input
+	if err := s.validateBlobInput(hash, data); err != nil {
+		return err
 	}
 
 	// Store the blob
@@ -486,6 +496,30 @@ func (s *DefaultServer) AddBlob(hash string, data []byte) error {
 	}
 
 	s.logger.Debug("Successfully stored blob", zap.String("hash", hash))
+
+	// Notify about blob addition
+	protocol.NotifyBlob(s.notifier, s.logger, protocol.NOTIFY_BLOB_ADDED, hash)
+
+	return nil
+}
+
+// AddSDBlob stores an SD blob and notifies about the addition
+func (s *DefaultServer) AddSDBlob(hash string, data []byte) error {
+	// Validate input
+	if err := s.validateBlobInput(hash, data); err != nil {
+		return err
+	}
+
+	// Store the SD blob
+	err := s.storage.PutSD(hash, data)
+	if err != nil {
+		s.logger.Error("Failed to store SD blob",
+			zap.String("hash", hash),
+			zap.Error(err))
+		return fmt.Errorf("failed to store SD blob %s: %w", hash, err)
+	}
+
+	s.logger.Debug("Successfully stored SD blob", zap.String("hash", hash))
 
 	// Notify about blob addition
 	protocol.NotifyBlob(s.notifier, s.logger, protocol.NOTIFY_BLOB_ADDED, hash)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -695,6 +695,7 @@ func TestDefaultServer_AddSDBlob(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
+		tc := tc // Capture loop variable to avoid race condition
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -621,6 +621,140 @@ func TestDefaultServer_AddBlob_WithNotifier(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestDefaultServer_AddSDBlob tests SD blob addition with various scenarios
+// Validates that SD blobs can be successfully stored and handles error cases properly
+func TestDefaultServer_AddSDBlob(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		hash           string
+		data           []byte
+		setupMocks     func(*testMocks, *DefaultServer)
+		expectErr      bool
+		expectedErrMsg string
+		description    string
+	}{
+		{
+			name: "success",
+			hash: TestBlobHash,
+			data: []byte(TestBlobData),
+			setupMocks: func(m *testMocks, s *DefaultServer) {
+				m.storage.EXPECT().PutSD(TestBlobHash, []byte(TestBlobData)).Return(nil)
+			},
+			expectErr:   false,
+			description: "Successfully stores SD blob",
+		},
+		{
+			name: "empty hash",
+			hash: "",
+			data: []byte(TestBlobData),
+			setupMocks: func(m *testMocks, s *DefaultServer) {
+				// No storage mock needed since validation fails first
+			},
+			expectErr:      true,
+			expectedErrMsg: "hash cannot be empty",
+			description:    "Rejects empty hash",
+		},
+		{
+			name: "empty data",
+			hash: TestBlobHash,
+			data: []byte{},
+			setupMocks: func(m *testMocks, s *DefaultServer) {
+				// No storage mock needed since validation fails first
+			},
+			expectErr:      true,
+			expectedErrMsg: "blob data cannot be empty",
+			description:    "Rejects empty data",
+		},
+		{
+			name: "storage failure",
+			hash: TestBlobHash,
+			data: []byte(TestBlobData),
+			setupMocks: func(m *testMocks, s *DefaultServer) {
+				storageError := errors.New("storage error")
+				m.storage.EXPECT().PutSD(TestBlobHash, []byte(TestBlobData)).Return(storageError)
+			},
+			expectErr:      true,
+			expectedErrMsg: "failed to store SD blob",
+			description:    "Propagates storage errors",
+		},
+		{
+			name: "with notifier",
+			hash: TestBlobHash,
+			data: []byte(TestBlobData),
+			setupMocks: func(m *testMocks, s *DefaultServer) {
+				mockNotifier := protocolMocks.NewMockNotifier(t)
+				s.notifier = mockNotifier
+				m.storage.EXPECT().PutSD(TestBlobHash, []byte(TestBlobData)).Return(nil)
+				mockNotifier.EXPECT().Notify(protocol.NOTIFY_BLOB_ADDED, TestNotificationHash).Return(nil)
+			},
+			expectErr:   false,
+			description: "Sends notification when notifier is configured",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			testMocks := setupMocks(t)
+			server := setupServer(t, testMocks, map[string]any{})
+
+			// Setup test-specific mocks
+			tc.setupMocks(testMocks, server)
+
+			err := server.AddSDBlob(tc.hash, tc.data)
+
+			if tc.expectErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// TestDefaultServer_ConcurrentAddSDBlob tests concurrent AddSDBlob operations
+// Validates thread safety and concurrent operation handling for SD blob addition
+func TestDefaultServer_ConcurrentAddSDBlob(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	blobHash := TestBlobHash
+	blobData := []byte(TestBlobData)
+	numGoroutines := 10
+	errors := make(chan error, numGoroutines)
+
+	var wg sync.WaitGroup
+
+	// Test concurrent AddSDBlob operations
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			// Setup mock expectations for each goroutine
+			testMocks.storage.EXPECT().PutSD(blobHash, blobData).Return(nil)
+
+			err := server.AddSDBlob(blobHash, blobData)
+			if err != nil {
+				errors <- err
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errors)
+
+	// Check for any errors
+	for err := range errors {
+		t.Errorf("Concurrent AddSDBlob error: %v", err)
+	}
+}
+
 // TestDefaultServer_RemoveBlob_Success tests successful blob removal
 // Validates that blobs can be successfully removed from the blob store
 func TestDefaultServer_RemoveBlob_Success(t *testing.T) {


### PR DESCRIPTION
- Introduces `AddSDBlob` method to `BlobManager` interface and `DefaultServer` implementation
- Adds input validation for blob hash and data in `validateBlobInput` helper
- Implements `AddSDBlob` with storage of SD blobs and notification of blob additions
- Updates mock generation for `Hasher` and `BlobManager` interfaces
- Includes comprehensive tests for `AddSDBlob` covering success, error conditions, and concurrency

---

* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for SD blob storage operations, including input validation and notifier integration.

* **Behavioral Changes**
  * Blob add/remove flows now enforce hash/blob validation and surface clearer errors.

* **Tests**
  * Added unit tests covering SD blob success/failure scenarios and concurrent AddSDBlob execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->