### PR TITLE
feat(server): introduce acquirer factory and default acquirer support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/go-errors/errors v1.5.1
 	github.com/ipfs/go-cid v0.5.0
 	github.com/knadh/koanf/v2 v2.3.0
-	github.com/lbryio/lbry.go/v2 v2.7.1
 	github.com/multiformats/go-multibase v0.2.0
 	github.com/multiformats/go-multihash v0.2.3
 	github.com/samber/lo v1.52.0
@@ -31,6 +30,7 @@ require (
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
+	github.com/lbryio/lbry.go/v2 v2.7.1 // indirect
 	github.com/lyoshenka/bencode v0.0.0-20180323155644-b7abd7672df5 // indirect
 	github.com/minio/sha256-simd v1.0.0 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
@@ -39,8 +39,6 @@ require (
 	github.com/multiformats/go-base32 v0.0.3 // indirect
 	github.com/multiformats/go-base36 v0.1.0 // indirect
 	github.com/multiformats/go-varint v0.0.7 // indirect
-	github.com/nlopes/slack v0.6.0 // indirect
-	github.com/pkg/errors v0.8.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/slack-go/slack v0.17.3 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,7 +104,6 @@ github.com/multiformats/go-multihash v0.2.3 h1:7Lyc8XfX/IY2jWb/gI7JP+o7JEq9hOa7B
 github.com/multiformats/go-multihash v0.2.3/go.mod h1:dXgKXCXjBzdscBLk9JkjINiEsCKRVch90MdaGiKsvSM=
 github.com/multiformats/go-varint v0.0.7 h1:sWSGR+f/eu5ABZA2ZpYKBILXTTs9JWpdEM/nEGOHFS8=
 github.com/multiformats/go-varint v0.0.7/go.mod h1:r8PUYw/fD/SjBCiKOoDlGF6QawOELpZAu9eioSos/OU=
-github.com/nlopes/slack v0.6.0 h1:jt0jxVQGhssx1Ib7naAOZEZcGdtIhTzkP0nopK0AsRA=
 github.com/nlopes/slack v0.6.0/go.mod h1:JzQ9m3PMAqcpeCam7UaHSuBuupz7CmpjehYMayT6YOk=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -112,7 +111,6 @@ github.com/onsi/ginkgo v1.10.2/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/server/builder.go
+++ b/server/builder.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/knadh/koanf/v2"
 	"go.lumeweb.com/liblbry"
+	"go.lumeweb.com/liblbry/blob/transfer"
 	"go.lumeweb.com/liblbry/protocol"
 	"go.lumeweb.com/liblbry/storage"
 	"go.lumeweb.com/liblbry/storage/disk"
@@ -14,25 +15,29 @@ import (
 
 // ServerBuilder provides a fluent interface for building a Server
 type ServerBuilder struct {
-	storage       storage.BlobStore
-	acquirer      liblbry.BlobAcquirer
-	accessControl storage.AccessControl
-	config        map[string]any
-	logger        *zap.Logger
-	dhtWorkers    int
-	dhtBatchSize  int
+	storage            storage.BlobStore
+	acquirer           liblbry.BlobAcquirer
+	acquirerFactory    AcquirerFactory
+	useDefaultAcquirer bool
+	accessControl      storage.AccessControl
+	config             map[string]any
+	logger             *zap.Logger
+	dhtWorkers         int
+	dhtBatchSize       int
 }
 
 // NewServerBuilder creates a new ServerBuilder instance
 func NewServerBuilder() *ServerBuilder {
 	return &ServerBuilder{
-		storage:       nil,
-		acquirer:      nil,
-		accessControl: nil,
-		config:        make(map[string]any),
-		logger:        zap.NewNop(),                    // Default to no-op logger
-		dhtWorkers:    DefaultDHTAnnouncerWorkers,      // Default value
-		dhtBatchSize:  DefaultDHTAnnouncementBatchSize, // Default batch size
+		storage:            nil,
+		acquirer:           nil,
+		acquirerFactory:    nil,
+		useDefaultAcquirer: false,
+		accessControl:      nil,
+		config:             make(map[string]any),
+		logger:             zap.NewNop(),                    // Default to no-op logger
+		dhtWorkers:         DefaultDHTAnnouncerWorkers,      // Default value
+		dhtBatchSize:       DefaultDHTAnnouncementBatchSize, // Default batch size
 	}
 }
 
@@ -45,6 +50,20 @@ func (b *ServerBuilder) WithStorage(store storage.BlobStore) *ServerBuilder {
 // WithAcquirer sets the blob acquirer for the server
 func (b *ServerBuilder) WithAcquirer(acquirer liblbry.BlobAcquirer) *ServerBuilder {
 	b.acquirer = acquirer
+	return b
+}
+
+// WithAcquirerFactory sets a factory function that creates the blob acquirer
+// This allows the acquirer to be created after the DHT is available during server build
+func (b *ServerBuilder) WithAcquirerFactory(factory func(protocol.DHTNode, storage.BlobStore) (liblbry.BlobAcquirer, error)) *ServerBuilder {
+	b.acquirerFactory = factory
+	return b
+}
+
+// WithDefaultAcquirer enables creation of a default acquirer with sensible defaults
+// The default acquirer will be configured with transfers based on enabled protocols
+func (b *ServerBuilder) WithDefaultAcquirer() *ServerBuilder {
+	b.useDefaultAcquirer = true
 	return b
 }
 
@@ -250,6 +269,25 @@ func (b *ServerBuilder) WithExistingDHT(dhtNode protocol.DHTNode) *ServerBuilder
 	return b
 }
 
+// createDefaultTransfers creates a slice of transfer.Transfer instances based on enabled protocols
+func (b *ServerBuilder) createDefaultTransfers(dhtNode protocol.DHTNode) []transfer.Transfer {
+	var transfers []transfer.Transfer
+
+	// Add peer transfer if DHT is enabled
+	if dhtNode != nil {
+		// Create a default peer client - this would need to be configurable in the future
+		peerClient := protocol.NewPeerClient(
+			protocol.WithClientLogger(b.logger.Named("peer_client")),
+		)
+		peerTransfer := transfer.NewPeerTransfer(dhtNode, peerClient,
+			transfer.WithPeerTransferLogger(b.logger.Named("peer_transfer")),
+		)
+		transfers = append(transfers, peerTransfer)
+	}
+
+	return transfers
+}
+
 // Build creates a Server instance from the builder configuration
 func (b *ServerBuilder) Build() (Server, error) {
 	if b.storage == nil {
@@ -266,7 +304,18 @@ func (b *ServerBuilder) Build() (Server, error) {
 		b.accessControl = storage.NewAllowAllAccess()
 	}
 
-	return &DefaultServer{
+	// Validate acquirer configuration
+	if b.acquirer != nil && b.acquirerFactory != nil {
+		return nil, errors.New("cannot specify both acquirer and acquirer factory")
+	}
+	if b.acquirer != nil && b.useDefaultAcquirer {
+		return nil, errors.New("cannot specify both acquirer and default acquirer")
+	}
+	if b.acquirerFactory != nil && b.useDefaultAcquirer {
+		return nil, errors.New("cannot specify both acquirer factory and default acquirer")
+	}
+
+	server := &DefaultServer{
 		storage:       b.storage,
 		acquirer:      b.acquirer,
 		accessControl: b.accessControl,
@@ -274,7 +323,20 @@ func (b *ServerBuilder) Build() (Server, error) {
 		logger:        b.logger.Named("server"),
 		dhtWorkers:    b.dhtWorkers,
 		dhtBatchSize:  b.dhtBatchSize,
-	}, nil
+	}
+
+	// Set acquirer creation functions for lazy initialization
+	if b.acquirerFactory != nil {
+		server.acquirerFactory = b.acquirerFactory
+	}
+	if b.useDefaultAcquirer {
+		server.acquirerFactory = func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
+			transfers := b.createDefaultTransfers(dhtNode)
+			return liblbry.NewBlobAcquirer(transfers, store)
+		}
+	}
+
+	return server, nil
 }
 
 // Preset helper functions for common server configurations

--- a/server/builder.go
+++ b/server/builder.go
@@ -55,13 +55,15 @@ func (b *ServerBuilder) WithAcquirer(acquirer liblbry.BlobAcquirer) *ServerBuild
 
 // WithAcquirerFactory sets a factory function that creates the blob acquirer
 // This allows the acquirer to be created after the DHT is available during server build
-func (b *ServerBuilder) WithAcquirerFactory(factory func(protocol.DHTNode, storage.BlobStore) (liblbry.BlobAcquirer, error)) *ServerBuilder {
+func (b *ServerBuilder) WithAcquirerFactory(factory AcquirerFactory) *ServerBuilder {
 	b.acquirerFactory = factory
 	return b
 }
 
 // WithDefaultAcquirer enables creation of a default acquirer with sensible defaults
-// The default acquirer will be configured with transfers based on enabled protocols
+// The default acquirer will be configured with transfers based on enabled protocols.
+// Note: DHT-based transfers require a DHT node to be configured; without DHT,
+// the acquirer will be created with an empty transfer set.
 func (b *ServerBuilder) WithDefaultAcquirer() *ServerBuilder {
 	b.useDefaultAcquirer = true
 	return b
@@ -269,18 +271,26 @@ func (b *ServerBuilder) WithExistingDHT(dhtNode protocol.DHTNode) *ServerBuilder
 	return b
 }
 
-// createDefaultTransfers creates a slice of transfer.Transfer instances based on enabled protocols
+// createDefaultTransfers creates a slice of transfer.Transfer instances based on enabled protocols.
+// Returns an empty slice if no DHT node is provided, as DHT is required for peer-based transfers.
 func (b *ServerBuilder) createDefaultTransfers(dhtNode protocol.DHTNode) []transfer.Transfer {
+	return createDefaultTransfersWithLogger(dhtNode, b.logger)
+}
+
+// createDefaultTransfersWithLogger creates a slice of transfer.Transfer instances based on enabled protocols.
+// This is a standalone helper function that avoids capturing the ServerBuilder instance.
+// Returns an empty slice if no DHT node is provided, as DHT is required for peer-based transfers.
+func createDefaultTransfersWithLogger(dhtNode protocol.DHTNode, logger *zap.Logger) []transfer.Transfer {
 	var transfers []transfer.Transfer
 
 	// Add peer transfer if DHT is enabled
 	if dhtNode != nil {
 		// Create a default peer client - this would need to be configurable in the future
 		peerClient := protocol.NewPeerClient(
-			protocol.WithClientLogger(b.logger.Named("peer_client")),
+			protocol.WithClientLogger(logger.Named("peer_client")),
 		)
 		peerTransfer := transfer.NewPeerTransfer(dhtNode, peerClient,
-			transfer.WithPeerTransferLogger(b.logger.Named("peer_transfer")),
+			transfer.WithPeerTransferLogger(logger.Named("peer_transfer")),
 		)
 		transfers = append(transfers, peerTransfer)
 	}
@@ -330,8 +340,10 @@ func (b *ServerBuilder) Build() (Server, error) {
 		server.acquirerFactory = b.acquirerFactory
 	}
 	if b.useDefaultAcquirer {
+		// Capture only the logger to avoid long-lived builder capture
+		logger := b.logger
 		server.acquirerFactory = func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
-			transfers := b.createDefaultTransfers(dhtNode)
+			transfers := createDefaultTransfersWithLogger(dhtNode, logger)
 			return liblbry.NewBlobAcquirer(transfers, store)
 		}
 	}

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -1177,6 +1177,12 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 
 		defaultServer := server.(*DefaultServer)
 
+		// Start the server to follow the documented contract for ensureAcquirer()
+		ctx := context.Background()
+		err = server.Start(ctx)
+		require.NoError(t, err)
+		defer server.Stop(ctx)
+
 		// Verify that the default factory still creates an acquirer even without DHT
 		// (it will have no transfers, but should still be created)
 		err = defaultServer.ensureAcquirer()

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/liblbry"
+	liblbryerrors "go.lumeweb.com/liblbry/errors"
 	"go.lumeweb.com/liblbry/mocks"
 	"go.lumeweb.com/liblbry/protocol"
 	protocolMocks "go.lumeweb.com/liblbry/protocol/mocks"
@@ -1074,11 +1075,17 @@ func TestServerBuilder_Build_AcquirerFactoryIntegration(t *testing.T) {
 }
 
 // TestServerBuilder_Build_DefaultAcquirerIntegration tests the integration of default acquirer with server lifecycle
+// and verifies that DHT-backed transfers are properly created when the server is started
 func TestServerBuilder_Build_DefaultAcquirerIntegration(t *testing.T) {
 	testMocks := setupBuilderMocks(t)
 
 	// Create a mock DHT node
 	mockDHTNode := protocolMocks.NewMockDHTNode(t)
+	mockDHTNode.EXPECT().Start().Return(nil)
+	mockDHTNode.EXPECT().Shutdown().Return()
+
+	// Add mock expectation for storage.List() called during DHT blob announcement
+	testMocks.storage.EXPECT().List(0, 1000).Return([]string{}, liblbryerrors.ErrEndOfList)
 
 	builder := NewServerBuilder().
 		WithStorage(testMocks.storage).
@@ -1097,6 +1104,12 @@ func TestServerBuilder_Build_DefaultAcquirerIntegration(t *testing.T) {
 	require.True(t, ok)
 	assert.NotNil(t, defaultServer.acquirerFactory)
 
+	// Start the server to initialize the DHT node
+	ctx := context.Background()
+	err = server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(ctx)
+
 	// Test that the default factory creates an acquirer with DHT-backed transfers
 	err = defaultServer.ensureAcquirer()
 	require.NoError(t, err)
@@ -1104,8 +1117,12 @@ func TestServerBuilder_Build_DefaultAcquirerIntegration(t *testing.T) {
 	// Verify acquirer was created
 	assert.NotNil(t, defaultServer.acquirer, "Default acquirer should be created")
 
-	// Verify that the acquirer was created with the expected DHT node by checking
-	// that the factory was called with the correct DHT node
+	// Verify that the DHT node is properly initialized in the server
+	dhtNode := defaultServer.getDhtNodeUnsafe()
+	assert.NotNil(t, dhtNode, "DHT node should be initialized after server.Start()")
+	assert.Equal(t, mockDHTNode, dhtNode, "DHT node should match the mock provided to builder")
+
+	// Verify that the acquirer was created with the expected DHT node
 	// Since we're using the default factory, we can verify this indirectly
 	// by ensuring the acquirer is non-nil when DHT is provided
 	assert.NotNil(t, defaultServer.acquirer, "Acquirer should be created when DHT node is provided")
@@ -1119,6 +1136,11 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 	t.Run("With DHT node", func(t *testing.T) {
 		// Create a mock DHT node
 		mockDHTNode := protocolMocks.NewMockDHTNode(t)
+		mockDHTNode.EXPECT().Start().Return(nil)
+		mockDHTNode.EXPECT().Shutdown().Return()
+
+		// Add mock expectation for storage.List() called during DHT blob announcement
+		testMocks.storage.EXPECT().List(0, 1000).Return([]string{}, liblbryerrors.ErrEndOfList)
 
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).
@@ -1131,6 +1153,17 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 		require.NoError(t, err)
 
 		defaultServer := server.(*DefaultServer)
+
+		// Start the server to initialize the DHT node
+		ctx := context.Background()
+		err = server.Start(ctx)
+		require.NoError(t, err)
+		defer server.Stop(ctx)
+
+		// Verify that the DHT node is properly initialized
+		dhtNode := defaultServer.getDhtNodeUnsafe()
+		assert.NotNil(t, dhtNode, "DHT node should be initialized after server.Start()")
+		assert.Equal(t, mockDHTNode, dhtNode, "DHT node should match the mock provided to builder")
 
 		// Verify that the default factory creates an acquirer when DHT is provided
 		err = defaultServer.ensureAcquirer()
@@ -1156,6 +1189,10 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 		err = defaultServer.ensureAcquirer()
 		require.NoError(t, err)
 		assert.NotNil(t, defaultServer.acquirer, "Acquirer should still be created even without DHT node")
+
+		// Verify that no DHT node is available when not configured
+		dhtNode := defaultServer.getDhtNodeUnsafe()
+		assert.Nil(t, dhtNode, "DHT node should be nil when not configured")
 	})
 }
 

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -907,57 +907,50 @@ func TestServerBuilder_WithDefaultAcquirer(t *testing.T) {
 func TestServerBuilder_Build_AcquirerFactoryValidation(t *testing.T) {
 	testMocks := setupBuilderMocks(t)
 
-	t.Run("AcquirerFactory_with_Acquirer_fails", func(t *testing.T) {
-		// Test that specifying both acquirer and acquirer factory fails
-		factory := func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
+	// Helper function to create a test factory
+	createTestFactory := func() AcquirerFactory {
+		return func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
 			return testMocks.acquirer, nil
 		}
+	}
 
-		builder := NewServerBuilder().
+	// Helper function to create a base builder with common configuration
+	createBaseBuilder := func() *ServerBuilder {
+		return NewServerBuilder().
 			WithStorage(testMocks.storage).
-			WithAcquirer(testMocks.acquirer).
-			WithAcquirerFactory(factory).
 			WithPeer(testPortPeer)
+	}
 
+	// Helper function to assert build failure with specific error message
+	assertBuildFailure := func(t *testing.T, builder *ServerBuilder, expectedError string) {
 		server, err := builder.Build()
-
 		require.Error(t, err)
 		assert.Nil(t, server)
-		assert.Contains(t, err.Error(), "cannot specify both acquirer and acquirer factory")
+		assert.Contains(t, err.Error(), expectedError)
+	}
+
+	t.Run("AcquirerFactory_with_Acquirer_fails", func(t *testing.T) {
+		builder := createBaseBuilder().
+			WithAcquirer(testMocks.acquirer).
+			WithAcquirerFactory(createTestFactory())
+
+		assertBuildFailure(t, builder, "cannot specify both acquirer and acquirer factory")
 	})
 
 	t.Run("AcquirerFactory_with_DefaultAcquirer_fails", func(t *testing.T) {
-		// Test that specifying both acquirer factory and default acquirer fails
-		factory := func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
-			return testMocks.acquirer, nil
-		}
+		builder := createBaseBuilder().
+			WithAcquirerFactory(createTestFactory()).
+			WithDefaultAcquirer()
 
-		builder := NewServerBuilder().
-			WithStorage(testMocks.storage).
-			WithAcquirerFactory(factory).
-			WithDefaultAcquirer().
-			WithPeer(testPortPeer)
-
-		server, err := builder.Build()
-
-		require.Error(t, err)
-		assert.Nil(t, server)
-		assert.Contains(t, err.Error(), "cannot specify both acquirer factory and default acquirer")
+		assertBuildFailure(t, builder, "cannot specify both acquirer factory and default acquirer")
 	})
 
 	t.Run("Acquirer_with_DefaultAcquirer_fails", func(t *testing.T) {
-		// Test that specifying both acquirer and default acquirer fails
-		builder := NewServerBuilder().
-			WithStorage(testMocks.storage).
+		builder := createBaseBuilder().
 			WithAcquirer(testMocks.acquirer).
-			WithDefaultAcquirer().
-			WithPeer(testPortPeer)
+			WithDefaultAcquirer()
 
-		server, err := builder.Build()
-
-		require.Error(t, err)
-		assert.Nil(t, server)
-		assert.Contains(t, err.Error(), "cannot specify both acquirer and default acquirer")
+		assertBuildFailure(t, builder, "cannot specify both acquirer and default acquirer")
 	})
 }
 
@@ -1085,7 +1078,7 @@ func TestServerBuilder_Build_DefaultAcquirerIntegration(t *testing.T) {
 	mockDHTNode.EXPECT().Shutdown().Return()
 
 	// Add mock expectation for storage.List() called during DHT blob announcement
-	testMocks.storage.EXPECT().List(0, 1000).Return([]string{}, liblbryerrors.ErrEndOfList)
+	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList)
 
 	builder := NewServerBuilder().
 		WithStorage(testMocks.storage).
@@ -1140,7 +1133,7 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 		mockDHTNode.EXPECT().Shutdown().Return()
 
 		// Add mock expectation for storage.List() called during DHT blob announcement
-		testMocks.storage.EXPECT().List(0, 1000).Return([]string{}, liblbryerrors.ErrEndOfList)
+		testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList)
 
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -997,7 +997,7 @@ func TestServerBuilder_Build_DefaultAcquirerSuccess(t *testing.T) {
 	builder := NewServerBuilder().
 		WithStorage(testMocks.storage).
 		WithDefaultAcquirer().
-		WithPeer(testPortPeer). // Need DHT for default transfers
+		WithPeer(testPortPeer). // Peer protocol for basic server functionality
 		WithAccessControl(testMocks.accessControl).
 		WithLogger(testMocks.logger)
 
@@ -1097,12 +1097,66 @@ func TestServerBuilder_Build_DefaultAcquirerIntegration(t *testing.T) {
 	require.True(t, ok)
 	assert.NotNil(t, defaultServer.acquirerFactory)
 
-	// Test that the default factory creates an acquirer
+	// Test that the default factory creates an acquirer with DHT-backed transfers
 	err = defaultServer.ensureAcquirer()
 	require.NoError(t, err)
 
 	// Verify acquirer was created
 	assert.NotNil(t, defaultServer.acquirer, "Default acquirer should be created")
+
+	// Verify that the acquirer was created with the expected DHT node by checking
+	// that the factory was called with the correct DHT node
+	// Since we're using the default factory, we can verify this indirectly
+	// by ensuring the acquirer is non-nil when DHT is provided
+	assert.NotNil(t, defaultServer.acquirer, "Acquirer should be created when DHT node is provided")
+}
+
+// TestServerBuilder_Build_DefaultAcquirerDHTUsage verifies that the default acquirer factory
+// properly utilizes the provided DHT node to create DHT-backed transfers
+func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	t.Run("With DHT node", func(t *testing.T) {
+		// Create a mock DHT node
+		mockDHTNode := protocolMocks.NewMockDHTNode(t)
+
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithDefaultAcquirer().
+			WithExistingDHT(mockDHTNode).
+			WithAccessControl(testMocks.accessControl).
+			WithLogger(testMocks.logger)
+
+		server, err := builder.Build()
+		require.NoError(t, err)
+
+		defaultServer := server.(*DefaultServer)
+
+		// Verify that the default factory creates an acquirer when DHT is provided
+		err = defaultServer.ensureAcquirer()
+		require.NoError(t, err)
+		assert.NotNil(t, defaultServer.acquirer, "Acquirer should be created when DHT node is provided")
+	})
+
+	t.Run("Without DHT node", func(t *testing.T) {
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithDefaultAcquirer().
+			WithPeer(testPortPeer). // Only peer protocol, no DHT
+			WithAccessControl(testMocks.accessControl).
+			WithLogger(testMocks.logger)
+
+		server, err := builder.Build()
+		require.NoError(t, err)
+
+		defaultServer := server.(*DefaultServer)
+
+		// Verify that the default factory still creates an acquirer even without DHT
+		// (it will have no transfers, but should still be created)
+		err = defaultServer.ensureAcquirer()
+		require.NoError(t, err)
+		assert.NotNil(t, defaultServer.acquirer, "Acquirer should still be created even without DHT node")
+	})
 }
 
 // TestServerBuilder_ChainedMethodsWithAcquirerFactory verifies that builder method chaining works correctly with acquirer factory

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.lumeweb.com/liblbry"
 	"go.lumeweb.com/liblbry/mocks"
 	"go.lumeweb.com/liblbry/protocol"
 	protocolMocks "go.lumeweb.com/liblbry/protocol/mocks"
+	"go.lumeweb.com/liblbry/storage"
 	"go.lumeweb.com/liblbry/storage/memory"
 	storageMocks "go.lumeweb.com/liblbry/storage/mocks"
 	"go.uber.org/zap"
@@ -870,4 +872,273 @@ func TestServerBuilder_WithExistingDHT_Tests(t *testing.T) {
 		// Verify the server was built successfully
 		assert.NotNil(t, server)
 	})
+}
+
+// TestServerBuilder_WithAcquirerFactory verifies that acquirer factory can be properly set on the builder
+// This ensures the builder correctly stores and references the provided acquirer factory function
+func TestServerBuilder_WithAcquirerFactory(t *testing.T) {
+	builder := NewServerBuilder()
+	testMocks := setupBuilderMocks(t)
+
+	// Create a mock acquirer factory function
+	factory := func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
+		return testMocks.acquirer, nil
+	}
+
+	result := builder.WithAcquirerFactory(factory)
+
+	assertBuilderReturnsSame(t, builder, result)
+	assert.NotNil(t, builder.acquirerFactory)
+}
+
+// TestServerBuilder_WithDefaultAcquirer verifies that default acquirer flag can be properly set on the builder
+// This ensures the builder correctly enables the default acquirer creation
+func TestServerBuilder_WithDefaultAcquirer(t *testing.T) {
+	builder := NewServerBuilder()
+
+	result := builder.WithDefaultAcquirer()
+
+	assertBuilderReturnsSame(t, builder, result)
+	assert.True(t, builder.useDefaultAcquirer)
+}
+
+// TestServerBuilder_Build_AcquirerFactoryValidation tests the validation logic for acquirer factory configuration
+func TestServerBuilder_Build_AcquirerFactoryValidation(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	t.Run("AcquirerFactory_with_Acquirer_fails", func(t *testing.T) {
+		// Test that specifying both acquirer and acquirer factory fails
+		factory := func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
+			return testMocks.acquirer, nil
+		}
+
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithAcquirer(testMocks.acquirer).
+			WithAcquirerFactory(factory).
+			WithPeer(testPortPeer)
+
+		server, err := builder.Build()
+
+		require.Error(t, err)
+		assert.Nil(t, server)
+		assert.Contains(t, err.Error(), "cannot specify both acquirer and acquirer factory")
+	})
+
+	t.Run("AcquirerFactory_with_DefaultAcquirer_fails", func(t *testing.T) {
+		// Test that specifying both acquirer factory and default acquirer fails
+		factory := func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
+			return testMocks.acquirer, nil
+		}
+
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithAcquirerFactory(factory).
+			WithDefaultAcquirer().
+			WithPeer(testPortPeer)
+
+		server, err := builder.Build()
+
+		require.Error(t, err)
+		assert.Nil(t, server)
+		assert.Contains(t, err.Error(), "cannot specify both acquirer factory and default acquirer")
+	})
+
+	t.Run("Acquirer_with_DefaultAcquirer_fails", func(t *testing.T) {
+		// Test that specifying both acquirer and default acquirer fails
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithAcquirer(testMocks.acquirer).
+			WithDefaultAcquirer().
+			WithPeer(testPortPeer)
+
+		server, err := builder.Build()
+
+		require.Error(t, err)
+		assert.Nil(t, server)
+		assert.Contains(t, err.Error(), "cannot specify both acquirer and default acquirer")
+	})
+}
+
+// TestServerBuilder_Build_AcquirerFactorySuccess tests successful server building with acquirer factory
+func TestServerBuilder_Build_AcquirerFactorySuccess(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	// Create a mock acquirer factory function
+	factory := func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
+		return testMocks.acquirer, nil
+	}
+
+	builder := NewServerBuilder().
+		WithStorage(testMocks.storage).
+		WithAcquirerFactory(factory).
+		WithPeer(testPortPeer).
+		WithAccessControl(testMocks.accessControl).
+		WithLogger(testMocks.logger)
+
+	server, err := builder.Build()
+
+	require.NoError(t, err)
+	assert.NotNil(t, server)
+
+	// Verify the server is of the correct type
+	defaultServer, ok := server.(*DefaultServer)
+	require.True(t, ok)
+	assert.Same(t, testMocks.storage, defaultServer.storage)
+	assert.Same(t, testMocks.accessControl, defaultServer.accessControl)
+	assert.NotNil(t, defaultServer.acquirerFactory)
+	assert.Nil(t, defaultServer.acquirer) // Should be nil until initialized
+}
+
+// TestServerBuilder_Build_DefaultAcquirerSuccess tests successful server building with default acquirer
+func TestServerBuilder_Build_DefaultAcquirerSuccess(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	builder := NewServerBuilder().
+		WithStorage(testMocks.storage).
+		WithDefaultAcquirer().
+		WithPeer(testPortPeer). // Need DHT for default transfers
+		WithAccessControl(testMocks.accessControl).
+		WithLogger(testMocks.logger)
+
+	server, err := builder.Build()
+
+	require.NoError(t, err)
+	assert.NotNil(t, server)
+
+	// Verify the server is of the correct type
+	defaultServer, ok := server.(*DefaultServer)
+	require.True(t, ok)
+	assert.Same(t, testMocks.storage, defaultServer.storage)
+	assert.Same(t, testMocks.accessControl, defaultServer.accessControl)
+	assert.NotNil(t, defaultServer.acquirerFactory)
+	assert.Nil(t, defaultServer.acquirer) // Should be nil until initialized
+}
+
+// TestServerBuilder_Build_AcquirerFactoryIntegration tests the integration of acquirer factory with server lifecycle
+func TestServerBuilder_Build_AcquirerFactoryIntegration(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	// Create a mock DHT node
+	mockDHTNode := protocolMocks.NewMockDHTNode(t)
+	mockDHTNode.EXPECT().Start().Return(nil)
+	mockDHTNode.EXPECT().Shutdown().Return()
+
+	// Create a mock acquirer factory function that tracks calls
+	var factoryCalled bool
+	var factoryDHTNode protocol.DHTNode
+	var factoryStore storage.BlobStore
+
+	factory := func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
+		factoryCalled = true
+		factoryDHTNode = dhtNode
+		factoryStore = store
+		return testMocks.acquirer, nil
+	}
+
+	// Mock the storage.List call that happens during DHT blob announcement
+	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil)
+
+	builder := NewServerBuilder().
+		WithStorage(testMocks.storage).
+		WithAcquirerFactory(factory).
+		WithExistingDHT(mockDHTNode).
+		WithAccessControl(testMocks.accessControl).
+		WithLogger(testMocks.logger)
+
+	server, err := builder.Build()
+
+	require.NoError(t, err)
+	assert.NotNil(t, server)
+
+	// Verify the server is of the correct type
+	defaultServer, ok := server.(*DefaultServer)
+	require.True(t, ok)
+	assert.NotNil(t, defaultServer.acquirerFactory)
+
+	// Start the server to initialize the DHT node
+	ctx := context.Background()
+	err = server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(ctx)
+
+	// Test that the factory is called when ensuring acquirer
+	err = defaultServer.ensureAcquirer()
+	require.NoError(t, err)
+
+	// Verify factory was called with correct parameters
+	assert.True(t, factoryCalled, "Factory should have been called")
+	assert.Equal(t, mockDHTNode, factoryDHTNode, "Factory should receive the correct DHT node")
+	assert.Equal(t, testMocks.storage, factoryStore, "Factory should receive the correct storage")
+	assert.Equal(t, testMocks.acquirer, defaultServer.acquirer, "Acquirer should be set from factory")
+}
+
+// TestServerBuilder_Build_DefaultAcquirerIntegration tests the integration of default acquirer with server lifecycle
+func TestServerBuilder_Build_DefaultAcquirerIntegration(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	// Create a mock DHT node
+	mockDHTNode := protocolMocks.NewMockDHTNode(t)
+
+	builder := NewServerBuilder().
+		WithStorage(testMocks.storage).
+		WithDefaultAcquirer().
+		WithExistingDHT(mockDHTNode).
+		WithAccessControl(testMocks.accessControl).
+		WithLogger(testMocks.logger)
+
+	server, err := builder.Build()
+
+	require.NoError(t, err)
+	assert.NotNil(t, server)
+
+	// Verify the server is of the correct type
+	defaultServer, ok := server.(*DefaultServer)
+	require.True(t, ok)
+	assert.NotNil(t, defaultServer.acquirerFactory)
+
+	// Test that the default factory creates an acquirer
+	err = defaultServer.ensureAcquirer()
+	require.NoError(t, err)
+
+	// Verify acquirer was created
+	assert.NotNil(t, defaultServer.acquirer, "Default acquirer should be created")
+}
+
+// TestServerBuilder_ChainedMethodsWithAcquirerFactory verifies that builder method chaining works correctly with acquirer factory
+func TestServerBuilder_ChainedMethodsWithAcquirerFactory(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	factory := func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
+		return testMocks.acquirer, nil
+	}
+
+	// Test method chaining works correctly with acquirer factory
+	server, err := NewServerBuilder().
+		WithStorage(testMocks.storage).
+		WithAcquirerFactory(factory).
+		WithAccessControl(testMocks.accessControl).
+		WithPeer(testPortPeer).
+		WithLogger(testMocks.logger).
+		Build()
+
+	require.NoError(t, err)
+	assert.NotNil(t, server)
+}
+
+// TestServerBuilder_ChainedMethodsWithDefaultAcquirer verifies that builder method chaining works correctly with default acquirer
+func TestServerBuilder_ChainedMethodsWithDefaultAcquirer(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	// Test method chaining works correctly with default acquirer
+	server, err := NewServerBuilder().
+		WithStorage(testMocks.storage).
+		WithDefaultAcquirer().
+		WithAccessControl(testMocks.accessControl).
+		WithPeer(testPortPeer).
+		WithLogger(testMocks.logger).
+		Build()
+
+	require.NoError(t, err)
+	assert.NotNil(t, server)
 }

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/liblbry"
 	liblbryerrors "go.lumeweb.com/liblbry/errors"
