### PR TITLE
refactor(stream): refactor key and IV generation for encryption

### DIFF
--- a/stream/encoder.go
+++ b/stream/encoder.go
@@ -109,13 +109,9 @@ type Encoder struct {
 	srcHash hash.Hash
 }
 
-// NewEncoder creates a new stream encoder
-func NewEncoder(src io.Reader) *Encoder {
-	key, err := generateKey()
-	if err != nil {
-		panic(err) // This maintains existing behavior for the constructor
-	}
-
+// newEncoderInternal creates a new stream encoder with the provided key
+// This is an internal helper that avoids key generation when a key is already available
+func newEncoderInternal(src io.Reader, key []byte) *Encoder {
 	return &Encoder{
 		src: src,
 
@@ -128,13 +124,22 @@ func NewEncoder(src io.Reader) *Encoder {
 	}
 }
 
+// NewEncoder creates a new stream encoder
+func NewEncoder(src io.Reader) *Encoder {
+	key, err := generateKey()
+	if err != nil {
+		panic(err) // This maintains existing behavior for the constructor
+	}
+
+	return newEncoderInternal(src, key)
+}
+
 // NewEncoderWithIVs creates a new encoder that uses preset cryptographic material
 func NewEncoderWithIVs(src io.Reader, key []byte, ivs [][]byte) *Encoder {
 	if len(key) != lbrycrypto.AES256KeySize {
 		panic(fmt.Sprintf("invalid key size: expected %d bytes, got %d bytes", lbrycrypto.AES256KeySize, len(key)))
 	}
-	e := NewEncoder(src)
-	e.sd.Key = key
+	e := newEncoderInternal(src, key)
 	e.ivs = ivs
 	return e
 }

--- a/stream/encoder.go
+++ b/stream/encoder.go
@@ -130,6 +130,9 @@ func NewEncoder(src io.Reader) *Encoder {
 
 // NewEncoderWithIVs creates a new encoder that uses preset cryptographic material
 func NewEncoderWithIVs(src io.Reader, key []byte, ivs [][]byte) *Encoder {
+	if len(key) != lbrycrypto.AES256KeySize {
+		panic(fmt.Sprintf("invalid key size: expected %d bytes, got %d bytes", lbrycrypto.AES256KeySize, len(key)))
+	}
 	e := NewEncoder(src)
 	e.sd.Key = key
 	e.ivs = ivs
@@ -251,6 +254,8 @@ func (e *Encoder) Encode(config *StreamConfig) (*StreamResult, error) {
 				return nil, liblbryerrors.Err("failed to generate new key for existing SD blob: %w", err)
 			}
 			sdBlob.Key = newKey
+		} else if len(sdBlob.Key) != lbrycrypto.AES256KeySize {
+			return nil, liblbryerrors.Err("existing SD blob has invalid key size: expected %d bytes, got %d bytes", lbrycrypto.AES256KeySize, len(sdBlob.Key))
 		}
 
 		e.sd = sdBlob
@@ -419,6 +424,9 @@ func (e *Encoder) nextIV() ([]byte, error) {
 
 // generateRandomBytes generates cryptographically secure random bytes of the specified size
 func generateRandomBytes(size int) ([]byte, error) {
+	if size <= 0 {
+		return nil, liblbryerrors.Err("invalid size for random bytes: %d", size)
+	}
 	data := make([]byte, size)
 	_, err := io.ReadFull(rand.Reader, data)
 	if err != nil {

--- a/stream/encoder.go
+++ b/stream/encoder.go
@@ -15,6 +15,7 @@ import (
 	"crypto/rand"
 	"crypto/sha512"
 	"encoding/hex"
+	"fmt"
 	"hash"
 	"io"
 	"math"

--- a/stream/encoder.go
+++ b/stream/encoder.go
@@ -11,6 +11,7 @@ package stream
 
 import (
 	"bytes"
+	"crypto/aes"
 	"crypto/rand"
 	"crypto/sha512"
 	"encoding/hex"
@@ -19,6 +20,7 @@ import (
 	"math"
 
 	"go.lumeweb.com/liblbry/blob"
+	lbrycrypto "go.lumeweb.com/liblbry/crypto"
 	liblbryerrors "go.lumeweb.com/liblbry/errors"
 )
 
@@ -109,19 +111,18 @@ type Encoder struct {
 
 // NewEncoder creates a new stream encoder
 func NewEncoder(src io.Reader) *Encoder {
+	key, err := generateKey()
+	if err != nil {
+		panic(err) // This maintains existing behavior for the constructor
+	}
+
 	return &Encoder{
 		src: src,
 
 		buf: make([]byte, maxBlobDataSize),
 		sd: &SDBlob{
 			StreamType: StreamTypeLBRYFile,
-			Key: func() []byte {
-				iv, err := randIV()
-				if err != nil {
-					panic(err) // This maintains existing behavior for the constructor
-				}
-				return iv
-			}(),
+			Key:        key,
 		},
 		srcHash: sha512.New384(),
 	}
@@ -242,6 +243,16 @@ func (e *Encoder) Encode(config *StreamConfig) (*StreamResult, error) {
 		if err != nil {
 			return nil, liblbryerrors.Err("failed to parse existing SD blob: %w", err)
 		}
+
+		// Generate a new key if the existing SD blob has an empty key
+		if len(sdBlob.Key) == 0 {
+			newKey, err := generateKey()
+			if err != nil {
+				return nil, liblbryerrors.Err("failed to generate new key for existing SD blob: %w", err)
+			}
+			sdBlob.Key = newKey
+		}
+
 		e.sd = sdBlob
 		// Seed IVs from existing SD blob
 		e.ivs = make([][]byte, len(sdBlob.BlobInfos))
@@ -406,12 +417,22 @@ func (e *Encoder) nextIV() ([]byte, error) {
 	return iv, nil
 }
 
+// generateRandomBytes generates cryptographically secure random bytes of the specified size
+func generateRandomBytes(size int) ([]byte, error) {
+	data := make([]byte, size)
+	_, err := io.ReadFull(rand.Reader, data)
+	if err != nil {
+		return nil, liblbryerrors.Err("failed to generate random bytes: %w", err)
+	}
+	return data, nil
+}
+
+// generateKey generates a cryptographically secure random key for encryption
+func generateKey() ([]byte, error) {
+	return generateRandomBytes(lbrycrypto.AES256KeySize) // 256-bit key for AES-256
+}
+
 // randIV generates a random initialization vector
 func randIV() ([]byte, error) {
-	iv := make([]byte, 16) // AES block size
-	_, err := io.ReadFull(rand.Reader, iv)
-	if err != nil {
-		return nil, liblbryerrors.Err("failed to generate random IV: %w", err)
-	}
-	return iv, nil
+	return generateRandomBytes(aes.BlockSize) // AES block size
 }


### PR DESCRIPTION
- Introduce `generateRandomBytes` for consistent cryptographically secure random byte generation
- Replace inline key and IV generation with `generateKey` and `randIV` functions
- Use `AES256KeySize` for key generation
- Maintain existing behavior with panic on key generation failure in constructor
- Add key regeneration for existing SD blobs with empty keys
---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and hardened cryptographic handling: keys are now consistently generated and validated as AES-256, and initialization vectors are reliably derived or regenerated from stored state.
  * Maintains existing public interfaces and constructor behavior while improving error reporting for invalid keys and generation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->