### PR TITLE
feat(server): add transfer options support

### DIFF
--- a/blob/transfer/peer_transfer.go
+++ b/blob/transfer/peer_transfer.go
@@ -73,12 +73,20 @@ type PeerTransferOptionAdapter struct {
 }
 
 // NewPeerTransferOptionAdapter creates a new adapter from a PeerTransferOption
-func NewPeerTransferOptionAdapter(option PeerTransferOption) *PeerTransferOptionAdapter {
-	return &PeerTransferOptionAdapter{option: option}
+// Returns an error if the provided option is nil to prevent runtime panics
+func NewPeerTransferOptionAdapter(option PeerTransferOption) (*PeerTransferOptionAdapter, error) {
+	if option == nil {
+		return nil, fmt.Errorf("PeerTransferOption cannot be nil")
+	}
+	return &PeerTransferOptionAdapter{option: option}, nil
 }
 
 // Apply applies the wrapped PeerTransferOption to a PeerTransfer instance
 func (a *PeerTransferOptionAdapter) Apply(transfer any) error {
+	if a.option == nil {
+		return fmt.Errorf("PeerTransferOptionAdapter has nil option")
+	}
+
 	peerTransfer, ok := transfer.(*PeerTransfer)
 	if !ok {
 		return fmt.Errorf("expected *PeerTransfer, got %T", transfer)
@@ -166,32 +174,62 @@ func WithPeerTransferDHTRetryDelay(delay time.Duration) PeerTransferOption {
 
 // WithPeerTransferTimeoutOption creates a TransferOption for setting peer transfer timeout
 func WithPeerTransferTimeoutOption(timeout time.Duration) TransferOption {
-	return NewPeerTransferOptionAdapter(WithPeerTransferTimeout(timeout))
+	adapter, err := NewPeerTransferOptionAdapter(WithPeerTransferTimeout(timeout))
+	if err != nil {
+		// This should never happen since WithPeerTransferTimeout never returns nil
+		panic(fmt.Errorf("failed to create peer transfer timeout option: %w", err))
+	}
+	return adapter
 }
 
 // WithPeerTransferMaxPeersOption creates a TransferOption for setting max peers
 func WithPeerTransferMaxPeersOption(maxPeers int) TransferOption {
-	return NewPeerTransferOptionAdapter(WithPeerTransferMaxPeers(maxPeers))
+	adapter, err := NewPeerTransferOptionAdapter(WithPeerTransferMaxPeers(maxPeers))
+	if err != nil {
+		// This should never happen since WithPeerTransferMaxPeers never returns nil
+		panic(fmt.Errorf("failed to create peer transfer max peers option: %w", err))
+	}
+	return adapter
 }
 
 // WithPeerTransferLoggerOption creates a TransferOption for setting peer transfer logger
 func WithPeerTransferLoggerOption(logger *zap.Logger) TransferOption {
-	return NewPeerTransferOptionAdapter(WithPeerTransferLogger(logger))
+	adapter, err := NewPeerTransferOptionAdapter(WithPeerTransferLogger(logger))
+	if err != nil {
+		// This should never happen since WithPeerTransferLogger never returns nil
+		panic(fmt.Errorf("failed to create peer transfer logger option: %w", err))
+	}
+	return adapter
 }
 
 // WithPeerTransferMaxConcurrencyOption creates a TransferOption for setting max concurrency
 func WithPeerTransferMaxConcurrencyOption(maxConcurrency int) TransferOption {
-	return NewPeerTransferOptionAdapter(WithPeerTransferMaxConcurrency(maxConcurrency))
+	adapter, err := NewPeerTransferOptionAdapter(WithPeerTransferMaxConcurrency(maxConcurrency))
+	if err != nil {
+		// This should never happen since WithPeerTransferMaxConcurrency never returns nil
+		panic(fmt.Errorf("failed to create peer transfer max concurrency option: %w", err))
+	}
+	return adapter
 }
 
 // WithPeerTransferDHTRetryAttemptsOption creates a TransferOption for setting DHT retry attempts
 func WithPeerTransferDHTRetryAttemptsOption(retryAttempts int) TransferOption {
-	return NewPeerTransferOptionAdapter(WithPeerTransferDHTRetryAttempts(retryAttempts))
+	adapter, err := NewPeerTransferOptionAdapter(WithPeerTransferDHTRetryAttempts(retryAttempts))
+	if err != nil {
+		// This should never happen since WithPeerTransferDHTRetryAttempts never returns nil
+		panic(fmt.Errorf("failed to create peer transfer DHT retry attempts option: %w", err))
+	}
+	return adapter
 }
 
 // WithPeerTransferDHTRetryDelayOption creates a TransferOption for setting DHT retry delay
 func WithPeerTransferDHTRetryDelayOption(delay time.Duration) TransferOption {
-	return NewPeerTransferOptionAdapter(WithPeerTransferDHTRetryDelay(delay))
+	adapter, err := NewPeerTransferOptionAdapter(WithPeerTransferDHTRetryDelay(delay))
+	if err != nil {
+		// This should never happen since WithPeerTransferDHTRetryDelay never returns nil
+		panic(fmt.Errorf("failed to create peer transfer DHT retry delay option: %w", err))
+	}
+	return adapter
 }
 
 // NewPeerTransfer creates a new PeerTransfer with the specified DHT node and peer client factory

--- a/blob/transfer/peer_transfer.go
+++ b/blob/transfer/peer_transfer.go
@@ -66,6 +66,27 @@ type PeerTransfer struct {
 // PeerTransferOption configures the peer transfer
 type PeerTransferOption func(*PeerTransfer)
 
+// PeerTransferOptionAdapter wraps PeerTransferOption to implement TransferOption interface
+// This allows PeerTransferOption functions to be used with the generic TransferOption interface
+type PeerTransferOptionAdapter struct {
+	option PeerTransferOption
+}
+
+// NewPeerTransferOptionAdapter creates a new adapter from a PeerTransferOption
+func NewPeerTransferOptionAdapter(option PeerTransferOption) *PeerTransferOptionAdapter {
+	return &PeerTransferOptionAdapter{option: option}
+}
+
+// Apply applies the wrapped PeerTransferOption to a PeerTransfer instance
+func (a *PeerTransferOptionAdapter) Apply(transfer any) error {
+	peerTransfer, ok := transfer.(*PeerTransfer)
+	if !ok {
+		return fmt.Errorf("expected *PeerTransfer, got %T", transfer)
+	}
+	a.option(peerTransfer)
+	return nil
+}
+
 // WithPeerTransferTimeout sets the timeout for peer transfers
 func WithPeerTransferTimeout(timeout time.Duration) PeerTransferOption {
 	return func(t *PeerTransfer) {
@@ -138,6 +159,39 @@ func WithPeerTransferDHTRetryDelay(delay time.Duration) PeerTransferOption {
 		}
 		t.dhtRetryDelay = delay
 	}
+}
+
+// Convenience functions for creating TransferOption instances from PeerTransferOption functions
+// These make it easier to use PeerTransferOption functions with the ServerBuilder
+
+// WithPeerTransferTimeoutOption creates a TransferOption for setting peer transfer timeout
+func WithPeerTransferTimeoutOption(timeout time.Duration) TransferOption {
+	return NewPeerTransferOptionAdapter(WithPeerTransferTimeout(timeout))
+}
+
+// WithPeerTransferMaxPeersOption creates a TransferOption for setting max peers
+func WithPeerTransferMaxPeersOption(maxPeers int) TransferOption {
+	return NewPeerTransferOptionAdapter(WithPeerTransferMaxPeers(maxPeers))
+}
+
+// WithPeerTransferLoggerOption creates a TransferOption for setting peer transfer logger
+func WithPeerTransferLoggerOption(logger *zap.Logger) TransferOption {
+	return NewPeerTransferOptionAdapter(WithPeerTransferLogger(logger))
+}
+
+// WithPeerTransferMaxConcurrencyOption creates a TransferOption for setting max concurrency
+func WithPeerTransferMaxConcurrencyOption(maxConcurrency int) TransferOption {
+	return NewPeerTransferOptionAdapter(WithPeerTransferMaxConcurrency(maxConcurrency))
+}
+
+// WithPeerTransferDHTRetryAttemptsOption creates a TransferOption for setting DHT retry attempts
+func WithPeerTransferDHTRetryAttemptsOption(retryAttempts int) TransferOption {
+	return NewPeerTransferOptionAdapter(WithPeerTransferDHTRetryAttempts(retryAttempts))
+}
+
+// WithPeerTransferDHTRetryDelayOption creates a TransferOption for setting DHT retry delay
+func WithPeerTransferDHTRetryDelayOption(delay time.Duration) TransferOption {
+	return NewPeerTransferOptionAdapter(WithPeerTransferDHTRetryDelay(delay))
 }
 
 // NewPeerTransfer creates a new PeerTransfer with the specified DHT node and peer client factory

--- a/blob/transfer/peer_transfer_test.go
+++ b/blob/transfer/peer_transfer_test.go
@@ -1116,48 +1116,63 @@ func TestTransferOptionConvenienceFunctions(t *testing.T) {
 	dhtNode := protocolMocks.NewMockDHTNode(t)
 	peerClientFactory := protocol.DefaultPeerClientFactory()
 
-	transfer, err := NewPeerTransfer(dhtNode, peerClientFactory)
-	require.NoError(t, err)
-
 	t.Run("WithPeerTransferTimeoutOption", func(t *testing.T) {
+		transfer, err := NewPeerTransfer(dhtNode, peerClientFactory)
+		require.NoError(t, err)
+
 		option := WithPeerTransferTimeoutOption(90 * time.Second)
-		err := option.Apply(transfer)
+		err = option.Apply(transfer)
 		assert.NoError(t, err)
 		assert.Equal(t, 90*time.Second, transfer.timeout)
 	})
 
 	t.Run("WithPeerTransferMaxPeersOption", func(t *testing.T) {
+		transfer, err := NewPeerTransfer(dhtNode, peerClientFactory)
+		require.NoError(t, err)
+
 		option := WithPeerTransferMaxPeersOption(20)
-		err := option.Apply(transfer)
+		err = option.Apply(transfer)
 		assert.NoError(t, err)
 		assert.Equal(t, 20, transfer.maxPeers)
 	})
 
 	t.Run("WithPeerTransferLoggerOption", func(t *testing.T) {
+		transfer, err := NewPeerTransfer(dhtNode, peerClientFactory)
+		require.NoError(t, err)
+
 		customLogger := zaptest.NewLogger(t).Named("convenience_test")
 		option := WithPeerTransferLoggerOption(customLogger)
-		err := option.Apply(transfer)
+		err = option.Apply(transfer)
 		assert.NoError(t, err)
 		assert.Equal(t, customLogger, transfer.logger)
 	})
 
 	t.Run("WithPeerTransferMaxConcurrencyOption", func(t *testing.T) {
+		transfer, err := NewPeerTransfer(dhtNode, peerClientFactory)
+		require.NoError(t, err)
+
 		option := WithPeerTransferMaxConcurrencyOption(12)
-		err := option.Apply(transfer)
+		err = option.Apply(transfer)
 		assert.NoError(t, err)
 		assert.Equal(t, 12, transfer.maxConcurrency)
 	})
 
 	t.Run("WithPeerTransferDHTRetryAttemptsOption", func(t *testing.T) {
+		transfer, err := NewPeerTransfer(dhtNode, peerClientFactory)
+		require.NoError(t, err)
+
 		option := WithPeerTransferDHTRetryAttemptsOption(7)
-		err := option.Apply(transfer)
+		err = option.Apply(transfer)
 		assert.NoError(t, err)
 		assert.Equal(t, 7, transfer.dhtRetryAttempts)
 	})
 
 	t.Run("WithPeerTransferDHTRetryDelayOption", func(t *testing.T) {
+		transfer, err := NewPeerTransfer(dhtNode, peerClientFactory)
+		require.NoError(t, err)
+
 		option := WithPeerTransferDHTRetryDelayOption(300 * time.Millisecond)
-		err := option.Apply(transfer)
+		err = option.Apply(transfer)
 		assert.NoError(t, err)
 		assert.Equal(t, 300*time.Millisecond, transfer.dhtRetryDelay)
 	})

--- a/blob/transfer/peer_transfer_test.go
+++ b/blob/transfer/peer_transfer_test.go
@@ -987,12 +987,29 @@ func TestPeerTransferOptionAdapter(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, transfer)
 
+	t.Run("NewPeerTransferOptionAdapterWithNil", func(t *testing.T) {
+		// Test creating adapter with nil option
+		adapter, err := NewPeerTransferOptionAdapter(nil)
+		assert.Error(t, err)
+		assert.Nil(t, adapter)
+		assert.Contains(t, err.Error(), "PeerTransferOption cannot be nil")
+	})
+
+	t.Run("ApplyWithNilOption", func(t *testing.T) {
+		// Test applying adapter with nil option (shouldn't happen with constructor validation, but test defensive check)
+		adapter := &PeerTransferOptionAdapter{option: nil}
+		err = adapter.Apply(transfer)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "PeerTransferOptionAdapter has nil option")
+	})
+
 	t.Run("ApplyWithValidPeerTransfer", func(t *testing.T) {
 		// Test applying option to valid PeerTransfer
 		option := WithPeerTransferTimeout(60 * time.Second)
-		adapter := NewPeerTransferOptionAdapter(option)
+		adapter, err := NewPeerTransferOptionAdapter(option)
+		require.NoError(t, err)
 
-		err := adapter.Apply(transfer)
+		err = adapter.Apply(transfer)
 		assert.NoError(t, err)
 		assert.Equal(t, 60*time.Second, transfer.timeout)
 	})
@@ -1000,9 +1017,10 @@ func TestPeerTransferOptionAdapter(t *testing.T) {
 	t.Run("ApplyWithInvalidType", func(t *testing.T) {
 		// Test applying option to invalid type
 		option := WithPeerTransferTimeout(60 * time.Second)
-		adapter := NewPeerTransferOptionAdapter(option)
+		adapter, err := NewPeerTransferOptionAdapter(option)
+		require.NoError(t, err)
 
-		err := adapter.Apply("not a peer transfer")
+		err = adapter.Apply("not a peer transfer")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "expected *PeerTransfer, got string")
 	})
@@ -1010,9 +1028,10 @@ func TestPeerTransferOptionAdapter(t *testing.T) {
 	t.Run("ApplyWithNil", func(t *testing.T) {
 		// Test applying option to nil
 		option := WithPeerTransferTimeout(60 * time.Second)
-		adapter := NewPeerTransferOptionAdapter(option)
+		adapter, err := NewPeerTransferOptionAdapter(option)
+		require.NoError(t, err)
 
-		err := adapter.Apply(nil)
+		err = adapter.Apply(nil)
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "expected *PeerTransfer, got <nil>")
 	})
@@ -1031,8 +1050,9 @@ func TestPeerTransferOptionAdapter(t *testing.T) {
 		}
 
 		for _, option := range options {
-			adapter := NewPeerTransferOptionAdapter(option)
-			err := adapter.Apply(transfer2)
+			adapter, err := NewPeerTransferOptionAdapter(option)
+			require.NoError(t, err)
+			err = adapter.Apply(transfer2)
 			assert.NoError(t, err)
 		}
 
@@ -1050,7 +1070,8 @@ func TestPeerTransferOptionAdapter(t *testing.T) {
 		require.NoError(t, err)
 
 		option := WithPeerTransferLogger(customLogger)
-		adapter := NewPeerTransferOptionAdapter(option)
+		adapter, err := NewPeerTransferOptionAdapter(option)
+		require.NoError(t, err)
 
 		err = adapter.Apply(transfer3)
 		assert.NoError(t, err)
@@ -1076,8 +1097,9 @@ func TestPeerTransferOptionAdapter(t *testing.T) {
 		}
 
 		for _, option := range invalidOptions {
-			adapter := NewPeerTransferOptionAdapter(option)
-			err := adapter.Apply(transfer4)
+			adapter, err := NewPeerTransferOptionAdapter(option)
+			require.NoError(t, err)
+			err = adapter.Apply(transfer4)
 			assert.NoError(t, err, "Invalid options should not return errors, just warn")
 		}
 

--- a/blob/transfer/peer_transfer_test.go
+++ b/blob/transfer/peer_transfer_test.go
@@ -21,6 +21,7 @@ import (
 	"go.lumeweb.com/liblbry/storage"
 	"go.lumeweb.com/liblbry/storage/memory"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
 )
 
 // TestPeerServer represents a running peer server for testing
@@ -973,4 +974,169 @@ func TestPeerTransfer_Get_ConcurrentSameHash(t *testing.T) {
 	transfer.backlogMu.RUnlock()
 
 	assert.Equal(t, 0, backlogSize, "Backlog should be empty after all requests complete")
+}
+
+// TestPeerTransferOptionAdapter tests the PeerTransferOptionAdapter functionality
+func TestPeerTransferOptionAdapter(t *testing.T) {
+	_ = zaptest.NewLogger(t) // logger available for subtests but not used directly
+	dhtNode := protocolMocks.NewMockDHTNode(t)
+	peerClientFactory := protocol.DefaultPeerClientFactory()
+
+	// Create a peer transfer with default values
+	transfer, err := NewPeerTransfer(dhtNode, peerClientFactory)
+	require.NoError(t, err)
+	require.NotNil(t, transfer)
+
+	t.Run("ApplyWithValidPeerTransfer", func(t *testing.T) {
+		// Test applying option to valid PeerTransfer
+		option := WithPeerTransferTimeout(60 * time.Second)
+		adapter := NewPeerTransferOptionAdapter(option)
+
+		err := adapter.Apply(transfer)
+		assert.NoError(t, err)
+		assert.Equal(t, 60*time.Second, transfer.timeout)
+	})
+
+	t.Run("ApplyWithInvalidType", func(t *testing.T) {
+		// Test applying option to invalid type
+		option := WithPeerTransferTimeout(60 * time.Second)
+		adapter := NewPeerTransferOptionAdapter(option)
+
+		err := adapter.Apply("not a peer transfer")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expected *PeerTransfer, got string")
+	})
+
+	t.Run("ApplyWithNil", func(t *testing.T) {
+		// Test applying option to nil
+		option := WithPeerTransferTimeout(60 * time.Second)
+		adapter := NewPeerTransferOptionAdapter(option)
+
+		err := adapter.Apply(nil)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "expected *PeerTransfer, got <nil>")
+	})
+
+	t.Run("MultipleOptions", func(t *testing.T) {
+		// Test applying multiple options
+		transfer2, err := NewPeerTransfer(dhtNode, peerClientFactory)
+		require.NoError(t, err)
+
+		options := []PeerTransferOption{
+			WithPeerTransferTimeout(45 * time.Second),
+			WithPeerTransferMaxPeers(15),
+			WithPeerTransferMaxConcurrency(8),
+			WithPeerTransferDHTRetryAttempts(5),
+			WithPeerTransferDHTRetryDelay(250 * time.Millisecond),
+		}
+
+		for _, option := range options {
+			adapter := NewPeerTransferOptionAdapter(option)
+			err := adapter.Apply(transfer2)
+			assert.NoError(t, err)
+		}
+
+		assert.Equal(t, 45*time.Second, transfer2.timeout)
+		assert.Equal(t, 15, transfer2.maxPeers)
+		assert.Equal(t, 8, transfer2.maxConcurrency)
+		assert.Equal(t, 5, transfer2.dhtRetryAttempts)
+		assert.Equal(t, 250*time.Millisecond, transfer2.dhtRetryDelay)
+	})
+
+	t.Run("OptionWithLogger", func(t *testing.T) {
+		// Test applying logger option
+		customLogger := zaptest.NewLogger(t).Named("custom")
+		transfer3, err := NewPeerTransfer(dhtNode, peerClientFactory)
+		require.NoError(t, err)
+
+		option := WithPeerTransferLogger(customLogger)
+		adapter := NewPeerTransferOptionAdapter(option)
+
+		err = adapter.Apply(transfer3)
+		assert.NoError(t, err)
+		assert.Equal(t, customLogger, transfer3.logger)
+	})
+
+	t.Run("InvalidOptionValues", func(t *testing.T) {
+		// Test applying options with invalid values (should not change the transfer)
+		transfer4, err := NewPeerTransfer(dhtNode, peerClientFactory)
+		require.NoError(t, err)
+
+		originalConcurrency := transfer4.maxConcurrency
+		originalRetryAttempts := transfer4.dhtRetryAttempts
+		originalRetryDelay := transfer4.dhtRetryDelay
+
+		// Apply invalid options
+		invalidOptions := []PeerTransferOption{
+			WithPeerTransferMaxConcurrency(0),    // Invalid: < 1
+			WithPeerTransferMaxConcurrency(-5),   // Invalid: < 1
+			WithPeerTransferDHTRetryAttempts(-1), // Invalid: < 0
+			WithPeerTransferDHTRetryDelay(0),     // Invalid: <= 0
+			WithPeerTransferDHTRetryDelay(-1),    // Invalid: <= 0
+		}
+
+		for _, option := range invalidOptions {
+			adapter := NewPeerTransferOptionAdapter(option)
+			err := adapter.Apply(transfer4)
+			assert.NoError(t, err, "Invalid options should not return errors, just warn")
+		}
+
+		// Values should remain unchanged
+		assert.Equal(t, originalConcurrency, transfer4.maxConcurrency)
+		assert.Equal(t, originalRetryAttempts, transfer4.dhtRetryAttempts)
+		assert.Equal(t, originalRetryDelay, transfer4.dhtRetryDelay)
+	})
+}
+
+// TestTransferOptionConvenienceFunctions tests the convenience functions
+func TestTransferOptionConvenienceFunctions(t *testing.T) {
+	_ = zaptest.NewLogger(t) // logger available for subtests but not used directly
+	dhtNode := protocolMocks.NewMockDHTNode(t)
+	peerClientFactory := protocol.DefaultPeerClientFactory()
+
+	transfer, err := NewPeerTransfer(dhtNode, peerClientFactory)
+	require.NoError(t, err)
+
+	t.Run("WithPeerTransferTimeoutOption", func(t *testing.T) {
+		option := WithPeerTransferTimeoutOption(90 * time.Second)
+		err := option.Apply(transfer)
+		assert.NoError(t, err)
+		assert.Equal(t, 90*time.Second, transfer.timeout)
+	})
+
+	t.Run("WithPeerTransferMaxPeersOption", func(t *testing.T) {
+		option := WithPeerTransferMaxPeersOption(20)
+		err := option.Apply(transfer)
+		assert.NoError(t, err)
+		assert.Equal(t, 20, transfer.maxPeers)
+	})
+
+	t.Run("WithPeerTransferLoggerOption", func(t *testing.T) {
+		customLogger := zaptest.NewLogger(t).Named("convenience_test")
+		option := WithPeerTransferLoggerOption(customLogger)
+		err := option.Apply(transfer)
+		assert.NoError(t, err)
+		assert.Equal(t, customLogger, transfer.logger)
+	})
+
+	t.Run("WithPeerTransferMaxConcurrencyOption", func(t *testing.T) {
+		option := WithPeerTransferMaxConcurrencyOption(12)
+		err := option.Apply(transfer)
+		assert.NoError(t, err)
+		assert.Equal(t, 12, transfer.maxConcurrency)
+	})
+
+	t.Run("WithPeerTransferDHTRetryAttemptsOption", func(t *testing.T) {
+		option := WithPeerTransferDHTRetryAttemptsOption(7)
+		err := option.Apply(transfer)
+		assert.NoError(t, err)
+		assert.Equal(t, 7, transfer.dhtRetryAttempts)
+	})
+
+	t.Run("WithPeerTransferDHTRetryDelayOption", func(t *testing.T) {
+		option := WithPeerTransferDHTRetryDelayOption(300 * time.Millisecond)
+		err := option.Apply(transfer)
+		assert.NoError(t, err)
+		assert.Equal(t, 300*time.Millisecond, transfer.dhtRetryDelay)
+	})
 }

--- a/blob/transfer/peer_transfer_test.go
+++ b/blob/transfer/peer_transfer_test.go
@@ -978,7 +978,6 @@ func TestPeerTransfer_Get_ConcurrentSameHash(t *testing.T) {
 
 // TestPeerTransferOptionAdapter tests the PeerTransferOptionAdapter functionality
 func TestPeerTransferOptionAdapter(t *testing.T) {
-	_ = zaptest.NewLogger(t) // logger available for subtests but not used directly
 	dhtNode := protocolMocks.NewMockDHTNode(t)
 	peerClientFactory := protocol.DefaultPeerClientFactory()
 
@@ -1112,7 +1111,6 @@ func TestPeerTransferOptionAdapter(t *testing.T) {
 
 // TestTransferOptionConvenienceFunctions tests the convenience functions
 func TestTransferOptionConvenienceFunctions(t *testing.T) {
-	_ = zaptest.NewLogger(t) // logger available for subtests but not used directly
 	dhtNode := protocolMocks.NewMockDHTNode(t)
 	peerClientFactory := protocol.DefaultPeerClientFactory()
 

--- a/blob/transfer/transfer.go
+++ b/blob/transfer/transfer.go
@@ -7,3 +7,12 @@ type Transfer interface {
 	Get(ctx context.Context, hash string) ([]byte, error)
 	Name() string
 }
+
+// TransferOption defines a generic interface for configuring transfer implementations
+// This allows the server builder to remain agnostic about specific transfer types
+// while providing type-safe configuration for each implementation.
+type TransferOption interface {
+	// Apply applies the option to the given transfer implementation
+	// The transfer parameter should be type-asserted to the expected type
+	Apply(transfer any) error
+}

--- a/blob/transfer/transfer.go
+++ b/blob/transfer/transfer.go
@@ -8,11 +8,39 @@ type Transfer interface {
 	Name() string
 }
 
-// TransferOption defines a generic interface for configuring transfer implementations
+// TransferOption defines a generic interface for configuring transfer implementations.
 // This allows the server builder to remain agnostic about specific transfer types
 // while providing type-safe configuration for each implementation.
+//
+// Contract and Expectations:
+//   - Reusability: Implementations MUST be reusable and safe to apply to multiple
+//     transfer instances of the same concrete type.
+//   - Side Effects: Implementations SHOULD be side-effect free beyond configuring
+//     the target transfer instance. Avoid modifying global state.
+//   - Multiple Calls: Implementations MUST be safe to call multiple times on the
+//     same transfer instance, with subsequent calls being idempotent or having
+//     well-defined cumulative behavior.
+//   - Type Safety: Implementations MUST perform type assertion on the transfer
+//     parameter and return a descriptive error if the type is unsupported.
+//   - Error Handling: Implementations SHOULD return errors for invalid configurations
+//     or type mismatches, but MUST NOT panic for expected failure conditions.
+//
+// Usage Pattern:
+//
+//	Options are typically created once and reused across multiple transfer instances
+//	during server construction. The builder pattern accumulates options and applies
+//	them to each compatible transfer implementation.
 type TransferOption interface {
-	// Apply applies the option to the given transfer implementation
-	// The transfer parameter should be type-asserted to the expected type
+	// Apply applies the option to the given transfer implementation.
+	// The transfer parameter should be type-asserted to the expected type.
+	//
+	// Returns an error if:
+	//   - The transfer parameter is not of the expected concrete type
+	//   - The option configuration is invalid
+	//   - The option cannot be applied due to transfer state constraints
+	//
+	// The implementation must be safe for concurrent use if the option instance
+	// is shared across goroutines, and must not modify the option's internal state
+	// in a way that affects subsequent applications.
 	Apply(transfer any) error
 }

--- a/server/builder.go
+++ b/server/builder.go
@@ -240,10 +240,15 @@ func (b *ServerBuilder) WithLogger(logger *zap.Logger) *ServerBuilder {
 	return b
 }
 
-// WithTransferOptions sets transfer options that will be applied to all transfer implementations
+// WithTransferOptions adds transfer options that will be applied to all transfer implementations
 // These options are applied during transfer creation and allow fine-tuning of transfer behavior
 func (b *ServerBuilder) WithTransferOptions(options ...transfer.TransferOption) *ServerBuilder {
-	b.transferOptions = append(b.transferOptions, options...)
+	// Filter out nil options to prevent nil interface panics when Apply is called
+	for _, option := range options {
+		if option != nil {
+			b.transferOptions = append(b.transferOptions, option)
+		}
+	}
 	return b
 }
 

--- a/server/builder.go
+++ b/server/builder.go
@@ -25,6 +25,7 @@ type ServerBuilder struct {
 	logger             *zap.Logger
 	dhtWorkers         int
 	dhtBatchSize       int
+	transferOptions    []transfer.TransferOption
 }
 
 // NewServerBuilder creates a new ServerBuilder instance
@@ -39,6 +40,7 @@ func NewServerBuilder() *ServerBuilder {
 		logger:             zap.NewNop(),                    // Default to no-op logger
 		dhtWorkers:         DefaultDHTAnnouncerWorkers,      // Default value
 		dhtBatchSize:       DefaultDHTAnnouncementBatchSize, // Default batch size
+		transferOptions:    make([]transfer.TransferOption, 0),
 	}
 }
 
@@ -238,6 +240,13 @@ func (b *ServerBuilder) WithLogger(logger *zap.Logger) *ServerBuilder {
 	return b
 }
 
+// WithTransferOptions sets transfer options that will be applied to all transfer implementations
+// These options are applied during transfer creation and allow fine-tuning of transfer behavior
+func (b *ServerBuilder) WithTransferOptions(options ...transfer.TransferOption) *ServerBuilder {
+	b.transferOptions = append(b.transferOptions, options...)
+	return b
+}
+
 // WithDHTWorkers sets the number of workers for DHT announcements
 func (b *ServerBuilder) WithDHTWorkers(workers int) *ServerBuilder {
 	if workers <= 0 {
@@ -275,13 +284,13 @@ func (b *ServerBuilder) WithExistingDHT(dhtNode protocol.DHTNode) *ServerBuilder
 // createDefaultTransfers creates a slice of transfer.Transfer instances based on enabled protocols.
 // Returns an empty slice if no DHT node is provided, as DHT is required for peer-based transfers.
 func (b *ServerBuilder) createDefaultTransfers(dhtNode protocol.DHTNode) ([]transfer.Transfer, error) {
-	return createDefaultTransfersWithLogger(dhtNode, b.logger)
+	return createDefaultTransfersWithLogger(dhtNode, b.logger, b.transferOptions)
 }
 
 // createDefaultTransfersWithLogger creates a slice of transfer.Transfer instances based on enabled protocols.
 // This is a standalone helper function that avoids capturing the ServerBuilder instance.
 // Returns an empty slice if no DHT node is provided, as DHT is required for peer-based transfers.
-func createDefaultTransfersWithLogger(dhtNode protocol.DHTNode, logger *zap.Logger) ([]transfer.Transfer, error) {
+func createDefaultTransfersWithLogger(dhtNode protocol.DHTNode, logger *zap.Logger, transferOptions []transfer.TransferOption) ([]transfer.Transfer, error) {
 	if logger == nil {
 		logger = zap.NewNop()
 	}
@@ -299,6 +308,15 @@ func createDefaultTransfersWithLogger(dhtNode protocol.DHTNode, logger *zap.Logg
 		if err != nil {
 			return nil, fmt.Errorf("failed to create peer transfer: %w", err)
 		}
+
+		// Apply transfer options to the peer transfer
+		for _, option := range transferOptions {
+			if err := option.Apply(peerTransfer); err != nil {
+				logger.Warn("Failed to apply transfer option", zap.Error(err))
+				// Continue with other options even if one fails
+			}
+		}
+
 		transfers = append(transfers, peerTransfer)
 	}
 
@@ -347,10 +365,12 @@ func (b *ServerBuilder) Build() (Server, error) {
 		server.acquirerFactory = b.acquirerFactory
 	}
 	if b.useDefaultAcquirer {
-		// Capture only the logger to avoid long-lived builder capture
+		// Capture only the logger and transfer options to avoid long-lived builder capture
 		logger := b.logger
+		transferOptions := make([]transfer.TransferOption, len(b.transferOptions))
+		copy(transferOptions, b.transferOptions)
 		server.acquirerFactory = func(dhtNode protocol.DHTNode, store storage.BlobStore) (liblbry.BlobAcquirer, error) {
-			transfers, err := createDefaultTransfersWithLogger(dhtNode, logger)
+			transfers, err := createDefaultTransfersWithLogger(dhtNode, logger, transferOptions)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create default transfers: %w", err)
 			}

--- a/server/builder.go
+++ b/server/builder.go
@@ -243,11 +243,12 @@ func (b *ServerBuilder) WithLogger(logger *zap.Logger) *ServerBuilder {
 // WithTransferOptions adds transfer options that will be applied to all transfer implementations
 // These options are applied during transfer creation and allow fine-tuning of transfer behavior
 func (b *ServerBuilder) WithTransferOptions(options ...transfer.TransferOption) *ServerBuilder {
-	// Filter out nil options to prevent nil interface panics when Apply is called
 	for _, option := range options {
-		if option != nil {
-			b.transferOptions = append(b.transferOptions, option)
+		if option == nil {
+			b.logger.Warn("Ignoring nil transfer option")
+			continue
 		}
+		b.transferOptions = append(b.transferOptions, option)
 	}
 	return b
 }

--- a/server/builder.go
+++ b/server/builder.go
@@ -318,7 +318,11 @@ func createDefaultTransfersWithLogger(dhtNode protocol.DHTNode, logger *zap.Logg
 		// Apply transfer options to the peer transfer
 		for _, option := range transferOptions {
 			if err := option.Apply(peerTransfer); err != nil {
-				logger.Warn("Failed to apply transfer option", zap.Error(err))
+				logger.Warn(
+					"Failed to apply transfer option",
+					zap.Error(err),
+					zap.String("option_type", fmt.Sprintf("%T", option)),
+				)
 				// Continue with other options even if one fails
 			}
 		}

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -2,12 +2,16 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/liblbry"
+	"go.lumeweb.com/liblbry/blob/transfer"
 	liblbryerrors "go.lumeweb.com/liblbry/errors"
 	"go.lumeweb.com/liblbry/mocks"
 	"go.lumeweb.com/liblbry/protocol"
@@ -19,17 +23,19 @@ import (
 	"go.uber.org/zap/zaptest"
 )
 
-// Test constants for protocol ports
-// These values are chosen to avoid conflicts with standard ports
-// and to clearly distinguish between different protocol types
-const (
-	testPortPeer       = 8080
-	testPortReflector  = 9090
-	testPortDHT        = 4444
-	testPortPeer2      = 5567
-	testPortReflector2 = 5566
-	testPortDHT2       = 5555
-)
+// getFreePort returns an available port number for testing
+// This function dynamically allocates ports to avoid conflicts during parallel test execution
+func getFreePort(t *testing.T) int {
+	t.Helper()
+
+	addr, err := net.Listen("tcp", ":0")
+	if err != nil {
+		t.Fatalf("Failed to get free port: %v", err)
+	}
+	defer addr.Close()
+
+	return addr.Addr().(*net.TCPAddr).Port
+}
 
 // builderTestMocks holds all common mocks used in builder tests
 type builderTestMocks struct {
@@ -172,13 +178,15 @@ func TestServerBuilder_WithLogger(t *testing.T) {
 // TestServerBuilder_WithPeer verifies peer protocol configuration with default and custom ports
 // This test ensures that peer config can be correctly configured with either default or custom ports
 func TestServerBuilder_WithPeer(t *testing.T) {
+	customPort := getFreePort(t)
+
 	tests := []struct {
 		name         string
 		port         int
 		expectedPort int
 	}{
 		{"DefaultPort", 0, DefaultPeerPort},
-		{"CustomPort", testPortPeer, testPortPeer},
+		{"CustomPort", customPort, customPort},
 	}
 
 	for _, tt := range tests {
@@ -201,13 +209,15 @@ func TestServerBuilder_WithPeer(t *testing.T) {
 // TestServerBuilder_WithReflector verifies reflector protocol configuration with default and custom ports
 // This test ensures that reflector config can be correctly configured with either default or custom ports
 func TestServerBuilder_WithReflector(t *testing.T) {
+	customPort := getFreePort(t)
+
 	tests := []struct {
 		name         string
 		port         int
 		expectedPort int
 	}{
 		{"DefaultPort", 0, DefaultReflectorPort},
-		{"CustomPort", testPortReflector, testPortReflector},
+		{"CustomPort", customPort, customPort},
 	}
 
 	for _, tt := range tests {
@@ -230,13 +240,15 @@ func TestServerBuilder_WithReflector(t *testing.T) {
 // TestServerBuilder_WithDHT verifies DHT protocol configuration with default and custom ports
 // This test ensures that DHT config can be correctly configured with either default or custom ports
 func TestServerBuilder_WithDHT(t *testing.T) {
+	customPort := getFreePort(t)
+
 	tests := []struct {
 		name         string
 		port         int
 		expectedPort int
 	}{
 		{"DefaultPort", 0, DefaultDHTPort},
-		{"CustomPort", testPortDHT, testPortDHT},
+		{"CustomPort", customPort, customPort},
 	}
 
 	for _, tt := range tests {
@@ -260,7 +272,7 @@ func TestServerBuilder_WithDHT(t *testing.T) {
 // This test ensures that a server can be properly constructed when all required components are provided
 func TestServerBuilder_Build_Success(t *testing.T) {
 	builder, testMocks := setupBuilderWithMocks(t)
-	builder.WithPeer(testPortPeer2)
+	builder.WithPeer(getFreePort(t))
 
 	server, err := builder.Build()
 
@@ -282,9 +294,9 @@ func TestServerBuilder_Build_Success(t *testing.T) {
 func TestServerBuilder_Build_MultipleProtocols(t *testing.T) {
 	builder, _ := setupBuilderWithMocks(t)
 	builder.
-		WithPeer(testPortPeer2).
-		WithReflector(testPortReflector2).
-		WithDHT(testPortDHT2)
+		WithPeer(getFreePort(t)).
+		WithReflector(getFreePort(t)).
+		WithDHT(getFreePort(t))
 
 	server, err := builder.Build()
 
@@ -309,7 +321,7 @@ func TestServerBuilder_Build_Errors(t *testing.T) {
 			name: "NoStorage",
 			setupBuilder: func(t *testing.T) *ServerBuilder {
 				builder := NewServerBuilder()
-				builder.WithPeer(testPortPeer2)
+				builder.WithPeer(getFreePort(t))
 				return builder
 			},
 			expectedError: "storage is required",
@@ -351,14 +363,281 @@ func TestServerBuilder_ChainedMethods(t *testing.T) {
 		WithStorage(testMocks.storage).
 		WithAcquirer(testMocks.acquirer).
 		WithAccessControl(testMocks.accessControl).
-		WithPeer(testPortPeer).
-		WithReflector(testPortReflector).
-		WithDHT(testPortDHT).
+		WithPeer(getFreePort(t)).
+		WithReflector(getFreePort(t)).
+		WithDHT(getFreePort(t)).
 		WithLogger(testMocks.logger).
 		Build()
 
 	require.NoError(t, err)
 	assert.NotNil(t, server)
+}
+
+// TestWithTransferOptions tests the WithTransferOptions functionality
+func TestWithTransferOptions(t *testing.T) {
+	t.Run("WithTransferOptionsBasic", func(t *testing.T) {
+		// Create fresh mocks for this test to avoid conflicts
+		testMocks := setupBuilderMocks(t)
+
+		// Set up mock expectations for List method calls during DHT blob announcement
+		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithPeer(getFreePort(t)).
+			WithDHT(getFreePort(t)).
+			WithDefaultAcquirer().
+			WithTransferOptions(
+				transfer.WithPeerTransferTimeoutOption(60*time.Second),
+				transfer.WithPeerTransferMaxPeersOption(10),
+			).
+			WithLogger(testMocks.logger)
+
+		// Verify builder has transfer options
+		assert.Len(t, builder.transferOptions, 2)
+
+		server, err := builder.Build()
+		require.NoError(t, err)
+		assert.NotNil(t, server)
+
+		// Test that the server can be started and stopped
+		ctx := context.Background()
+		err = server.Start(ctx)
+		require.NoError(t, err)
+
+		err = server.Stop(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("WithTransferOptionsEmpty", func(t *testing.T) {
+		// Create fresh mocks for this test to avoid conflicts
+		testMocks := setupBuilderMocks(t)
+
+		// Set up mock expectations for List method calls during DHT blob announcement
+		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithPeer(getFreePort(t)).
+			WithDHT(getFreePort(t)).
+			WithDefaultAcquirer().
+			WithTransferOptions(). // Empty options
+			WithLogger(testMocks.logger)
+
+		assert.Len(t, builder.transferOptions, 0)
+
+		server, err := builder.Build()
+		require.NoError(t, err)
+		assert.NotNil(t, server)
+	})
+
+	t.Run("WithTransferOptionsMultipleCalls", func(t *testing.T) {
+		// Create fresh mocks for this test to avoid conflicts
+		testMocks := setupBuilderMocks(t)
+
+		// Set up mock expectations for List method calls during DHT blob announcement
+		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithPeer(getFreePort(t)).
+			WithDHT(getFreePort(t)).
+			WithDefaultAcquirer().
+			WithTransferOptions(transfer.WithPeerTransferTimeoutOption(30*time.Second)).
+			WithTransferOptions(transfer.WithPeerTransferMaxPeersOption(5), transfer.WithPeerTransferMaxConcurrencyOption(8)).
+			WithLogger(testMocks.logger)
+
+		// Should have 3 options total (1 from first call, 2 from second call)
+		assert.Len(t, builder.transferOptions, 3)
+
+		server, err := builder.Build()
+		require.NoError(t, err)
+		assert.NotNil(t, server)
+	})
+
+	t.Run("WithTransferOptionsWithoutDefaultAcquirer", func(t *testing.T) {
+		// Create fresh mocks for this test to avoid conflicts
+		testMocks := setupBuilderMocks(t)
+
+		// Set up mock expectations for List method calls during DHT blob announcement
+		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+
+		// Transfer options should be stored even without default acquirer
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithPeer(getFreePort(t)).
+			WithDHT(getFreePort(t)).
+			WithTransferOptions(transfer.WithPeerTransferTimeoutOption(45 * time.Second)).
+			WithLogger(testMocks.logger)
+
+		assert.Len(t, builder.transferOptions, 1)
+
+		// Should still build successfully with custom acquirer
+		builder.WithAcquirer(testMocks.acquirer)
+		server, err := builder.Build()
+		require.NoError(t, err)
+		assert.NotNil(t, server)
+	})
+
+	t.Run("WithTransferOptionsAppliedToTransfer", func(t *testing.T) {
+		// This test verifies that transfer options are actually applied to the created transfers
+		logger := zaptest.NewLogger(t)
+
+		builder := NewServerBuilder().
+			WithStorage(memory.NewMemoryStore()).
+			WithPeer(getFreePort(t)).
+			WithDHT(getFreePort(t)).
+			WithDefaultAcquirer().
+			WithTransferOptions(
+				transfer.WithPeerTransferTimeoutOption(75*time.Second),
+				transfer.WithPeerTransferMaxPeersOption(12),
+				transfer.WithPeerTransferMaxConcurrencyOption(6),
+				transfer.WithPeerTransferLoggerOption(logger.Named("test_transfer")),
+			).
+			WithLogger(logger)
+
+		server, err := builder.Build()
+		require.NoError(t, err)
+
+		// Start the server to initialize the acquirer
+		ctx := context.Background()
+		err = server.Start(ctx)
+		require.NoError(t, err)
+
+		// Cast to DefaultServer to access AcquireBlob method
+		defaultServer := server.(*DefaultServer)
+
+		// Test blob acquisition directly on server to verify transfers are working with applied options
+		testHash := "1234567890123456789012345678901234567890123456789012345678901234"
+
+		// This will fail because we don't have real peers, but it will exercise the transfer
+		// and verify that the options were applied without causing panics
+		_, err = defaultServer.AcquireBlob(ctx, testHash)
+		// We expect this to fail (no peers), but not panic due to misconfigured options
+		assert.Error(t, err)
+
+		err = server.Stop(ctx)
+		require.NoError(t, err)
+	})
+
+	t.Run("WithTransferOptionsWithInvalidOption", func(t *testing.T) {
+		// Create fresh mocks for this test to avoid conflicts
+		testMocks := setupBuilderMocks(t)
+
+		// Set up mock expectations for List method calls during DHT blob announcement
+		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+
+		// Test that invalid options don't break the build process
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithPeer(getFreePort(t)).
+			WithDHT(getFreePort(t)).
+			WithDefaultAcquirer().
+			WithTransferOptions(
+				transfer.WithPeerTransferMaxConcurrencyOption(0),       // Invalid, should be ignored
+				transfer.WithPeerTransferTimeoutOption(30*time.Second), // Valid
+			).
+			WithLogger(testMocks.logger)
+
+		server, err := builder.Build()
+		require.NoError(t, err)
+		assert.NotNil(t, server)
+
+		// Server should still work despite invalid option
+		ctx := context.Background()
+		err = server.Start(ctx)
+		require.NoError(t, err)
+
+		err = server.Stop(ctx)
+		require.NoError(t, err)
+	})
+}
+
+// TestTransferOptionsIntegration tests the full integration of transfer options
+func TestTransferOptionsIntegration(t *testing.T) {
+	logger := zaptest.NewLogger(t)
+
+	t.Run("FullIntegrationWithRealDHT", func(t *testing.T) {
+		// Create a real DHT node for more realistic testing
+		dhtPort := getFreePort(t)
+		dhtNode, err := protocol.NewDHTNodeWithDefaults(
+			protocol.WithDHTAddress(fmt.Sprintf("127.0.0.1:%d", dhtPort)),
+		)
+		require.NoError(t, err)
+
+		builder := NewServerBuilder().
+			WithStorage(memory.NewMemoryStore()).
+			WithExistingDHT(dhtNode).
+			WithPeer(getFreePort(t)).
+			WithDefaultAcquirer().
+			WithTransferOptions(
+				transfer.WithPeerTransferTimeoutOption(20*time.Second),
+				transfer.WithPeerTransferMaxPeersOption(3),
+				transfer.WithPeerTransferMaxConcurrencyOption(2),
+				transfer.WithPeerTransferDHTRetryAttemptsOption(1),
+				transfer.WithPeerTransferDHTRetryDelayOption(50*time.Millisecond),
+				transfer.WithPeerTransferLoggerOption(logger.Named("integration_test")),
+			).
+			WithLogger(logger)
+
+		server, err := builder.Build()
+		require.NoError(t, err)
+
+		// Start the server
+		ctx := context.Background()
+		err = server.Start(ctx)
+		require.NoError(t, err)
+
+		// Cast to DefaultServer to access AcquireBlob method
+		defaultServer := server.(*DefaultServer)
+
+		// Test blob acquisition directly on server (will fail due to no peers, but tests the transfer configuration)
+		testHash := "1234567890123456789012345678901234567890123456789012345678901234"
+
+		_, err = defaultServer.AcquireBlob(ctx, testHash)
+		assert.Error(t, err) // Expected to fail
+
+		// Stop the server - this will also shutdown the DHT node
+		err = server.Stop(ctx)
+		require.NoError(t, err)
+
+		// Manually shutdown the DHT node to avoid resource leaks
+		dhtNode.Shutdown()
+	})
+
+	t.Run("CustomTransferOption", func(t *testing.T) {
+		testMocks := setupBuilderMocks(t)
+
+		// Set up mock expectations for List method calls during DHT blob announcement
+		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+
+		// Test creating a custom transfer option
+		customOption := transfer.NewPeerTransferOptionAdapter(
+			transfer.WithPeerTransferTimeout(120 * time.Second),
+		)
+
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithPeer(getFreePort(t)).
+			WithDHT(getFreePort(t)).
+			WithDefaultAcquirer().
+			WithTransferOptions(
+				customOption,
+				transfer.WithPeerTransferMaxPeersOption(8),
+			).
+			WithLogger(testMocks.logger)
+
+		server, err := builder.Build()
+		require.NoError(t, err)
+		assert.NotNil(t, server)
+
+		ctx := context.Background()
+		err = server.Start(ctx)
+		require.NoError(t, err)
+
+		err = server.Stop(ctx)
+		require.NoError(t, err)
+	})
 }
 
 // TestServerBuilder_ProtocolOverwrite verifies that protocol configurations can be overwritten
@@ -374,25 +653,25 @@ func TestServerBuilder_ProtocolOverwrite(t *testing.T) {
 			name:         "PeerProtocol",
 			protocolName: ProtocolPeer,
 			setupFunc: func(b *ServerBuilder) {
-				b.WithPeer(testPortPeer2).WithPeer(testPortPeer)
+				b.WithPeer(getFreePort(t)).WithPeer(getFreePort(t))
 			},
-			expectedPort: testPortPeer,
+			expectedPort: 0, // Will be set in test
 		},
 		{
 			name:         "ReflectorProtocol",
 			protocolName: ProtocolReflector,
 			setupFunc: func(b *ServerBuilder) {
-				b.WithReflector(testPortReflector2).WithReflector(testPortReflector)
+				b.WithReflector(getFreePort(t)).WithReflector(getFreePort(t))
 			},
-			expectedPort: testPortReflector,
+			expectedPort: 0, // Will be set in test
 		},
 		{
 			name:         "DHTProtocol",
 			protocolName: ProtocolDHT,
 			setupFunc: func(b *ServerBuilder) {
-				b.WithDHT(testPortDHT2).WithDHT(testPortDHT)
+				b.WithDHT(getFreePort(t)).WithDHT(getFreePort(t))
 			},
-			expectedPort: testPortDHT,
+			expectedPort: 0, // Will be set in test
 		},
 	}
 
@@ -401,13 +680,31 @@ func TestServerBuilder_ProtocolOverwrite(t *testing.T) {
 			testMocks := setupBuilderMocks(t)
 			builder := NewServerBuilder().WithStorage(testMocks.storage)
 
-			tt.setupFunc(builder)
+			// For protocol overwrite tests, we need to capture the final port
+			var finalPort int
+			switch tt.name {
+			case "PeerProtocol":
+				firstPort := getFreePort(t)
+				secondPort := getFreePort(t)
+				builder.WithPeer(firstPort).WithPeer(secondPort)
+				finalPort = secondPort
+			case "ReflectorProtocol":
+				firstPort := getFreePort(t)
+				secondPort := getFreePort(t)
+				builder.WithReflector(firstPort).WithReflector(secondPort)
+				finalPort = secondPort
+			case "DHTProtocol":
+				firstPort := getFreePort(t)
+				secondPort := getFreePort(t)
+				builder.WithDHT(firstPort).WithDHT(secondPort)
+				finalPort = secondPort
+			}
 
 			server, err := builder.Build()
 			require.NoError(t, err)
 
 			defaultServer := server.(*DefaultServer)
-			assertServerProtocolConfig(t, defaultServer, tt.protocolName, tt.expectedPort)
+			assertServerProtocolConfig(t, defaultServer, tt.protocolName, finalPort)
 		})
 	}
 }
@@ -570,9 +867,11 @@ func TestServerBuilder_WithDHTAddress(t *testing.T) {
 // TestServerBuilder_WithFixedPeerPort verifies that WithFixedPeerPort correctly sets the fixed peer port
 func TestServerBuilder_WithFixedPeerPort(t *testing.T) {
 	t.Run("FixedPeerPort with existing peer config", func(t *testing.T) {
+		peerPort := getFreePort(t)
+		fixedPort := getFreePort(t)
 		builder := NewServerBuilder().
-			WithPeer(testPortPeer).
-			WithFixedPeerPort(testPortPeer2).
+			WithPeer(peerPort).
+			WithFixedPeerPort(fixedPort).
 			WithStorage(memory.NewMemoryStore())
 
 		server, err := builder.Build()
@@ -580,13 +879,14 @@ func TestServerBuilder_WithFixedPeerPort(t *testing.T) {
 
 		defaultServer := server.(*DefaultServer)
 		peerConfig := defaultServer.config[ProtocolPeer].(*PeerConfig)
-		assert.Equal(t, testPortPeer, peerConfig.Port, "Peer port should be preserved")
-		assert.Equal(t, testPortPeer2, peerConfig.FixedPort, "Fixed peer port should be set")
+		assert.Equal(t, peerPort, peerConfig.Port, "Peer port should be preserved")
+		assert.Equal(t, fixedPort, peerConfig.FixedPort, "Fixed peer port should be set")
 	})
 
 	t.Run("FixedPeerPort without existing peer config", func(t *testing.T) {
+		fixedPort := getFreePort(t)
 		builder := NewServerBuilder().
-			WithFixedPeerPort(testPortPeer2).
+			WithFixedPeerPort(fixedPort).
 			WithStorage(memory.NewMemoryStore())
 
 		server, err := builder.Build()
@@ -595,14 +895,17 @@ func TestServerBuilder_WithFixedPeerPort(t *testing.T) {
 		defaultServer := server.(*DefaultServer)
 		peerConfig := defaultServer.config[ProtocolPeer].(*PeerConfig)
 		assert.Equal(t, DefaultPeerPort, peerConfig.Port, "Default peer port should be used")
-		assert.Equal(t, testPortPeer2, peerConfig.FixedPort, "Fixed peer port should be set")
+		assert.Equal(t, fixedPort, peerConfig.FixedPort, "Fixed peer port should be set")
 	})
 
 	t.Run("Multiple FixedPeerPort calls", func(t *testing.T) {
+		peerPort := getFreePort(t)
+		firstFixedPort := getFreePort(t)
+		secondFixedPort := getFreePort(t)
 		builder := NewServerBuilder().
-			WithPeer(testPortPeer).
-			WithFixedPeerPort(testPortPeer2).
-			WithFixedPeerPort(testPortDHT2).
+			WithPeer(peerPort).
+			WithFixedPeerPort(firstFixedPort).
+			WithFixedPeerPort(secondFixedPort).
 			WithStorage(memory.NewMemoryStore())
 
 		server, err := builder.Build()
@@ -610,8 +913,8 @@ func TestServerBuilder_WithFixedPeerPort(t *testing.T) {
 
 		defaultServer := server.(*DefaultServer)
 		peerConfig := defaultServer.config[ProtocolPeer].(*PeerConfig)
-		assert.Equal(t, testPortPeer, peerConfig.Port, "Peer port should be preserved")
-		assert.Equal(t, testPortDHT2, peerConfig.FixedPort, "Last fixed peer port should be used")
+		assert.Equal(t, peerPort, peerConfig.Port, "Peer port should be preserved")
+		assert.Equal(t, secondFixedPort, peerConfig.FixedPort, "Last fixed peer port should be used")
 	})
 }
 
@@ -815,7 +1118,7 @@ func TestServerBuilder_WithExistingDHT_Tests(t *testing.T) {
 		// Create a server builder with existing DHT and other config
 		builder := NewServerBuilder().
 			WithExistingDHT(mockDHTNode).
-			WithPeer(testPortPeer).
+			WithPeer(getFreePort(t)).
 			WithStorage(mocks.storage).
 			WithAcquirer(mocks.acquirer).
 			WithAccessControl(mocks.accessControl)
@@ -861,7 +1164,7 @@ func TestServerBuilder_WithExistingDHT_Tests(t *testing.T) {
 		// Create a server builder with both existing DHT and DHT config
 		builder := NewServerBuilder().
 			WithExistingDHT(mockDHTNode).
-			WithDHT(testPortDHT).
+			WithDHT(getFreePort(t)).
 			WithStorage(mocks.storage).
 			WithAcquirer(mocks.acquirer).
 			WithAccessControl(mocks.accessControl)
@@ -919,7 +1222,7 @@ func TestServerBuilder_Build_AcquirerFactoryValidation(t *testing.T) {
 	createBaseBuilder := func() *ServerBuilder {
 		return NewServerBuilder().
 			WithStorage(testMocks.storage).
-			WithPeer(testPortPeer)
+			WithPeer(getFreePort(t))
 	}
 
 	t.Run("AcquirerFactory_with_Acquirer_fails", func(t *testing.T) {
@@ -959,7 +1262,7 @@ func TestServerBuilder_Build_AcquirerFactorySuccess(t *testing.T) {
 	builder := NewServerBuilder().
 		WithStorage(testMocks.storage).
 		WithAcquirerFactory(factory).
-		WithPeer(testPortPeer).
+		WithPeer(getFreePort(t)).
 		WithAccessControl(testMocks.accessControl).
 		WithLogger(testMocks.logger)
 
@@ -984,7 +1287,7 @@ func TestServerBuilder_Build_DefaultAcquirerSuccess(t *testing.T) {
 	builder := NewServerBuilder().
 		WithStorage(testMocks.storage).
 		WithDefaultAcquirer().
-		WithPeer(testPortPeer). // Peer protocol for basic server functionality
+		WithPeer(getFreePort(t)). // Peer protocol for basic server functionality
 		WithAccessControl(testMocks.accessControl).
 		WithLogger(testMocks.logger)
 
@@ -1164,7 +1467,7 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).
 			WithDefaultAcquirer().
-			WithPeer(testPortPeer). // Only peer protocol, no DHT
+			WithPeer(getFreePort(t)). // Only peer protocol, no DHT
 			WithAccessControl(testMocks.accessControl).
 			WithLogger(testMocks.logger)
 
@@ -1204,7 +1507,7 @@ func TestServerBuilder_ChainedMethodsWithAcquirerFactory(t *testing.T) {
 		WithStorage(testMocks.storage).
 		WithAcquirerFactory(factory).
 		WithAccessControl(testMocks.accessControl).
-		WithPeer(testPortPeer).
+		WithPeer(getFreePort(t)).
 		WithLogger(testMocks.logger).
 		Build()
 
@@ -1221,7 +1524,7 @@ func TestServerBuilder_ChainedMethodsWithDefaultAcquirer(t *testing.T) {
 		WithStorage(testMocks.storage).
 		WithDefaultAcquirer().
 		WithAccessControl(testMocks.accessControl).
-		WithPeer(testPortPeer).
+		WithPeer(getFreePort(t)).
 		WithLogger(testMocks.logger).
 		Build()
 

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -683,32 +683,18 @@ func TestServerBuilder_ProtocolOverwrite(t *testing.T) {
 	tests := []struct {
 		name         string
 		protocolName string
-		setupFunc    func(*ServerBuilder)
-		expectedPort int
 	}{
 		{
 			name:         "PeerProtocol",
 			protocolName: ProtocolPeer,
-			setupFunc: func(b *ServerBuilder) {
-				b.WithPeer(getFreePort(t)).WithPeer(getFreePort(t))
-			},
-			expectedPort: 0, // Will be set in test
 		},
 		{
 			name:         "ReflectorProtocol",
 			protocolName: ProtocolReflector,
-			setupFunc: func(b *ServerBuilder) {
-				b.WithReflector(getFreePort(t)).WithReflector(getFreePort(t))
-			},
-			expectedPort: 0, // Will be set in test
 		},
 		{
 			name:         "DHTProtocol",
 			protocolName: ProtocolDHT,
-			setupFunc: func(b *ServerBuilder) {
-				b.WithDHT(getFreePort(t)).WithDHT(getFreePort(t))
-			},
-			expectedPort: 0, // Will be set in test
 		},
 	}
 
@@ -717,31 +703,26 @@ func TestServerBuilder_ProtocolOverwrite(t *testing.T) {
 			testMocks := setupBuilderMocks(t)
 			builder := NewServerBuilder().WithStorage(testMocks.storage)
 
-			// For protocol overwrite tests, we need to capture the final port
-			var finalPort int
+			// Test protocol overwrite by configuring the same protocol twice
+			// The second configuration should overwrite the first one
+			firstPort := getFreePort(t)
+			secondPort := getFreePort(t)
+
 			switch tt.name {
 			case "PeerProtocol":
-				firstPort := getFreePort(t)
-				secondPort := getFreePort(t)
 				builder.WithPeer(firstPort).WithPeer(secondPort)
-				finalPort = secondPort
 			case "ReflectorProtocol":
-				firstPort := getFreePort(t)
-				secondPort := getFreePort(t)
 				builder.WithReflector(firstPort).WithReflector(secondPort)
-				finalPort = secondPort
 			case "DHTProtocol":
-				firstPort := getFreePort(t)
-				secondPort := getFreePort(t)
 				builder.WithDHT(firstPort).WithDHT(secondPort)
-				finalPort = secondPort
 			}
 
 			server, err := builder.Build()
 			require.NoError(t, err)
 
 			defaultServer := server.(*DefaultServer)
-			assertServerProtocolConfig(t, defaultServer, tt.protocolName, finalPort)
+			// The final port should be the second port (overwrite behavior)
+			assertServerProtocolConfig(t, defaultServer, tt.protocolName, secondPort)
 		})
 	}
 }

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -612,9 +612,10 @@ func TestTransferOptionsIntegration(t *testing.T) {
 		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
 
 		// Test creating a custom transfer option
-		customOption := transfer.NewPeerTransferOptionAdapter(
+		customOption, err := transfer.NewPeerTransferOptionAdapter(
 			transfer.WithPeerTransferTimeout(120 * time.Second),
 		)
+		require.NoError(t, err)
 
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -28,7 +28,7 @@ import (
 func getFreePort(t *testing.T) int {
 	t.Helper()
 
-	addr, err := net.Listen("tcp", ":0")
+	addr, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("Failed to get free port: %v", err)
 	}

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -551,6 +551,42 @@ func TestWithTransferOptions(t *testing.T) {
 		err = server.Stop(ctx)
 		require.NoError(t, err)
 	})
+
+	t.Run("WithTransferOptionsNilOption", func(t *testing.T) {
+		// Create fresh mocks for this test to avoid conflicts
+		testMocks := setupBuilderMocks(t)
+
+		// Set up mock expectations for List method calls during DHT blob announcement
+		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+
+		// Test that nil options are handled gracefully (ignored and logged)
+		builder := NewServerBuilder().
+			WithStorage(testMocks.storage).
+			WithPeer(getFreePort(t)).
+			WithDHT(getFreePort(t)).
+			WithDefaultAcquirer().
+			WithTransferOptions(
+				transfer.WithPeerTransferTimeoutOption(30*time.Second), // Valid option
+				nil, // Nil option should be ignored
+				transfer.WithPeerTransferMaxPeersOption(5), // Another valid option
+			).
+			WithLogger(testMocks.logger)
+
+		// Should have 2 valid options (nil option filtered out)
+		assert.Len(t, builder.transferOptions, 2)
+
+		server, err := builder.Build()
+		require.NoError(t, err)
+		assert.NotNil(t, server)
+
+		// Server should work normally despite nil option
+		ctx := context.Background()
+		err = server.Start(ctx)
+		require.NoError(t, err)
+
+		err = server.Stop(ctx)
+		require.NoError(t, err)
+	})
 }
 
 // TestTransferOptionsIntegration tests the full integration of transfer options

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -509,9 +509,11 @@ func TestPeerPortDHTAlignment(t *testing.T) {
 
 	t.Run("DHT port alignment when no fixed port", func(t *testing.T) {
 		// When no fixed port is specified, DHT should announce peer port = DHT port
+		peerPort := getFreePort(t)
+		dhtPort := getFreePort(t)
 		builder := NewServerBuilder().
-			WithPeer(testPortPeer).
-			WithDHT(testPortDHT).
+			WithPeer(peerPort).
+			WithDHT(dhtPort).
 			WithStorage(builderMocks.storage).
 			WithAcquirer(builderMocks.acquirer)
 
@@ -522,9 +524,9 @@ func TestPeerPortDHTAlignment(t *testing.T) {
 		peerConfig := defaultServer.config[ProtocolPeer].(*PeerConfig)
 		dhtConfig := defaultServer.config[ProtocolDHT].(*DHTConfig)
 
-		assert.Equal(t, testPortPeer, peerConfig.Port, "Peer port should be configured")
+		assert.Equal(t, peerPort, peerConfig.Port, "Peer port should be configured")
 		assert.Equal(t, 0, peerConfig.FixedPort, "Fixed port should be 0 (disabled)")
-		assert.Equal(t, testPortDHT, dhtConfig.Port, "DHT port should be configured")
+		assert.Equal(t, dhtPort, dhtConfig.Port, "DHT port should be configured")
 
 		// The DHT announcement logic should align peer port with DHT port when no fixed port
 		// This is tested indirectly through the startDHT logic
@@ -532,10 +534,13 @@ func TestPeerPortDHTAlignment(t *testing.T) {
 
 	t.Run("Fixed port takes precedence", func(t *testing.T) {
 		// When fixed port is specified, it should be used for DHT announcements
+		peerPort := getFreePort(t)
+		fixedPort := getFreePort(t)
+		dhtPort := getFreePort(t)
 		builder := NewServerBuilder().
-			WithPeer(testPortPeer).
-			WithFixedPeerPort(testPortPeer2).
-			WithDHT(testPortDHT).
+			WithPeer(peerPort).
+			WithFixedPeerPort(fixedPort).
+			WithDHT(dhtPort).
 			WithStorage(builderMocks.storage).
 			WithAcquirer(builderMocks.acquirer)
 
@@ -546,9 +551,9 @@ func TestPeerPortDHTAlignment(t *testing.T) {
 		peerConfig := defaultServer.config[ProtocolPeer].(*PeerConfig)
 		dhtConfig := defaultServer.config[ProtocolDHT].(*DHTConfig)
 
-		assert.Equal(t, testPortPeer, peerConfig.Port, "Peer port should be configured")
-		assert.Equal(t, testPortPeer2, peerConfig.FixedPort, "Fixed port should be set")
-		assert.Equal(t, testPortDHT, dhtConfig.Port, "DHT port should be configured")
+		assert.Equal(t, peerPort, peerConfig.Port, "Peer port should be configured")
+		assert.Equal(t, fixedPort, peerConfig.FixedPort, "Fixed port should be set")
+		assert.Equal(t, dhtPort, dhtConfig.Port, "DHT port should be configured")
 	})
 }
 


### PR DESCRIPTION
- Introduces `TransferOption` interface to enable generic configuration of transfer implementations
- Adds `PeerTransferOptionAdapter` to bridge `PeerTransferOption` functions to the generic `TransferOption` interface
- Provides convenience functions like `WithPeerTransferTimeoutOption` for easy creation of `TransferOption` instances
- Updates `ServerBuilder` to accept and apply `TransferOption` instances to all created transfers
- Includes comprehensive tests for the new functionality, covering basic usage, multiple options, and error handling
---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Server builders can accept reusable transfer options to configure transfers.
  * Convenience options to customize peer transfers: timeout, max peers, logger, max concurrency, DHT retry attempts and delay.
  * New generic transfer option interface for configurable transfer implementations.

* **Improvements**
  * Stronger validation for peer transfer construction and safer application of transfer options with graceful logging on failures.

* **Tests**
  * Expanded coverage for transfer options and switched tests to dynamic port allocation for parallel-safe execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->