@@ -921,20 +922,12 @@ func TestServerBuilder_Build_AcquirerFactoryValidation(t *testing.T) {
 			WithPeer(testPortPeer)
 	}
 
-	// Helper function to assert build failure with specific error message
-	assertBuildFailure := func(t *testing.T, builder *ServerBuilder, expectedError string) {
-		server, err := builder.Build()
-		require.Error(t, err)
-		assert.Nil(t, server)
-		assert.Contains(t, err.Error(), expectedError)
-	}
-
 	t.Run("AcquirerFactory_with_Acquirer_fails", func(t *testing.T) {
 		builder := createBaseBuilder().
 			WithAcquirer(testMocks.acquirer).
 			WithAcquirerFactory(createTestFactory())
 
-		assertBuildFailure(t, builder, "cannot specify both acquirer and acquirer factory")
+		assertBuildError(t, builder, "cannot specify both acquirer and acquirer factory")
 	})
 
 	t.Run("AcquirerFactory_with_DefaultAcquirer_fails", func(t *testing.T) {
@@ -942,7 +935,7 @@ func TestServerBuilder_Build_AcquirerFactoryValidation(t *testing.T) {
 			WithAcquirerFactory(createTestFactory()).
 			WithDefaultAcquirer()
 
-		assertBuildFailure(t, builder, "cannot specify both acquirer factory and default acquirer")
+		assertBuildError(t, builder, "cannot specify both acquirer factory and default acquirer")
 	})
 
 	t.Run("Acquirer_with_DefaultAcquirer_fails", func(t *testing.T) {
@@ -950,7 +943,7 @@ func TestServerBuilder_Build_AcquirerFactoryValidation(t *testing.T) {
 			WithAcquirer(testMocks.acquirer).
 			WithDefaultAcquirer()
 
-		assertBuildFailure(t, builder, "cannot specify both acquirer and default acquirer")
+		assertBuildError(t, builder, "cannot specify both acquirer and default acquirer")
 	})
 }
 
@@ -1031,7 +1024,7 @@ func TestServerBuilder_Build_AcquirerFactoryIntegration(t *testing.T) {
 	}
 
 	// Mock the storage.List call that happens during DHT blob announcement
-	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil)
+	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil).Times(1)
 
 	builder := NewServerBuilder().
 		WithStorage(testMocks.storage).
