### PR TITLE
feat(server): add blob acquisition methods

### DIFF
--- a/server/mocks/BlobManager.go
+++ b/server/mocks/BlobManager.go
@@ -5,7 +5,11 @@
 package mocks
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
+	"go.lumeweb.com/liblbry/server"
+	"go.lumeweb.com/liblbry/stream"
 )
 
 // NewMockBlobManager creates a new instance of MockBlobManager. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
@@ -33,6 +37,161 @@ type MockBlobManager_Expecter struct {
 
 func (_m *MockBlobManager) EXPECT() *MockBlobManager_Expecter {
 	return &MockBlobManager_Expecter{mock: &_m.Mock}
+}
+
+// AcquireBlob provides a mock function for the type MockBlobManager
+func (_mock *MockBlobManager) AcquireBlob(ctx context.Context, hash string) ([]byte, error) {
+	ret := _mock.Called(ctx, hash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AcquireBlob")
+	}
+
+	var r0 []byte
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]byte, error)); ok {
+		return returnFunc(ctx, hash)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
+		r0 = returnFunc(ctx, hash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, hash)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBlobManager_AcquireBlob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AcquireBlob'
+type MockBlobManager_AcquireBlob_Call struct {
+	*mock.Call
+}
+
+// AcquireBlob is a helper method to define mock.On call
+//   - ctx context.Context
+//   - hash string
+func (_e *MockBlobManager_Expecter) AcquireBlob(ctx interface{}, hash interface{}) *MockBlobManager_AcquireBlob_Call {
+	return &MockBlobManager_AcquireBlob_Call{Call: _e.mock.On("AcquireBlob", ctx, hash)}
+}
+
+func (_c *MockBlobManager_AcquireBlob_Call) Run(run func(ctx context.Context, hash string)) *MockBlobManager_AcquireBlob_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBlobManager_AcquireBlob_Call) Return(bytes []byte, err error) *MockBlobManager_AcquireBlob_Call {
+	_c.Call.Return(bytes, err)
+	return _c
+}
+
+func (_c *MockBlobManager_AcquireBlob_Call) RunAndReturn(run func(ctx context.Context, hash string) ([]byte, error)) *MockBlobManager_AcquireBlob_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// AcquireSDBlob provides a mock function for the type MockBlobManager
+func (_mock *MockBlobManager) AcquireSDBlob(ctx context.Context, hash string, opts ...server.AcquireSDOption) (*stream.StreamResult, error) {
+	// server.AcquireSDOption
+	_va := make([]interface{}, len(opts))
+	for _i := range opts {
+		_va[_i] = opts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, hash)
+	_ca = append(_ca, _va...)
+	ret := _mock.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AcquireSDBlob")
+	}
+
+	var r0 *stream.StreamResult
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...server.AcquireSDOption) (*stream.StreamResult, error)); ok {
+		return returnFunc(ctx, hash, opts...)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, ...server.AcquireSDOption) *stream.StreamResult); ok {
+		r0 = returnFunc(ctx, hash, opts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*stream.StreamResult)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, ...server.AcquireSDOption) error); ok {
+		r1 = returnFunc(ctx, hash, opts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBlobManager_AcquireSDBlob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AcquireSDBlob'
+type MockBlobManager_AcquireSDBlob_Call struct {
+	*mock.Call
+}
+
+// AcquireSDBlob is a helper method to define mock.On call
+//   - ctx context.Context
+//   - hash string
+//   - opts ...server.AcquireSDOption
+func (_e *MockBlobManager_Expecter) AcquireSDBlob(ctx interface{}, hash interface{}, opts ...interface{}) *MockBlobManager_AcquireSDBlob_Call {
+	return &MockBlobManager_AcquireSDBlob_Call{Call: _e.mock.On("AcquireSDBlob",
+		append([]interface{}{ctx, hash}, opts...)...)}
+}
+
+func (_c *MockBlobManager_AcquireSDBlob_Call) Run(run func(ctx context.Context, hash string, opts ...server.AcquireSDOption)) *MockBlobManager_AcquireSDBlob_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 []server.AcquireSDOption
+		variadicArgs := make([]server.AcquireSDOption, len(args)-2)
+		for i, a := range args[2:] {
+			if a != nil {
+				variadicArgs[i] = a.(server.AcquireSDOption)
+			}
+		}
+		arg2 = variadicArgs
+		run(
+			arg0,
+			arg1,
+			arg2...,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBlobManager_AcquireSDBlob_Call) Return(streamResult *stream.StreamResult, err error) *MockBlobManager_AcquireSDBlob_Call {
+	_c.Call.Return(streamResult, err)
+	return _c
+}
+
+func (_c *MockBlobManager_AcquireSDBlob_Call) RunAndReturn(run func(ctx context.Context, hash string, opts ...server.AcquireSDOption) (*stream.StreamResult, error)) *MockBlobManager_AcquireSDBlob_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // AddBlob provides a mock function for the type MockBlobManager

--- a/server/server.go
+++ b/server/server.go
@@ -651,9 +651,9 @@ func (s *DefaultServer) AcquireSDBlob(ctx context.Context, hash string, opts ...
 	}
 
 	// Recursive: fetch all content blobs
-	contentBlobs := make([][]byte, 0, len(sdBlob.BlobInfos)-1)
-	contentHashes := make([]string, 0, len(sdBlob.BlobInfos)-1)
-	chunkSizes := make([]int, 0, len(sdBlob.BlobInfos)-1)
+	contentBlobs := make([][]byte, 0, len(sdBlob.BlobInfos))
+	contentHashes := make([]string, 0, len(sdBlob.BlobInfos))
+	chunkSizes := make([]int, 0, len(sdBlob.BlobInfos))
 
 	// Get all content blobs (excluding the terminating null blob)
 	for i, blobInfo := range sdBlob.BlobInfos {

--- a/server/server.go
+++ b/server/server.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"net"
 	"strings"
@@ -13,6 +15,7 @@ import (
 	liblbryerrors "go.lumeweb.com/liblbry/errors"
 	"go.lumeweb.com/liblbry/protocol"
 	"go.lumeweb.com/liblbry/storage"
+	"go.lumeweb.com/liblbry/stream"
 
 	"go.uber.org/zap"
 	"golang.org/x/text/cases"
@@ -48,6 +51,26 @@ type BlobManager interface {
 	AddSDBlob(hash string, data []byte) error
 	// RemoveBlob deletes a blob and notifies about the removal
 	RemoveBlob(hash string) error
+
+	// AcquireBlob retrieves a blob using available transfer methods
+	AcquireBlob(ctx context.Context, hash string) ([]byte, error)
+	// AcquireSDBlob retrieves an SD blob and optionally its content blobs
+	AcquireSDBlob(ctx context.Context, hash string, opts ...AcquireSDOption) (*stream.StreamResult, error)
+}
+
+// AcquireSDConfig holds configuration for SD blob acquisition
+type AcquireSDConfig struct {
+	Recursive bool // Whether to fetch all content blobs
+}
+
+// AcquireSDOption defines a function type for configuring SD blob acquisition
+type AcquireSDOption func(*AcquireSDConfig)
+
+// WithAcquireRecursive sets whether to recursively fetch all content blobs
+func WithAcquireRecursive(recursive bool) AcquireSDOption {
+	return func(config *AcquireSDConfig) {
+		config.Recursive = recursive
+	}
 }
 
 // Server defines the interface for a liblbry server
@@ -570,6 +593,117 @@ func (s *DefaultServer) RemoveBlob(hash string) error {
 	protocol.NotifyBlob(s.notifier, s.logger, protocol.NOTIFY_BLOB_REMOVED, hash)
 
 	return nil
+}
+
+// AcquireBlob retrieves a blob using available transfer methods
+func (s *DefaultServer) AcquireBlob(ctx context.Context, hash string) ([]byte, error) {
+	// Validate hash
+	if err := validateHash(hash); err != nil {
+		return nil, err
+	}
+
+	// Use the acquirer to get the blob
+	if s.acquirer == nil {
+		return nil, fmt.Errorf("no acquirer configured")
+	}
+
+	return s.acquirer.Acquire(ctx, hash)
+}
+
+// AcquireSDBlob retrieves an SD blob and optionally its content blobs
+func (s *DefaultServer) AcquireSDBlob(ctx context.Context, hash string, opts ...AcquireSDOption) (*stream.StreamResult, error) {
+	// Validate hash
+	if err := validateHash(hash); err != nil {
+		return nil, err
+	}
+
+	// Apply default configuration
+	config := &AcquireSDConfig{
+		Recursive: true, // Default to recursive fetching
+	}
+	for _, opt := range opts {
+		opt(config)
+	}
+
+	// Acquire the SD blob first
+	sdBlobData, err := s.AcquireBlob(ctx, hash)
+	if err != nil {
+		return nil, fmt.Errorf("failed to acquire SD blob %s: %w", hash, err)
+	}
+
+	// Parse the SD blob
+	var sdBlob stream.SDBlob
+	if err := json.Unmarshal(sdBlobData, &sdBlob); err != nil {
+		return nil, fmt.Errorf("failed to parse SD blob %s: %w", hash, err)
+	}
+
+	// Create the basic stream result
+	result := &stream.StreamResult{
+		SDBlob:     &sdBlob,
+		SDBlobData: sdBlobData,
+		SDBlobHash: hash,
+		StreamHash: hex.EncodeToString(sdBlob.StreamHash),
+	}
+
+	// If not recursive, return just the SD blob metadata
+	if !config.Recursive {
+		return result, nil
+	}
+
+	// Recursive: fetch all content blobs
+	contentBlobs := make([][]byte, 0, len(sdBlob.BlobInfos)-1)
+	contentHashes := make([]string, 0, len(sdBlob.BlobInfos)-1)
+	chunkSizes := make([]int, 0, len(sdBlob.BlobInfos)-1)
+
+	// Get all content blobs (excluding the terminating null blob)
+	for i, blobInfo := range sdBlob.BlobInfos {
+		// Skip the terminating null blob
+		if blobInfo.Length == 0 {
+			break
+		}
+
+		// Check for context cancellation
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		blobHash := hex.EncodeToString(blobInfo.BlobHash)
+
+		// Check if we already have this blob
+		if has, err := s.storage.Has(blobHash); err == nil && has {
+			// Blob exists in storage, retrieve it
+			blobData, err := s.storage.Get(blobHash)
+			if err != nil {
+				s.logger.Warn("Failed to retrieve existing blob from storage",
+					zap.String("hash", blobHash),
+					zap.Error(err))
+				// Continue with acquisition
+			} else {
+				contentBlobs = append(contentBlobs, blobData)
+				contentHashes = append(contentHashes, blobHash)
+				chunkSizes = append(chunkSizes, blobInfo.Length)
+				continue
+			}
+		}
+
+		// Acquire the blob
+		blobData, err := s.AcquireBlob(ctx, blobHash)
+		if err != nil {
+			return nil, fmt.Errorf("failed to acquire content blob %s (index %d): %w", blobHash, i, err)
+		}
+
+		contentBlobs = append(contentBlobs, blobData)
+		contentHashes = append(contentHashes, blobHash)
+		chunkSizes = append(chunkSizes, blobInfo.Length)
+	}
+
+	// Update the result with content information
+	result.ContentBlobs = contentBlobs
+	result.ContentHashes = contentHashes
+	result.TotalChunks = len(contentBlobs)
+	result.ChunkSizes = chunkSizes
+
+	return result, nil
 }
 
 // startTCPProtocol starts a generic TCP protocol handler

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1105,7 +1105,7 @@ func TestDefaultServer_AcquireBlob_ContextCancellation(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	// Setup mock expectations (should not be called due to context cancellation)
+	// Setup mock expectations (acquirer is called and should return context.Canceled when given a cancelled context)
 	testMocks.acquirer.EXPECT().Acquire(ctx, blobHash).Return(nil, context.Canceled)
 
 	// Test with cancelled context

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -55,6 +55,31 @@ func generateNamedTestBlobHash(name string, index int) string {
 	return fmt.Sprintf("%s_%02x", name, index)
 }
 
+// runConcurrentTest executes a test function concurrently and collects any errors.
+// This helper reduces duplication across concurrent test patterns.
+func runConcurrentTest(t *testing.T, numGoroutines int, testFunc func(int) error) {
+	var wg sync.WaitGroup
+	errChan := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(index int) {
+			defer wg.Done()
+			if err := testFunc(index); err != nil {
+				errChan <- err
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errChan)
+
+	// Check for any errors
+	for err := range errChan {
+		t.Errorf("Concurrent test error: %v", err)
+	}
+}
+
 // testMocks holds all common mocks used in tests
 type testMocks struct {
 	storage       *storageMocks.MockBlobStore
@@ -729,32 +754,14 @@ func TestDefaultServer_ConcurrentAddSDBlob(t *testing.T) {
 	blobHash := TestBlobHash
 	blobData := []byte(TestBlobData)
 	numGoroutines := 10
-	errChan := make(chan error, numGoroutines)
 
-	var wg sync.WaitGroup
+	// Pre-register mock expectations to avoid concurrent registration fragility
+	testMocks.storage.EXPECT().PutSD(blobHash, blobData).Times(numGoroutines).Return(nil)
 
-	// Test concurrent AddSDBlob operations
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			// Setup mock expectations for each goroutine
-			testMocks.storage.EXPECT().PutSD(blobHash, blobData).Return(nil)
-
-			err := server.AddSDBlob(blobHash, blobData)
-			if err != nil {
-				errChan <- err
-			}
-		}(i)
-	}
-
-	wg.Wait()
-	close(errChan)
-
-	// Check for any errors
-	for err := range errChan {
-		t.Errorf("Concurrent AddSDBlob error: %v", err)
-	}
+	// Test concurrent AddSDBlob operations using helper
+	runConcurrentTest(t, numGoroutines, func(index int) error {
+		return server.AddSDBlob(blobHash, blobData)
+	})
 }
 
 // TestDefaultServer_RemoveBlob_Success tests successful blob removal
@@ -848,35 +855,21 @@ func TestDefaultServer_ConcurrentAddBlob(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
-	var wg sync.WaitGroup
 	numGoroutines := 10
-	errChan := make(chan error, numGoroutines)
 
-	// Test concurrent AddBlob operations
+	// Pre-register mock expectations for all goroutines
 	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			blobHash := generateTestBlobHash(index)
-			blobData := generateSimpleTestBlobData(index)
-
-			// Setup mock expectations for each goroutine
-			testMocks.storage.EXPECT().Put(blobHash, blobData).Return(nil)
-
-			err := server.AddBlob(blobHash, blobData)
-			if err != nil {
-				errChan <- err
-			}
-		}(i)
+		blobHash := generateTestBlobHash(i)
+		blobData := generateSimpleTestBlobData(i)
+		testMocks.storage.EXPECT().Put(blobHash, blobData).Return(nil)
 	}
 
-	wg.Wait()
-	close(errChan)
-
-	// Check for any errors
-	for err := range errChan {
-		t.Errorf("Concurrent AddBlob error: %v", err)
-	}
+	// Test concurrent AddBlob operations using helper
+	runConcurrentTest(t, numGoroutines, func(index int) error {
+		blobHash := generateTestBlobHash(index)
+		blobData := generateSimpleTestBlobData(index)
+		return server.AddBlob(blobHash, blobData)
+	})
 }
 
 // TestDefaultServer_ConcurrentRemoveBlob tests concurrent RemoveBlob operations
@@ -887,34 +880,19 @@ func TestDefaultServer_ConcurrentRemoveBlob(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
-	var wg sync.WaitGroup
 	numGoroutines := 10
-	errChan := make(chan error, numGoroutines)
 
-	// Test concurrent RemoveBlob operations
+	// Pre-register mock expectations for all goroutines
 	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			blobHash := generateTestBlobHash(index)
-
-			// Setup mock expectations for each goroutine
-			testMocks.storage.EXPECT().Delete(blobHash).Return(nil)
-
-			err := server.RemoveBlob(blobHash)
-			if err != nil {
-				errChan <- err
-			}
-		}(i)
+		blobHash := generateTestBlobHash(i)
+		testMocks.storage.EXPECT().Delete(blobHash).Return(nil)
 	}
 
-	wg.Wait()
-	close(errChan)
-
-	// Check for any errors
-	for err := range errChan {
-		t.Errorf("Concurrent RemoveBlob error: %v", err)
-	}
+	// Test concurrent RemoveBlob operations using helper
+	runConcurrentTest(t, numGoroutines, func(index int) error {
+		blobHash := generateTestBlobHash(index)
+		return server.RemoveBlob(blobHash)
+	})
 }
 
 // TestDefaultServer_ConcurrentBlobOperations tests mixed concurrent blob operations
@@ -925,49 +903,33 @@ func TestDefaultServer_ConcurrentBlobOperations(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
-	var wg sync.WaitGroup
-	numOperations := 20 // 10 adds + 10 removes
-	errChan := make(chan error, numOperations)
+	numOperations := 10 // 10 adds + 10 removes = 20 total operations
 
-	// Test concurrent Add and Remove operations
-	for i := 0; i < 10; i++ {
-		// Add operation
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			blobHash := generateNamedTestBlobHash("add_hash", index)
-			blobData := generateTestBlobData("add data", index)
-
-			testMocks.storage.EXPECT().Put(blobHash, blobData).Return(nil)
-
-			err := server.AddBlob(blobHash, blobData)
-			if err != nil {
-				errChan <- err
-			}
-		}(i)
-
-		// Remove operation
-		wg.Add(1)
-		go func(index int) {
-			defer wg.Done()
-			blobHash := generateNamedTestBlobHash("remove_hash", index)
-
-			testMocks.storage.EXPECT().Delete(blobHash).Return(nil)
-
-			err := server.RemoveBlob(blobHash)
-			if err != nil {
-				errChan <- err
-			}
-		}(i)
+	// Pre-register mock expectations for all add operations
+	for i := 0; i < numOperations; i++ {
+		addBlobHash := generateNamedTestBlobHash("add_hash", i)
+		addBlobData := generateTestBlobData("add data", i)
+		testMocks.storage.EXPECT().Put(addBlobHash, addBlobData).Return(nil)
 	}
 
-	wg.Wait()
-	close(errChan)
-
-	// Check for any errors
-	for err := range errChan {
-		t.Errorf("Concurrent blob operation error: %v", err)
+	// Pre-register mock expectations for all remove operations
+	for i := 0; i < numOperations; i++ {
+		removeBlobHash := generateNamedTestBlobHash("remove_hash", i)
+		testMocks.storage.EXPECT().Delete(removeBlobHash).Return(nil)
 	}
+
+	// Test concurrent Add operations using helper
+	runConcurrentTest(t, numOperations, func(index int) error {
+		blobHash := generateNamedTestBlobHash("add_hash", index)
+		blobData := generateTestBlobData("add data", index)
+		return server.AddBlob(blobHash, blobData)
+	})
+
+	// Test concurrent Remove operations using helper
+	runConcurrentTest(t, numOperations, func(index int) error {
+		blobHash := generateNamedTestBlobHash("remove_hash", index)
+		return server.RemoveBlob(blobHash)
+	})
 }
 
 // TestDefaultServer_announceBlobsToDHT_UsesLBRYHash tests that DHT blob announcements
@@ -1263,5 +1225,93 @@ func TestDefaultServer_AcquireSDBlob_InvalidJSON(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to parse SD blob")
 	assert.Contains(t, err.Error(), sdBlobHash)
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_AcquireSDBlob_StorageHit tests recursive SD blob acquisition when content blobs exist in storage
+// Validates that existing blobs are retrieved from storage without calling the acquirer
+func TestDefaultServer_AcquireSDBlob_StorageHit(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	sdBlobHash := TestBlobHash
+	contentBlobHash := "e28ce752b41c8434050f1f5181c8781ac817c975afc918b73eb0b3d8a90d0a06161f53048153b2c2b1029a4007477c26"
+	contentBlobData := []byte("existing content blob data")
+	sdBlobData := []byte(fmt.Sprintf(`{
+		"blobs": [
+			{"length": %d, "blob_num": 0, "blob_hash": "%s", "iv": "1234567890123456"},
+			{"length": 0, "blob_num": 1, "blob_hash": "", "iv": ""}
+		],
+		"stream_type": "lbryfile",
+		"stream_hash": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+	}`, len(contentBlobData), contentBlobHash))
+
+	expectedStreamHash := "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+	ctx := context.Background()
+
+	// Setup mock expectations - SD blob acquisition, then storage hit for content blob
+	testMocks.acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return(sdBlobData, nil)
+	// Content blob exists in storage
+	testMocks.storage.EXPECT().Has(contentBlobHash).Return(true, nil)
+	// Retrieve from storage (acquirer should NOT be called for content blob)
+	testMocks.storage.EXPECT().Get(contentBlobHash).Return(contentBlobData, nil)
+
+	// Test successful recursive SD blob acquisition with storage hit
+	result, err := server.AcquireSDBlob(ctx, sdBlobHash, WithAcquireRecursive(true))
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, sdBlobHash, result.SDBlobHash)
+	assert.Equal(t, expectedStreamHash, result.StreamHash)
+	assert.NotNil(t, result.SDBlob)
+	assert.Equal(t, sdBlobData, result.SDBlobData)
+	assert.NotNil(t, result.ContentBlobs)
+	assert.Equal(t, 1, len(result.ContentBlobs))
+	assert.Equal(t, contentBlobData, result.ContentBlobs[0])
+	assert.NotNil(t, result.ContentHashes)
+	assert.Equal(t, 1, len(result.ContentHashes))
+	assert.Equal(t, contentBlobHash, result.ContentHashes[0])
+	assert.Equal(t, 1, result.TotalChunks)
+	assert.NotNil(t, result.ChunkSizes)
+	assert.Equal(t, 1, len(result.ChunkSizes))
+	assert.Equal(t, len(contentBlobData), result.ChunkSizes[0])
+}
+
+// TestDefaultServer_AcquireSDBlob_ContentBlobAcquisitionFailure tests recursive SD blob acquisition when content blob acquisition fails
+// Validates that content blob acquisition failures are properly wrapped and propagated
+func TestDefaultServer_AcquireSDBlob_ContentBlobAcquisitionFailure(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	sdBlobHash := TestBlobHash
+	contentBlobHash := "e28ce752b41c8434050f1f5181c8781ac817c975afc918b73eb0b3d8a90d0a06161f53048153b2c2b1029a4007477c26"
+	sdBlobData := []byte(fmt.Sprintf(`{
+		"blobs": [
+			{"length": 100, "blob_num": 0, "blob_hash": "%s", "iv": "1234567890123456"},
+			{"length": 0, "blob_num": 1, "blob_hash": "", "iv": ""}
+		],
+		"stream_type": "lbryfile",
+		"stream_hash": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+	}`, contentBlobHash))
+
+	ctx := context.Background()
+	acquirerError := errors.New("content blob acquisition failed")
+
+	// Setup mock expectations - SD blob acquisition succeeds, but content blob acquisition fails
+	testMocks.acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return(sdBlobData, nil)
+	// Content blob doesn't exist in storage
+	testMocks.storage.EXPECT().Has(contentBlobHash).Return(false, nil)
+	// Content blob acquisition fails
+	testMocks.acquirer.EXPECT().Acquire(mock.Anything, contentBlobHash).Return(nil, acquirerError)
+
+	// Test content blob acquisition failure
+	result, err := server.AcquireSDBlob(ctx, sdBlobHash, WithAcquireRecursive(true))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to acquire content blob")
+	assert.Contains(t, err.Error(), contentBlobHash)
+	assert.Contains(t, err.Error(), "index 0")
 	assert.Nil(t, result)
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/liblbry/mocks"
 	"go.lumeweb.com/liblbry/protocol"
@@ -479,15 +480,15 @@ func TestProtocolConstants(t *testing.T) {
 }
 
 func TestPeerPortDHTAlignment(t *testing.T) {
-	mocks := setupBuilderMocks(t)
+	builderMocks := setupBuilderMocks(t)
 
 	t.Run("DHT port alignment when no fixed port", func(t *testing.T) {
 		// When no fixed port is specified, DHT should announce peer port = DHT port
 		builder := NewServerBuilder().
 			WithPeer(testPortPeer).
 			WithDHT(testPortDHT).
-			WithStorage(mocks.storage).
-			WithAcquirer(mocks.acquirer)
+			WithStorage(builderMocks.storage).
+			WithAcquirer(builderMocks.acquirer)
 
 		server, err := builder.Build()
 		require.NoError(t, err)
@@ -510,8 +511,8 @@ func TestPeerPortDHTAlignment(t *testing.T) {
 			WithPeer(testPortPeer).
 			WithFixedPeerPort(testPortPeer2).
 			WithDHT(testPortDHT).
-			WithStorage(mocks.storage).
-			WithAcquirer(mocks.acquirer)
+			WithStorage(builderMocks.storage).
+			WithAcquirer(builderMocks.acquirer)
 
 		server, err := builder.Build()
 		require.NoError(t, err)
@@ -728,7 +729,7 @@ func TestDefaultServer_ConcurrentAddSDBlob(t *testing.T) {
 	blobHash := TestBlobHash
 	blobData := []byte(TestBlobData)
 	numGoroutines := 10
-	errors := make(chan error, numGoroutines)
+	errChan := make(chan error, numGoroutines)
 
 	var wg sync.WaitGroup
 
@@ -742,16 +743,16 @@ func TestDefaultServer_ConcurrentAddSDBlob(t *testing.T) {
 
 			err := server.AddSDBlob(blobHash, blobData)
 			if err != nil {
-				errors <- err
+				errChan <- err
 			}
 		}(i)
 	}
 
 	wg.Wait()
-	close(errors)
+	close(errChan)
 
 	// Check for any errors
-	for err := range errors {
+	for err := range errChan {
 		t.Errorf("Concurrent AddSDBlob error: %v", err)
 	}
 }
@@ -849,7 +850,7 @@ func TestDefaultServer_ConcurrentAddBlob(t *testing.T) {
 
 	var wg sync.WaitGroup
 	numGoroutines := 10
-	errors := make(chan error, numGoroutines)
+	errChan := make(chan error, numGoroutines)
 
 	// Test concurrent AddBlob operations
 	for i := 0; i < numGoroutines; i++ {
@@ -864,16 +865,16 @@ func TestDefaultServer_ConcurrentAddBlob(t *testing.T) {
 
 			err := server.AddBlob(blobHash, blobData)
 			if err != nil {
-				errors <- err
+				errChan <- err
 			}
 		}(i)
 	}
 
 	wg.Wait()
-	close(errors)
+	close(errChan)
 
 	// Check for any errors
-	for err := range errors {
+	for err := range errChan {
 		t.Errorf("Concurrent AddBlob error: %v", err)
 	}
 }
@@ -888,7 +889,7 @@ func TestDefaultServer_ConcurrentRemoveBlob(t *testing.T) {
 
 	var wg sync.WaitGroup
 	numGoroutines := 10
-	errors := make(chan error, numGoroutines)
+	errChan := make(chan error, numGoroutines)
 
 	// Test concurrent RemoveBlob operations
 	for i := 0; i < numGoroutines; i++ {
@@ -902,16 +903,16 @@ func TestDefaultServer_ConcurrentRemoveBlob(t *testing.T) {
 
 			err := server.RemoveBlob(blobHash)
 			if err != nil {
-				errors <- err
+				errChan <- err
 			}
 		}(i)
 	}
 
 	wg.Wait()
-	close(errors)
+	close(errChan)
 
 	// Check for any errors
-	for err := range errors {
+	for err := range errChan {
 		t.Errorf("Concurrent RemoveBlob error: %v", err)
 	}
 }
@@ -926,7 +927,7 @@ func TestDefaultServer_ConcurrentBlobOperations(t *testing.T) {
 
 	var wg sync.WaitGroup
 	numOperations := 20 // 10 adds + 10 removes
-	errors := make(chan error, numOperations)
+	errChan := make(chan error, numOperations)
 
 	// Test concurrent Add and Remove operations
 	for i := 0; i < 10; i++ {
@@ -941,7 +942,7 @@ func TestDefaultServer_ConcurrentBlobOperations(t *testing.T) {
 
 			err := server.AddBlob(blobHash, blobData)
 			if err != nil {
-				errors <- err
+				errChan <- err
 			}
 		}(i)
 
@@ -955,16 +956,16 @@ func TestDefaultServer_ConcurrentBlobOperations(t *testing.T) {
 
 			err := server.RemoveBlob(blobHash)
 			if err != nil {
-				errors <- err
+				errChan <- err
 			}
 		}(i)
 	}
 
 	wg.Wait()
-	close(errors)
+	close(errChan)
 
 	// Check for any errors
-	for err := range errors {
+	for err := range errChan {
 		t.Errorf("Concurrent blob operation error: %v", err)
 	}
 }
@@ -1009,4 +1010,258 @@ func TestDefaultServer_announceBlobsToDHT_UsesLBRYHash(t *testing.T) {
 	// Verify all mock expectations were met
 	// This ensures that LBRY hashes were passed directly to AnnounceBlob,
 	// not converted to multihash format first
+}
+
+// TestDefaultServer_AcquireBlob_Success tests successful blob acquisition
+// Validates that blobs can be successfully acquired using the configured acquirer
+func TestDefaultServer_AcquireBlob_Success(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	blobHash := TestBlobHash
+	expectedData := []byte(TestBlobData)
+	ctx := context.Background()
+
+	// Setup mock expectations
+	testMocks.acquirer.EXPECT().Acquire(ctx, blobHash).Return(expectedData, nil)
+
+	// Test successful blob acquisition
+	result, err := server.AcquireBlob(ctx, blobHash)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedData, result)
+}
+
+// TestDefaultServer_AcquireBlob_EmptyHash tests error handling for empty hash
+// Validates that blob acquisition properly rejects empty hash values
+func TestDefaultServer_AcquireBlob_EmptyHash(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	ctx := context.Background()
+
+	// Test with empty hash
+	result, err := server.AcquireBlob(ctx, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hash cannot be empty")
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_AcquireBlob_NoAcquirer tests error handling when no acquirer is configured
+// Validates that blob acquisition properly handles missing acquirer configuration
+func TestDefaultServer_AcquireBlob_NoAcquirer(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+	server.acquirer = nil // Explicitly set acquirer to nil
+
+	blobHash := TestBlobHash
+	ctx := context.Background()
+
+	// Test with no acquirer configured
+	result, err := server.AcquireBlob(ctx, blobHash)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no acquirer configured")
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_AcquireBlob_AcquirerFailure tests error handling when acquirer fails
+// Validates that blob acquisition properly propagates acquirer errors
+func TestDefaultServer_AcquireBlob_AcquirerFailure(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	blobHash := TestBlobHash
+	ctx := context.Background()
+	acquirerError := errors.New("acquirer error")
+
+	// Setup mock expectations
+	testMocks.acquirer.EXPECT().Acquire(ctx, blobHash).Return(nil, acquirerError)
+
+	// Test acquirer failure
+	result, err := server.AcquireBlob(ctx, blobHash)
+	assert.Error(t, err)
+	assert.Equal(t, acquirerError, err)
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_AcquireBlob_ContextCancellation tests context cancellation handling
+// Validates that blob acquisition properly respects context cancellation
+func TestDefaultServer_AcquireBlob_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	blobHash := TestBlobHash
+
+	// Create a cancelled context
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	// Setup mock expectations (should not be called due to context cancellation)
+	testMocks.acquirer.EXPECT().Acquire(ctx, blobHash).Return(nil, context.Canceled)
+
+	// Test with cancelled context
+	result, err := server.AcquireBlob(ctx, blobHash)
+	assert.Error(t, err)
+	assert.Equal(t, context.Canceled, err)
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_AcquireSDBlob_Success tests successful SD blob acquisition (non-recursive)
+// Validates that SD blobs can be successfully acquired without fetching content blobs
+func TestDefaultServer_AcquireSDBlob_Success(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	sdBlobHash := TestBlobHash
+	sdBlobData := []byte(`{
+		"blobs": [
+			{"length": 100, "blob_num": 0, "blob_hash": "68c0ff52fca66bc20c736e49967760d6378ce73aaf4b0a870f1c2142455629ab50dc49dae0b03c56a9bff7f270a2edf3", "iv": "1234567890123456"},
+			{"length": 0, "blob_num": 1, "blob_hash": "", "iv": ""}
+		],
+		"stream_type": "lbryfile",
+		"stream_hash": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+	}`)
+	expectedStreamHash := "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+	ctx := context.Background()
+
+	// Setup mock expectations for SD blob acquisition
+	testMocks.acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return([]byte(sdBlobData), nil)
+
+	// Test successful SD blob acquisition (non-recursive)
+	result, err := server.AcquireSDBlob(ctx, sdBlobHash, WithAcquireRecursive(false))
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, sdBlobHash, result.SDBlobHash)
+	assert.Equal(t, expectedStreamHash, result.StreamHash)
+	assert.NotNil(t, result.SDBlob)
+	assert.Equal(t, []byte(sdBlobData), result.SDBlobData)
+	assert.Nil(t, result.ContentBlobs)     // Should be nil for non-recursive
+	assert.Nil(t, result.ContentHashes)    // Should be nil for non-recursive
+	assert.Equal(t, 0, result.TotalChunks) // Should be 0 for non-recursive
+}
+
+// TestDefaultServer_AcquireSDBlob_RecursiveSuccess tests successful recursive SD blob acquisition
+// Validates that SD blobs can be successfully acquired with all content blobs
+func TestDefaultServer_AcquireSDBlob_RecursiveSuccess(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	sdBlobHash := TestBlobHash
+	contentBlobHash := "e28ce752b41c8434050f1f5181c8781ac817c975afc918b73eb0b3d8a90d0a06161f53048153b2c2b1029a4007477c26"
+	contentBlobData := []byte("content blob data")
+	sdBlobData := []byte(fmt.Sprintf(`{
+		"blobs": [
+			{"length": %d, "blob_num": 0, "blob_hash": "%s", "iv": "1234567890123456"},
+			{"length": 0, "blob_num": 1, "blob_hash": "", "iv": ""}
+		],
+		"stream_type": "lbryfile",
+		"stream_hash": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+	}`, len(contentBlobData), contentBlobHash))
+
+	expectedStreamHash := "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+	ctx := context.Background()
+
+	// Setup mock expectations with explicit call ordering
+	// First, acquire the SD blob
+	testMocks.acquirer.EXPECT().Acquire(mock.Anything, sdBlobHash).Return(sdBlobData, nil)
+	// Check if content blob exists in storage - it doesn't
+	testMocks.storage.EXPECT().Has(contentBlobHash).Return(false, nil)
+	// Then, acquire the content blob - use Anything for context to be more flexible
+	testMocks.acquirer.EXPECT().Acquire(mock.Anything, contentBlobHash).Return(contentBlobData, nil)
+
+	// Test successful recursive SD blob acquisition
+	result, err := server.AcquireSDBlob(ctx, sdBlobHash, WithAcquireRecursive(true))
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, sdBlobHash, result.SDBlobHash)
+	assert.Equal(t, expectedStreamHash, result.StreamHash)
+	assert.NotNil(t, result.SDBlob)
+	assert.Equal(t, sdBlobData, result.SDBlobData)
+	assert.NotNil(t, result.ContentBlobs)
+	assert.Equal(t, 1, len(result.ContentBlobs))
+
+	assert.Equal(t, contentBlobData, result.ContentBlobs[0])
+	assert.NotNil(t, result.ContentHashes)
+	assert.Equal(t, 1, len(result.ContentHashes))
+	assert.Equal(t, contentBlobHash, result.ContentHashes[0])
+	assert.Equal(t, 1, result.TotalChunks)
+	assert.NotNil(t, result.ChunkSizes)
+	assert.Equal(t, 1, len(result.ChunkSizes))
+	assert.Equal(t, len(contentBlobData), result.ChunkSizes[0])
+}
+
+// TestDefaultServer_AcquireSDBlob_EmptyHash tests error handling for empty hash
+// Validates that SD blob acquisition properly rejects empty hash values
+func TestDefaultServer_AcquireSDBlob_EmptyHash(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	ctx := context.Background()
+
+	// Test with empty hash
+	result, err := server.AcquireSDBlob(ctx, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hash cannot be empty")
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_AcquireSDBlob_SDBlobAcquisitionFailure tests error handling when SD blob acquisition fails
+// Validates that SD blob acquisition properly propagates acquirer errors for SD blob
+func TestDefaultServer_AcquireSDBlob_SDBlobAcquisitionFailure(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	sdBlobHash := TestBlobHash
+	ctx := context.Background()
+	acquirerError := errors.New("acquirer error")
+
+	// Setup mock expectations
+	testMocks.acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return(nil, acquirerError)
+
+	// Test SD blob acquisition failure
+	result, err := server.AcquireSDBlob(ctx, sdBlobHash)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to acquire SD blob")
+	assert.Contains(t, err.Error(), sdBlobHash)
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_AcquireSDBlob_InvalidJSON tests error handling for invalid SD blob JSON
+// Validates that SD blob acquisition properly handles malformed JSON data
+func TestDefaultServer_AcquireSDBlob_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	sdBlobHash := TestBlobHash
+	invalidJSON := []byte("{ invalid json")
+	ctx := context.Background()
+
+	// Setup mock expectations
+	testMocks.acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return(invalidJSON, nil)
+
+	// Test invalid JSON handling
+	result, err := server.AcquireSDBlob(ctx, sdBlobHash)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to parse SD blob")
+	assert.Contains(t, err.Error(), sdBlobHash)
+	assert.Nil(t, result)
 }


### PR DESCRIPTION
- Added `AcquireBlob` and `AcquireSDBlob` methods to the `BlobManager` interface and `DefaultServer` implementation
- Implemented recursive SD blob content acquisition with support for context cancellation
- Added `AcquireSDConfig` and `AcquireSDOption` types for configuring SD blob acquisition
- Added comprehensive test coverage for new acquisition methods
---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single-blob retrieval and SD-blob retrieval with optional recursive fetching of referenced content.
  * Added a configuration option to control recursive acquisition behavior.

* **Tests**
  * Expanded test coverage for blob and SD-blob acquisition across success, error, recursion and concurrency scenarios.
  * Added mocks and standardized concurrent test helpers to improve reliability and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->