### PR TITLE
fix(server): resolve race conditions with mutex locking

### DIFF
--- a/protocol/reflector_client_test.go
+++ b/protocol/reflector_client_test.go
@@ -71,9 +71,12 @@ func setupReflectorIntegrationTestServer(t *testing.T, server ReflectorServer) s
 // testReflectorSetup creates common test components
 func testReflectorSetup(t *testing.T) (*memory.MemoryStore, *zap.Logger, ReflectorServer) {
 	store := memory.NewMemoryStore()
-	logger := zaptest.NewLogger(t)
-	server := NewReflectorServer(store, WithReflectorLogger(logger))
-	return store, logger, server
+	// Use production logger for server to ensure thread-safety
+	serverLogger, err := zap.NewProduction()
+	require.NoError(t, err)
+	clientLogger := zaptest.NewLogger(t)
+	server := NewReflectorServer(store, WithReflectorLogger(serverLogger))
+	return store, clientLogger, server
 }
 
 // testReflectorClientSetup creates a test client and connects it to the server
@@ -94,15 +97,17 @@ func testReflectorClientSetup(t *testing.T, addr string, logger *zap.Logger, tim
 
 // setupReflectorIntegrationTest creates a complete integration test setup
 func setupReflectorIntegrationTest(t *testing.T, opts ...ReflectorServerOption) (*memory.MemoryStore, *zap.Logger, ReflectorServer, string) {
-	store, logger, server := testReflectorSetup(t)
+	store, clientLogger, server := testReflectorSetup(t)
 
 	// Apply additional server options
-	serverOpts := []ReflectorServerOption{WithReflectorLogger(logger)}
+	// Use zap.NewNop() for a no-op logger that's thread-safe for tests
+	// This avoids potential race conditions while maintaining thread-safety
+	serverOpts := []ReflectorServerOption{WithReflectorLogger(zap.NewNop())}
 	serverOpts = append(serverOpts, opts...)
 	server = NewReflectorServer(store, serverOpts...)
 
 	addr := setupReflectorIntegrationTestServer(t, server)
-	return store, logger, server, addr
+	return store, clientLogger, server, addr
 }
 
 // setupReflectorTestClient creates a test client with automatic cleanup

--- a/server/server.go
+++ b/server/server.go
@@ -105,13 +105,16 @@ type DefaultServer struct {
 	wg        sync.WaitGroup
 	ctx       context.Context
 	cancel    context.CancelFunc
+	mu        sync.Mutex // Protects shared state
 }
 
 // Start starts the server and all configured config
 func (s *DefaultServer) Start(ctx context.Context) error {
+	s.mu.Lock()
 	s.ctx, s.cancel = context.WithCancel(ctx)
 	s.listeners = make(map[string]net.Listener)
 	s.servers = make(map[string]any)
+	s.mu.Unlock()
 
 	// Initialize notifier system
 	s.createNotifier()
@@ -161,10 +164,11 @@ func (s *DefaultServer) Start(ctx context.Context) error {
 
 // Stop stops the server and all configured config gracefully
 func (s *DefaultServer) Stop(ctx context.Context) error {
+	s.mu.Lock()
 	if s.cancel != nil {
 		s.cancel()
 	}
-
+	
 	// Close all listeners first to stop accepting new connections
 	for name, listener := range s.listeners {
 		if err := listener.Close(); err != nil {
@@ -179,6 +183,7 @@ func (s *DefaultServer) Stop(ctx context.Context) error {
 			s.logger.Info("DHT node shutdown completed")
 		}
 	}
+	s.mu.Unlock()
 
 	// Wait for all goroutines to finish with timeout
 	done := make(chan struct{})
@@ -321,6 +326,8 @@ func (s *DefaultServer) createDHTNode(config *DHTConfig, announcePeerPort int) (
 
 // getDhtNode returns the DHT node from the servers map with proper type assertion
 func (s *DefaultServer) getDhtNode() protocol.DHTNode {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	if dhtNode, ok := s.servers[ProtocolDHT].(protocol.DHTNode); ok {
 		return dhtNode
 	}
@@ -350,7 +357,9 @@ func (s *DefaultServer) setupDHTNode(config *DHTConfig, announcePeerPort int, fi
 
 // storeServer stores a server in the servers map
 func (s *DefaultServer) storeServer(protocolName string, server any) {
+	s.mu.Lock()
 	s.servers[protocolName] = server
+	s.mu.Unlock()
 }
 
 // setupExistingDHTNode handles setup of an existing DHT node
@@ -376,12 +385,16 @@ func (s *DefaultServer) setupExistingDHTNode(dhtNode protocol.DHTNode) error {
 // setupDHTAnnouncerAndNotifier sets up the DHT announcer and notifier
 func (s *DefaultServer) setupDHTAnnouncerAndNotifier(dhtNode protocol.DHTNode) {
 	// Set up DHT announcer and notifier
+	s.mu.Lock()
 	s.dhtAnnouncer = protocol.NewDefaultDHTAnnouncer(dhtNode)
+	s.mu.Unlock()
 
 	// Register DHT notifier with the existing group notifier
 	if s.notifier != nil {
 		if group, ok := s.notifier.(*protocol.GroupNotifier); ok {
+			s.mu.Lock()
 			group.AddNotifier(protocol.NewDHTNotifier(s.dhtAnnouncer, s.logger.Named("dht-notifier")))
+			s.mu.Unlock()
 		}
 	}
 }
@@ -397,7 +410,9 @@ func (s *DefaultServer) createNotifier() {
 	// Add the logging notifier to the group
 	groupNotifier.AddNotifier(loggingNotifier)
 
+	s.mu.Lock()
 	s.notifier = groupNotifier
+	s.mu.Unlock()
 }
 
 // announceBlobsToDHT enumerates all blobs from storage and announces them to the DHT

--- a/server/server.go
+++ b/server/server.go
@@ -384,19 +384,17 @@ func (s *DefaultServer) setupExistingDHTNode(dhtNode protocol.DHTNode) error {
 
 // setupDHTAnnouncerAndNotifier sets up the DHT announcer and notifier
 func (s *DefaultServer) setupDHTAnnouncerAndNotifier(dhtNode protocol.DHTNode) {
-	// Set up DHT announcer and notifier
+	// Set up DHT announcer
 	s.mu.Lock()
 	s.dhtAnnouncer = protocol.NewDefaultDHTAnnouncer(dhtNode)
-	s.mu.Unlock()
 
 	// Register DHT notifier with the existing group notifier
 	if s.notifier != nil {
 		if group, ok := s.notifier.(*protocol.GroupNotifier); ok {
-			s.mu.Lock()
 			group.AddNotifier(protocol.NewDHTNotifier(s.dhtAnnouncer, s.logger.Named("dht-notifier")))
-			s.mu.Unlock()
 		}
 	}
+	s.mu.Unlock()
 }
 
 // createNotifier initializes the notifier system


### PR DESCRIPTION
*   Introduces `sync.Mutex` (`mu`) to `DefaultServer` to protect access to shared mutable state (`servers`, `listeners`, `ctx`, `cancel`).
*   Acquires the mutex before modifying shared state in `Start`, `Stop`, `getDhtNode`, `storeServer`, `setupDHTAnnouncerAndNotifier`, and `createNotifier`.
*   Ensures thread-safety for concurrent access to server runtime state.
*   Updates logger usage in `reflector_client_test.go` to improve test reliability and thread-safety.
---

* Tests can be run with `go test -race ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved thread-safety in core server operations to reduce race conditions and improve reliability of startup/shutdown and network handling.
* **Tests**
  * Updated test setup and logging so test servers use thread-safe logging and test logs are clearly separated from production logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->