@@ -1078,7 +1071,7 @@ func TestServerBuilder_Build_DefaultAcquirerIntegration(t *testing.T) {
 	mockDHTNode.EXPECT().Shutdown().Return()
 
 	// Add mock expectation for storage.List() called during DHT blob announcement
-	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList)
+	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList).Times(1)
 
 	builder := NewServerBuilder().
 		WithStorage(testMocks.storage).
@@ -1133,7 +1126,7 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 		mockDHTNode.EXPECT().Shutdown().Return()
 
 		// Add mock expectation for storage.List() called during DHT blob announcement
-		testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList)
+		testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList).Times(1)
 
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).
@@ -1165,6 +1158,9 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 	})
 
 	t.Run("Without DHT node", func(t *testing.T) {
+		// Ensure storage.List is not called when no DHT node is configured
+		testMocks.storage.EXPECT().List(mock.Anything, mock.Anything).Times(0)
+
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).
 			WithDefaultAcquirer().

--- a/server/server.go
+++ b/server/server.go
@@ -671,6 +671,17 @@ func (s *DefaultServer) ensureAcquirer() error {
 	return nil
 }
 
+// requireStarted checks if the server has been started and returns an error if not
+func (s *DefaultServer) requireStarted() error {
+	s.mu.Lock()
+	started := s.started
+	s.mu.Unlock()
+	if !started {
+		return fmt.Errorf("server must be started before calling acquisition methods")
+	}
+	return nil
+}
+
 // AcquireBlob retrieves a blob using available transfer methods
 func (s *DefaultServer) AcquireBlob(ctx context.Context, hash string) ([]byte, error) {
 	// Validate hash
@@ -679,11 +690,8 @@ func (s *DefaultServer) AcquireBlob(ctx context.Context, hash string) ([]byte, e
 	}
 
 	// Check if server has been started
-	s.mu.Lock()
-	started := s.started
-	s.mu.Unlock()
-	if !started {
-		return nil, fmt.Errorf("server must be started before calling AcquireBlob")
+	if err := s.requireStarted(); err != nil {
+		return nil, err
 	}
 
 	// Ensure acquirer is initialized
@@ -702,11 +710,8 @@ func (s *DefaultServer) AcquireSDBlob(ctx context.Context, hash string, opts ...
 	}
 
 	// Check if server has been started
-	s.mu.Lock()
-	started := s.started
-	s.mu.Unlock()
-	if !started {
-		return nil, fmt.Errorf("server must be started before calling AcquireSDBlob")
+	if err := s.requireStarted(); err != nil {
+		return nil, err
 	}
 
 	// Apply default configuration

--- a/server/server.go
+++ b/server/server.go
@@ -22,6 +22,10 @@ import (
 	"golang.org/x/text/language"
 )
 
+// AcquirerFactory defines a function type for creating blob acquirers
+// This allows lazy initialization of acquirers after DHT and other dependencies are available
+type AcquirerFactory func(protocol.DHTNode, storage.BlobStore) (liblbry.BlobAcquirer, error)
+
 // Default protocol ports
 const (
 	DefaultPeerPort      = 5567
@@ -110,12 +114,13 @@ type DHTConfig struct {
 type DefaultServer struct {
 	BlobManager // Embedded interface
 
-	storage       storage.BlobStore
-	acquirer      liblbry.BlobAcquirer
-	accessControl storage.AccessControl
-	config        map[string]any
-	logger        *zap.Logger
-	dhtWorkers    int
+	storage         storage.BlobStore
+	acquirer        liblbry.BlobAcquirer
+	acquirerFactory AcquirerFactory
+	accessControl   storage.AccessControl
+	config          map[string]any
+	logger          *zap.Logger
+	dhtWorkers      int
 
 	// DHT management - kept at server level
 	dhtAnnouncer protocol.DHTAnnouncer
@@ -595,6 +600,29 @@ func (s *DefaultServer) RemoveBlob(hash string) error {
 	return nil
 }
 
+// ensureAcquirer ensures the acquirer is initialized, creating it if necessary
+func (s *DefaultServer) ensureAcquirer() error {
+	if s.acquirer != nil {
+		return nil // Already initialized
+	}
+
+	if s.acquirerFactory == nil {
+		return fmt.Errorf("no acquirer configured")
+	}
+
+	// Get the DHT node if available
+	dhtNode := s.getDhtNode()
+
+	// Create the acquirer using the factory
+	acquirer, err := s.acquirerFactory(dhtNode, s.storage)
+	if err != nil {
+		return fmt.Errorf("failed to create acquirer: %w", err)
+	}
+
+	s.acquirer = acquirer
+	return nil
+}
+
 // AcquireBlob retrieves a blob using available transfer methods
 func (s *DefaultServer) AcquireBlob(ctx context.Context, hash string) ([]byte, error) {
 	// Validate hash
@@ -602,9 +630,9 @@ func (s *DefaultServer) AcquireBlob(ctx context.Context, hash string) ([]byte, e
 		return nil, err
 	}
 
-	// Use the acquirer to get the blob
-	if s.acquirer == nil {
-		return nil, fmt.Errorf("no acquirer configured")
+	// Ensure acquirer is initialized
+	if err := s.ensureAcquirer(); err != nil {
+		return nil, err
 	}
 
 	return s.acquirer.Acquire(ctx, hash)

--- a/server/server.go
+++ b/server/server.go
@@ -600,18 +600,36 @@ func (s *DefaultServer) RemoveBlob(hash string) error {
 	return nil
 }
 
+// getDhtNodeUnsafe returns the DHT node without locking
+// This should only be called when the caller already holds s.mu
+func (s *DefaultServer) getDhtNodeUnsafe() protocol.DHTNode {
+	if dhtNode, ok := s.servers[ProtocolDHT].(protocol.DHTNode); ok {
+		return dhtNode
+	}
+	return nil
+}
+
 // ensureAcquirer ensures the acquirer is initialized, creating it if necessary
 func (s *DefaultServer) ensureAcquirer() error {
+	// First check without lock for fast path
 	if s.acquirer != nil {
-		return nil // Already initialized
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Double-check after acquiring lock
+	if s.acquirer != nil {
+		return nil
 	}
 
 	if s.acquirerFactory == nil {
 		return fmt.Errorf("no acquirer configured")
 	}
 
-	// Get the DHT node if available
-	dhtNode := s.getDhtNode()
+	// Get the DHT node if available using the unsafe version to avoid deadlock
+	dhtNode := s.getDhtNodeUnsafe()
 
 	// Create the acquirer using the factory
 	acquirer, err := s.acquirerFactory(dhtNode, s.storage)

--- a/server/server.go
+++ b/server/server.go
@@ -134,6 +134,7 @@ type DefaultServer struct {
 	ctx       context.Context
 	cancel    context.CancelFunc
 	mu        sync.Mutex // Protects shared state
+	started   bool       // Tracks whether Start() has been called
 }
 
 // Start starts the server and all configured config
@@ -181,6 +182,11 @@ func (s *DefaultServer) Start(ctx context.Context) error {
 		}
 	}
 
+	// Mark server as started
+	s.mu.Lock()
+	s.started = true
+	s.mu.Unlock()
+
 	// Announce all blobs to DHT after all config are started
 	if s.dhtAnnouncer != nil && s.storage != nil {
 		s.announceBlobsToDHT(s.dhtWorkers, s.dhtBatchSize)
@@ -211,6 +217,9 @@ func (s *DefaultServer) Stop(ctx context.Context) error {
 			s.logger.Info("DHT node shutdown completed")
 		}
 	}
+
+	// Mark server as stopped
+	s.started = false
 	s.mu.Unlock()
 
 	// Wait for all goroutines to finish with timeout
@@ -610,6 +619,9 @@ func (s *DefaultServer) getDhtNodeUnsafe() protocol.DHTNode {
 }
 
 // ensureAcquirer ensures the acquirer is initialized, creating it if necessary
+// Note: This method should only be called after Start() has been invoked to ensure
+// DHT nodes are properly initialized. Calling before Start() will result in an acquirer
+// without DHT-backed transfers.
 func (s *DefaultServer) ensureAcquirer() error {
 	// First check without lock for fast path
 	if s.acquirer != nil {
@@ -617,22 +629,40 @@ func (s *DefaultServer) ensureAcquirer() error {
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	// Double-check after acquiring lock
 	if s.acquirer != nil {
+		s.mu.Unlock()
 		return nil
 	}
 
 	if s.acquirerFactory == nil {
+		s.mu.Unlock()
 		return fmt.Errorf("no acquirer configured")
 	}
 
 	// Get the DHT node if available using the unsafe version to avoid deadlock
 	dhtNode := s.getDhtNodeUnsafe()
 
-	// Create the acquirer using the factory
-	acquirer, err := s.acquirerFactory(dhtNode, s.storage)
+	// Snapshot factory and dependencies to minimize lock scope
+	factory := s.acquirerFactory
+	storage := s.storage
+
+	// Release lock before calling factory to avoid potential deadlocks
+	s.mu.Unlock()
+
+	// Create the acquirer using the factory outside of lock
+	acquirer, err := factory(dhtNode, storage)
+
+	// Re-acquire lock to assign the result
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Double-check again in case another goroutine initialized while we were unlocked
+	if s.acquirer != nil {
+		return nil
+	}
+
 	if err != nil {
 		return fmt.Errorf("failed to create acquirer: %w", err)
 	}
@@ -648,6 +678,14 @@ func (s *DefaultServer) AcquireBlob(ctx context.Context, hash string) ([]byte, e
 		return nil, err
 	}
 
+	// Check if server has been started
+	s.mu.Lock()
+	started := s.started
+	s.mu.Unlock()
+	if !started {
+		return nil, fmt.Errorf("server must be started before calling AcquireBlob")
+	}
+
 	// Ensure acquirer is initialized
 	if err := s.ensureAcquirer(); err != nil {
 		return nil, err
@@ -661,6 +699,14 @@ func (s *DefaultServer) AcquireSDBlob(ctx context.Context, hash string, opts ...
 	// Validate hash
 	if err := validateHash(hash); err != nil {
 		return nil, err
+	}
+
+	// Check if server has been started
+	s.mu.Lock()
+	started := s.started
+	s.mu.Unlock()
+	if !started {
+		return nil, fmt.Errorf("server must be started before calling AcquireSDBlob")
 	}
 
 	// Apply default configuration

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -982,9 +982,14 @@ func TestDefaultServer_AcquireBlob_Success(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
+	// Start the server to enable blob acquisition
+	ctx := context.Background()
+	err := server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
 	blobHash := TestBlobHash
 	expectedData := []byte(TestBlobData)
-	ctx := context.Background()
 
 	// Setup mock expectations
 	testMocks.acquirer.EXPECT().Acquire(ctx, blobHash).Return(expectedData, nil)
@@ -1021,8 +1026,13 @@ func TestDefaultServer_AcquireBlob_NoAcquirer(t *testing.T) {
 	server := setupServer(t, testMocks, map[string]any{})
 	server.acquirer = nil // Explicitly set acquirer to nil
 
-	blobHash := TestBlobHash
+	// Start the server to enable blob acquisition
 	ctx := context.Background()
+	err := server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
+	blobHash := TestBlobHash
 
 	// Test with no acquirer configured
 	result, err := server.AcquireBlob(ctx, blobHash)
@@ -1039,8 +1049,13 @@ func TestDefaultServer_AcquireBlob_AcquirerFailure(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
-	blobHash := TestBlobHash
+	// Start the server to enable blob acquisition
 	ctx := context.Background()
+	err := server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
+	blobHash := TestBlobHash
 	acquirerError := errors.New("acquirer error")
 
 	// Setup mock expectations
@@ -1061,11 +1076,16 @@ func TestDefaultServer_AcquireBlob_ContextCancellation(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
+	// Start the server to enable blob acquisition
+	ctx, cancel := context.WithCancel(context.Background())
+	err := server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
 	blobHash := TestBlobHash
 
-	// Create a cancelled context
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
+	// Cancel the context after starting the server
+	cancel()
 
 	// Setup mock expectations (acquirer is called and should return context.Canceled when given a cancelled context)
 	testMocks.acquirer.EXPECT().Acquire(ctx, blobHash).Return(nil, context.Canceled)
@@ -1085,6 +1105,12 @@ func TestDefaultServer_AcquireSDBlob_Success(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
+	// Start the server to enable blob acquisition
+	ctx := context.Background()
+	err := server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
 	sdBlobHash := TestBlobHash
 	sdBlobData := []byte(`{
 		"blobs": [
@@ -1095,7 +1121,6 @@ func TestDefaultServer_AcquireSDBlob_Success(t *testing.T) {
 		"stream_hash": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
 	}`)
 	expectedStreamHash := "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
-	ctx := context.Background()
 
 	// Setup mock expectations for SD blob acquisition
 	testMocks.acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return([]byte(sdBlobData), nil)
@@ -1121,6 +1146,12 @@ func TestDefaultServer_AcquireSDBlob_RecursiveSuccess(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
+	// Start the server to enable blob acquisition
+	ctx := context.Background()
+	err := server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
 	sdBlobHash := TestBlobHash
 	contentBlobHash := "e28ce752b41c8434050f1f5181c8781ac817c975afc918b73eb0b3d8a90d0a06161f53048153b2c2b1029a4007477c26"
 	contentBlobData := []byte("content blob data")
@@ -1134,7 +1165,6 @@ func TestDefaultServer_AcquireSDBlob_RecursiveSuccess(t *testing.T) {
 	}`, len(contentBlobData), contentBlobHash))
 
 	expectedStreamHash := "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
-	ctx := context.Background()
 
 	// Setup mock expectations with explicit call ordering
 	// First, acquire the SD blob
@@ -1190,8 +1220,13 @@ func TestDefaultServer_AcquireSDBlob_SDBlobAcquisitionFailure(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
-	sdBlobHash := TestBlobHash
+	// Start the server to enable blob acquisition
 	ctx := context.Background()
+	err := server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
+	sdBlobHash := TestBlobHash
 	acquirerError := errors.New("acquirer error")
 
 	// Setup mock expectations
@@ -1213,9 +1248,14 @@ func TestDefaultServer_AcquireSDBlob_InvalidJSON(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
+	// Start the server to enable blob acquisition
+	ctx := context.Background()
+	err := server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
 	sdBlobHash := TestBlobHash
 	invalidJSON := []byte("{ invalid json")
-	ctx := context.Background()
 
 	// Setup mock expectations
 	testMocks.acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return(invalidJSON, nil)
@@ -1236,6 +1276,12 @@ func TestDefaultServer_AcquireSDBlob_StorageHit(t *testing.T) {
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
+	// Start the server to enable blob acquisition
+	ctx := context.Background()
+	err := server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
 	sdBlobHash := TestBlobHash
 	contentBlobHash := "e28ce752b41c8434050f1f5181c8781ac817c975afc918b73eb0b3d8a90d0a06161f53048153b2c2b1029a4007477c26"
 	contentBlobData := []byte("existing content blob data")
@@ -1249,7 +1295,6 @@ func TestDefaultServer_AcquireSDBlob_StorageHit(t *testing.T) {
 	}`, len(contentBlobData), contentBlobHash))
 
 	expectedStreamHash := "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
-	ctx := context.Background()
 
 	// Setup mock expectations - SD blob acquisition, then storage hit for content blob
 	testMocks.acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return(sdBlobData, nil)
@@ -1286,6 +1331,12 @@ func TestDefaultServer_AcquireSDBlob_ContentBlobAcquisitionFailure(t *testing.T)
 	testMocks := setupMocks(t)
 	server := setupServer(t, testMocks, map[string]any{})
 
+	// Start the server to enable blob acquisition
+	ctx := context.Background()
+	err := server.Start(ctx)
+	require.NoError(t, err)
+	defer server.Stop(context.Background())
+
 	sdBlobHash := TestBlobHash
 	contentBlobHash := "e28ce752b41c8434050f1f5181c8781ac817c975afc918b73eb0b3d8a90d0a06161f53048153b2c2b1029a4007477c26"
 	sdBlobData := []byte(fmt.Sprintf(`{
@@ -1297,7 +1348,6 @@ func TestDefaultServer_AcquireSDBlob_ContentBlobAcquisitionFailure(t *testing.T)
 		"stream_hash": "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
 	}`, contentBlobHash))
 
-	ctx := context.Background()
 	acquirerError := errors.New("content blob acquisition failed")
 
 	// Setup mock expectations - SD blob acquisition succeeds, but content blob acquisition fails

--- a/stream/encoder.go
+++ b/stream/encoder.go
@@ -137,8 +137,8 @@ func NewEncoder(src io.Reader) *Encoder {
 
 // NewEncoderWithIVs creates a new encoder that uses preset cryptographic material
 func NewEncoderWithIVs(src io.Reader, key []byte, ivs [][]byte) *Encoder {
-	if len(key) != lbrycrypto.AES256KeySize {
-		panic(fmt.Sprintf("invalid key size: expected %d bytes, got %d bytes", lbrycrypto.AES256KeySize, len(key)))
+	if len(key) != lbrycrypto.AES256KeySize && len(key) != lbrycrypto.AES128KeySize {
+		panic(fmt.Sprintf("invalid key size: expected %d or %d bytes, got %d bytes", lbrycrypto.AES256KeySize, lbrycrypto.AES128KeySize, len(key)))
 	}
 	e := newEncoderInternal(src, key)
 	e.ivs = ivs


### PR DESCRIPTION
- Added `AcquirerFactory` type and related methods (`WithAcquirerFactory`, `WithDefaultAcquirer`) to `ServerBuilder`
- Implemented lazy initialization of blob acquirers via factory functions
- Added `ensureAcquirer` method to `DefaultServer` for proper acquirer initialization
- Updated `AcquireBlob` to use the new acquirer initialization flow
- Extended `NewEncoderWithIVs` to accept both AES-128 and AES-256 key sizes
- Added comprehensive tests for the new acquirer functionality
---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Flexible acquirer setup: customizable acquirer factory and a default lazy acquirer that initializes when network discovery is available, with validation to prevent conflicting configurations.
  * Server lifecycle enforced: Start/Stop now required for blob acquisition.
  * Stream encoder accepts both AES-128 and AES-256 key sizes.
* **Tests**
  * Expanded coverage for acquirer flows, configuration validation, lifecycle, DHT/integration and acquisition scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->