### PR TITLE
fix(transfer): handle peer port configuration in address resolution

### DIFF
--- a/blob/transfer/peer_transfer.go
+++ b/blob/transfer/peer_transfer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -426,7 +427,14 @@ func (t *PeerTransfer) Get(ctx context.Context, hash string) ([]byte, error) {
 
 	for i := 0; i < peersToTry; i++ {
 		contact := contacts[i]
-		peerAddr := contact.Addr().String()
+
+		// Use peer's specific port if available, otherwise use the address from Addr()
+		var peerAddr string
+		if contact.PeerPort != 0 {
+			peerAddr = net.JoinHostPort(contact.IP.String(), fmt.Sprintf("%d", contact.PeerPort))
+		} else {
+			peerAddr = contact.Addr().String()
+		}
 
 		// Capture loop variables
 		peerAddrCopy := peerAddr


### PR DESCRIPTION
- Introduces logic to use a peer's specific port if available, falling back to the default address resolution
- Enhances peer address construction for more accurate network communication

---
* Tests can be run with `go test ./...`
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved peer address resolution to prioritize peer-specific port information when available, with graceful fallback to default address handling for better connectivity management in peer communication.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->