### PR TITLE
feat(transfer): add DHT retry logic for peer discovery

### DIFF
--- a/blob/transfer/peer_transfer.go
+++ b/blob/transfer/peer_transfer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"net"
 	"sync"
 	"sync/atomic"
@@ -429,10 +430,17 @@ func (t *PeerTransfer) Get(ctx context.Context, hash string) ([]byte, error) {
 				zap.Int("attempt", attempt),
 				zap.Int("maxAttempts", t.dhtRetryAttempts))
 
-			// Add delay between retries using configurable delay with simple backoff
-			delay := time.Duration(attempt) * t.dhtRetryDelay
+			// Add delay between retries using configurable delay with exponential backoff
+			// Exponential backoff: base_delay × 2^(attempt-1) with jitter
+			backoffFactor := time.Duration(1 << uint(attempt-1)) // 1, 2, 4, 8...
+			delay := backoffFactor * t.dhtRetryDelay
+			// Add jitter: ±25% randomization
+			jitter := time.Duration(rand.Int63n(int64(delay / 2)))
+			delay = delay - delay/4 + jitter
+			timer := time.NewTimer(delay)
+			defer timer.Stop()
 			select {
-			case <-time.After(delay):
+			case <-timer.C:
 			case <-ctx.Done():
 				req.once.Do(func() {
 					req.result = taskResult{err: ctx.Err()}

--- a/blob/transfer/peer_transfer.go
+++ b/blob/transfer/peer_transfer.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/gammazero/workerpool"
+	"go.lumeweb.com/lbry-dht"
 	liblbryerrors "go.lumeweb.com/liblbry/errors"
 	"go.lumeweb.com/liblbry/protocol"
 	"go.lumeweb.com/liblbry/stream"
@@ -45,6 +46,7 @@ type PeerTransfer struct {
 	peerClientFactory protocol.PeerClientFactory
 	timeout           time.Duration
 	maxPeers          int
+	dhtRetryAttempts  int
 	logger            *zap.Logger
 
 	// Concurrent execution fields
@@ -102,6 +104,23 @@ func WithPeerTransferMaxConcurrency(maxConcurrency int) PeerTransferOption {
 	}
 }
 
+// WithPeerTransferDHTRetryAttempts sets the number of retry attempts when DHT returns 0 contacts
+// Values less than 0 are treated as invalid and will be rejected with a warning
+func WithPeerTransferDHTRetryAttempts(retryAttempts int) PeerTransferOption {
+	return func(t *PeerTransfer) {
+		if retryAttempts < 0 {
+			if t.logger != nil {
+				t.logger.Warn("Invalid dhtRetryAttempts value provided, must be >= 0. Using default value instead.",
+					zap.Int("provided", retryAttempts),
+					zap.Int("default", 0))
+			}
+			// Keep the existing default value instead of silently changing it
+			return
+		}
+		t.dhtRetryAttempts = retryAttempts
+	}
+}
+
 // NewPeerTransfer creates a new PeerTransfer with the specified DHT node and peer client factory
 // Returns an error if peerClientFactory is nil
 func NewPeerTransfer(dhtNode protocol.DHTNode, peerClientFactory protocol.PeerClientFactory, options ...PeerTransferOption) (*PeerTransfer, error) {
@@ -115,6 +134,7 @@ func NewPeerTransfer(dhtNode protocol.DHTNode, peerClientFactory protocol.PeerCl
 		peerClientFactory: peerClientFactory,
 		timeout:           30 * time.Second,
 		maxPeers:          5,
+		dhtRetryAttempts:  0, // Default to no retries
 		logger:            zap.NewNop(),
 		maxConcurrency:    DefaultMaxConcurrency,
 		backlog:           make(map[string]*blobRequest),
@@ -371,14 +391,38 @@ func (t *PeerTransfer) Get(ctx context.Context, hash string) ([]byte, error) {
 		return nil, fmt.Errorf("failed to parse hash for DHT lookup: %w", err)
 	}
 
-	contacts, err := t.dhtNode.Get(hashBitmap)
-	if err != nil {
-		// Complete the placeholder request with error so waiters are unblocked
-		req.once.Do(func() {
-			req.result = taskResult{err: fmt.Errorf("failed to discover peers via DHT: %w", err)}
-			close(req.done)
-		})
-		return nil, fmt.Errorf("failed to discover peers via DHT: %w", err)
+	// Retry logic for DHT contact discovery
+	var contacts []dht.Contact
+
+	for attempt := 0; attempt <= t.dhtRetryAttempts; attempt++ {
+		if attempt > 0 {
+			t.logger.Debug("Retrying DHT contact discovery",
+				zap.String("hash", hash),
+				zap.Int("attempt", attempt),
+				zap.Int("maxAttempts", t.dhtRetryAttempts))
+		}
+
+		contacts, err = t.dhtNode.Get(hashBitmap)
+		if err != nil {
+			// Complete the placeholder request with error so waiters are unblocked
+			req.once.Do(func() {
+				req.result = taskResult{err: fmt.Errorf("failed to discover peers via DHT: %w", err)}
+				close(req.done)
+			})
+			return nil, fmt.Errorf("failed to discover peers via DHT: %w", err)
+		}
+
+		// If we found contacts, break out of retry loop
+		if len(contacts) > 0 {
+			break
+		}
+
+		// If this was the last attempt, we'll fall through to the error handling below
+		if attempt == t.dhtRetryAttempts {
+			t.logger.Debug("No contacts found after all retry attempts",
+				zap.String("hash", hash),
+				zap.Int("totalAttempts", t.dhtRetryAttempts+1))
+		}
 	}
 
 	if len(contacts) == 0 {

--- a/blob/transfer/peer_transfer.go
+++ b/blob/transfer/peer_transfer.go
@@ -47,6 +47,7 @@ type PeerTransfer struct {
 	timeout           time.Duration
 	maxPeers          int
 	dhtRetryAttempts  int
+	dhtRetryDelay     time.Duration
 	logger            *zap.Logger
 
 	// Concurrent execution fields
@@ -121,6 +122,23 @@ func WithPeerTransferDHTRetryAttempts(retryAttempts int) PeerTransferOption {
 	}
 }
 
+// WithPeerTransferDHTRetryDelay sets the delay between DHT retry attempts
+// Values less than or equal to 0 are treated as invalid and will be rejected with a warning
+func WithPeerTransferDHTRetryDelay(delay time.Duration) PeerTransferOption {
+	return func(t *PeerTransfer) {
+		if delay <= 0 {
+			if t.logger != nil {
+				t.logger.Warn("Invalid dhtRetryDelay value provided, must be > 0. Using default value instead.",
+					zap.Duration("provided", delay),
+					zap.Duration("default", 100*time.Millisecond))
+			}
+			// Keep the existing default value instead of silently changing it
+			return
+		}
+		t.dhtRetryDelay = delay
+	}
+}
+
 // NewPeerTransfer creates a new PeerTransfer with the specified DHT node and peer client factory
 // Returns an error if peerClientFactory is nil
 func NewPeerTransfer(dhtNode protocol.DHTNode, peerClientFactory protocol.PeerClientFactory, options ...PeerTransferOption) (*PeerTransfer, error) {
@@ -134,7 +152,8 @@ func NewPeerTransfer(dhtNode protocol.DHTNode, peerClientFactory protocol.PeerCl
 		peerClientFactory: peerClientFactory,
 		timeout:           30 * time.Second,
 		maxPeers:          5,
-		dhtRetryAttempts:  0, // Default to no retries
+		dhtRetryAttempts:  0,                      // Default to no retries
+		dhtRetryDelay:     100 * time.Millisecond, // Default retry delay
 		logger:            zap.NewNop(),
 		maxConcurrency:    DefaultMaxConcurrency,
 		backlog:           make(map[string]*blobRequest),
@@ -395,11 +414,32 @@ func (t *PeerTransfer) Get(ctx context.Context, hash string) ([]byte, error) {
 	var contacts []dht.Contact
 
 	for attempt := 0; attempt <= t.dhtRetryAttempts; attempt++ {
+		// Check if context is cancelled before retrying
+		if ctx.Err() != nil {
+			req.once.Do(func() {
+				req.result = taskResult{err: ctx.Err()}
+				close(req.done)
+			})
+			return nil, ctx.Err()
+		}
+
 		if attempt > 0 {
 			t.logger.Debug("Retrying DHT contact discovery",
 				zap.String("hash", hash),
 				zap.Int("attempt", attempt),
 				zap.Int("maxAttempts", t.dhtRetryAttempts))
+
+			// Add delay between retries using configurable delay with simple backoff
+			delay := time.Duration(attempt) * t.dhtRetryDelay
+			select {
+			case <-time.After(delay):
+			case <-ctx.Done():
+				req.once.Do(func() {
+					req.result = taskResult{err: ctx.Err()}
+					close(req.done)
+				})
+				return nil, ctx.Err()
+			}
 		}
 
 		contacts, err = t.dhtNode.Get(hashBitmap)


### PR DESCRIPTION
- Introduces `dhtRetryAttempts` configuration option to retry DHT contact discovery
- Adds `WithPeerTransferDHTRetryAttempts` option for configuring retry attempts
- Implements retry loop when initial DHT lookup returns no contacts
- Logs retry attempts at debug level for observability
- Maintains backward compatibility with default 0 retries
---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable retry capabilities for peer discovery, including options to adjust retry attempts and delay intervals between retries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->