### PR TITLE
feat(protocol): add duration tracking to network crawler

### DIFF
--- a/protocol/mocks/NetworkCrawler.go
+++ b/protocol/mocks/NetworkCrawler.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	"time"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -33,6 +35,50 @@ type MockNetworkCrawler_Expecter struct {
 
 func (_m *MockNetworkCrawler) EXPECT() *MockNetworkCrawler_Expecter {
 	return &MockNetworkCrawler_Expecter{mock: &_m.Mock}
+}
+
+// GetDuration provides a mock function for the type MockNetworkCrawler
+func (_mock *MockNetworkCrawler) GetDuration() time.Duration {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDuration")
+	}
+
+	var r0 time.Duration
+	if returnFunc, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+	return r0
+}
+
+// MockNetworkCrawler_GetDuration_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDuration'
+type MockNetworkCrawler_GetDuration_Call struct {
+	*mock.Call
+}
+
+// GetDuration is a helper method to define mock.On call
+func (_e *MockNetworkCrawler_Expecter) GetDuration() *MockNetworkCrawler_GetDuration_Call {
+	return &MockNetworkCrawler_GetDuration_Call{Call: _e.mock.On("GetDuration")}
+}
+
+func (_c *MockNetworkCrawler_GetDuration_Call) Run(run func()) *MockNetworkCrawler_GetDuration_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockNetworkCrawler_GetDuration_Call) Return(duration time.Duration) *MockNetworkCrawler_GetDuration_Call {
+	_c.Call.Return(duration)
+	return _c
+}
+
+func (_c *MockNetworkCrawler_GetDuration_Call) RunAndReturn(run func() time.Duration) *MockNetworkCrawler_GetDuration_Call {
+	_c.Call.Return(run)
+	return _c
 }
 
 // Run provides a mock function for the type MockNetworkCrawler

--- a/protocol/network_crawler.go
+++ b/protocol/network_crawler.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/zap"
 )
@@ -9,13 +10,17 @@ import (
 // NetworkCrawler handles systematic network exploration to populate the routing table
 type NetworkCrawler interface {
 	Run() error
+	// GetDuration returns the duration of the last crawl operation
+	// Returns zero duration if no crawl has been completed yet
+	GetDuration() time.Duration
 }
 
 // DefaultNetworkCrawler is the default implementation of NetworkCrawler
 type DefaultNetworkCrawler struct {
-	dhtNode DHTNode
-	ctx     context.Context
-	logger  *zap.Logger
+	dhtNode  DHTNode
+	ctx      context.Context
+	logger   *zap.Logger
+	duration time.Duration
 }
 
 // NewNetworkCrawler creates a new NetworkCrawler instance
@@ -35,6 +40,12 @@ func NewNetworkCrawler(dhtNode DHTNode, ctx context.Context, logger *zap.Logger)
 
 // Run executes the network exploration
 func (c *DefaultNetworkCrawler) Run() error {
+	// Start timer to track crawl duration
+	startTime := time.Now()
+	defer func() {
+		c.duration = time.Since(startTime)
+	}()
+
 	// Check if context is cancelled before starting work
 	if err := c.ctx.Err(); err != nil {
 		c.logger.Info("Network crawler cancelled", zap.Error(err))
@@ -82,6 +93,13 @@ func (c *DefaultNetworkCrawler) Run() error {
 
 	c.logger.Info("Network crawler completed",
 		zap.Int("discovered", len(contacts)),
-		zap.Int("added", addedCount))
+		zap.Int("added", addedCount),
+		zap.Duration("duration", c.duration))
 	return nil
+}
+
+// GetDuration returns the duration of the last crawl operation
+// Returns zero duration if no crawl has been completed yet
+func (c *DefaultNetworkCrawler) GetDuration() time.Duration {
+	return c.duration
 }


### PR DESCRIPTION
- Introduces a `GetDuration()` method to the `NetworkCrawler` interface and `DefaultNetworkCrawler` implementation
- Adds functionality to measure and store the duration of the last crawl operation
- Updates the `Run()` method to start a timer before execution and capture the elapsed time
- Logs the crawl duration when the process completes
- Modifies the `NetworkCrawler` struct to include a `duration` field
- Imports the `time` package in relevant files
---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Network crawl operations now track and expose execution duration.

* **Tests**
  * Enhanced mock infrastructure with configurable duration handling and custom callback support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->