### PR TITLE
fix(dht): set logger on both dht and dht node log instances

### DIFF
--- a/protocol/dht_node.go
+++ b/protocol/dht_node.go
@@ -61,6 +61,7 @@ func NewDHTNode(dhtImpl DHT, options ...DHTOption) (DHTNode, error) {
 			// behavior for different nodes, set the logger once during application startup before any
 			// dht.New() calls, or manage logging at a higher level.
 			dht.UseLogger(config.Logger)
+			dht.NodeFinderUseLogger(config.Logger)
 		}
 	}
 


### PR DESCRIPTION
---
* Tests can be run with `go test ./...`
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced logging configuration to ensure the DHT node finder component uses the same logger instance as the main DHT service for consistent distributed hash table monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->