### PR TITLE
refactor(watchdog): refactor DHT watchdog to return updated contact info and remove DHT coupling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/sergi/go-diff v1.4.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
-	go.lumeweb.com/lbry-dht v0.0.0-20251121061118-741f2c0c6daa
+	go.lumeweb.com/lbry-dht v0.0.0-20251122030212-8156f51f8639
 	go.uber.org/zap v1.27.0
 	golang.org/x/text v0.31.0
 )

--- a/go.sum
+++ b/go.sum
@@ -153,6 +153,8 @@ go.lumeweb.com/lbry-dht v0.0.0-20251120194654-3f37a0467a3f h1:yuRUjvKJBg1febiiJN
 go.lumeweb.com/lbry-dht v0.0.0-20251120194654-3f37a0467a3f/go.mod h1:9nE2dYybu+bfxSvufJyvCPU27U8uR2/5euxBhCrK6pI=
 go.lumeweb.com/lbry-dht v0.0.0-20251121061118-741f2c0c6daa h1:V8TYgKsUsl3bZMRPS0+W9j+OQ9KNfIJslQGxQw3Mrow=
 go.lumeweb.com/lbry-dht v0.0.0-20251121061118-741f2c0c6daa/go.mod h1:9nE2dYybu+bfxSvufJyvCPU27U8uR2/5euxBhCrK6pI=
+go.lumeweb.com/lbry-dht v0.0.0-20251122030212-8156f51f8639 h1:qOpSIFc0o2GCY1fS5NFHPDGqBy96p1YTBljr69vcgHU=
+go.lumeweb.com/lbry-dht v0.0.0-20251122030212-8156f51f8639/go.mod h1:9nE2dYybu+bfxSvufJyvCPU27U8uR2/5euxBhCrK6pI=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=
 go.uber.org/atomic v1.11.0/go.mod h1:LUxbIzbOniOlMKjJjyPfpl4v+PKK2cNJn91OQbhoJI0=

--- a/protocol/watchdog/dht_watchdog.go
+++ b/protocol/watchdog/dht_watchdog.go
@@ -1,8 +1,8 @@
 // Package watchdog provides DHT contact validation with caching and blacklisting functionality.
 //
-// IMPORTANT: The validation methods in this package may mutate contact parameters by updating
-// the PeerPort field when a working port is discovered. This behavior is intentional for DHT
-// integration to dynamically update contact information with discovered working ports.
+// IMPORTANT: The validation methods in this package return updated contact information when a working
+// port is discovered. The DHT library will handle updating the contact in the routing table
+// with the returned contact information.
 package watchdog
 
 import (
@@ -33,12 +33,6 @@ func logErrorIfLogger(logger *zap.Logger, msg string, err error, fields ...zap.F
 	if logger != nil {
 		logger.Error(msg, append(fields, zap.Error(err))...)
 	}
-}
-
-// dht defines a minimal interface for DHT operations needed by the watchdog
-type DHT interface {
-	// GetRoutingTable returns the routing table for contact updates
-	GetRoutingTable() _dht.RoutingTable
 }
 
 // DHTWatchdog extends the existing _dht.ContactValidator interface with caching and blacklisting functionality
@@ -73,10 +67,6 @@ type DHTWatchdog interface {
 
 	// Name returns the watchdog name
 	Name() string
-
-	// SetDHT sets the DHT interface for updating contacts in the routing table
-	// This method is used when the DHT needs to be created after the watchdog
-	SetDHT(dht DHT)
 
 	// Stop stops the watchdog and cleans up resources
 	Stop()
@@ -187,14 +177,6 @@ func WithLogger(logger *zap.Logger) WatchdogOption {
 	}
 }
 
-// SetDHT sets the DHT interface for updating contacts in the routing table
-// This method is used when the DHT needs to be created after the watchdog
-func (w *DefaultDHTWatchdog) SetDHT(dht DHT) {
-	w.mutex.Lock()
-	defer w.mutex.Unlock()
-	w.dht = dht
-}
-
 // DefaultDHTWatchdog implements DHTWatchdog interface
 type DefaultDHTWatchdog struct {
 	config      *WatchdogConfig
@@ -205,7 +187,6 @@ type DefaultDHTWatchdog struct {
 	ctx         context.Context
 	cancel      context.CancelFunc
 	wg          sync.WaitGroup
-	dht         DHT
 }
 
 // New creates a new DHT watchdog with the given options
@@ -233,17 +214,18 @@ func New(options ...WatchdogOption) *DefaultDHTWatchdog {
 
 // ValidateContactForHash implements _dht.ContactValidator interface
 // Validates if a contact is suitable for storing/returning for a specific blob hash
-func (w *DefaultDHTWatchdog) ValidateContactForHash(_ bits.Bitmap, contact _dht.Contact) bool {
+// Returns a pointer to the (possibly modified) contact, or nil if no update needed, and a boolean indicating validity
+func (w *DefaultDHTWatchdog) ValidateContactForHash(_ bits.Bitmap, contact *_dht.Contact) (*_dht.Contact, bool) {
 	// Use our port testing validation logic
-	return w.ValidateAndUpdateContact(w.ctx, &contact)
+	return w.ValidateAndUpdateContact(w.ctx, contact)
 }
 
 // ValidateAndUpdateContact tests connectivity to a contact and updates its port information.
-// This method mutates the contact's PeerPort field if it is 0 and a working port is discovered.
-// The mutation is intentional for DHT integration to update contact information with discovered working ports.
-func (w *DefaultDHTWatchdog) ValidateAndUpdateContact(ctx context.Context, contact *_dht.Contact) bool {
+// This method returns a pointer to the (possibly modified) contact, or nil if no update needed, and a boolean indicating validity.
+// The DHT library will handle updating the contact in the routing table if an updated contact is returned.
+func (w *DefaultDHTWatchdog) ValidateAndUpdateContact(ctx context.Context, contact *_dht.Contact) (*_dht.Contact, bool) {
 	if contact == nil {
-		return false
+		return nil, false
 	}
 
 	contactID := contact.ID
@@ -252,14 +234,14 @@ func (w *DefaultDHTWatchdog) ValidateAndUpdateContact(ctx context.Context, conta
 	if w.IsCached(contactID) {
 		logDebugIfLogger(w.config.Logger, "Contact already cached as valid",
 			zap.String("contact_id", contactID.HexShort()))
-		return true
+		return nil, true
 	}
 
 	// Check if blacklisted
 	if w.IsBlacklisted(contactID) {
 		logDebugIfLogger(w.config.Logger, "Contact is blacklisted",
 			zap.String("contact_id", contactID.HexShort()))
-		return false
+		return nil, false
 	}
 
 	// Test connectivity on configured ports
@@ -267,6 +249,8 @@ func (w *DefaultDHTWatchdog) ValidateAndUpdateContact(ctx context.Context, conta
 
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
+
+	var updatedContact *_dht.Contact
 
 	if success {
 		// Cache the successful validation and update contact port
@@ -279,21 +263,10 @@ func (w *DefaultDHTWatchdog) ValidateAndUpdateContact(ctx context.Context, conta
 		// Update the contact's PeerPort if we found a working port
 		if successfulPort > 0 && contact.PeerPort == 0 {
 			contact.PeerPort = successfulPort
+			updatedContact = contact // Return the updated contact
 			logDebugIfLogger(w.config.Logger, "Updated contact PeerPort",
 				zap.String("contact_id", contactID.HexShort()),
 				zap.Int("port", successfulPort))
-
-			// Update the contact in the DHT routing table if DHT interface is available
-			// Note: w.dht access is protected by w.mutex which is already held
-			if w.dht != nil {
-				_routingTable := w.dht.GetRoutingTable()
-				if _routingTable != nil {
-					_routingTable.Update(*contact)
-					logDebugIfLogger(w.config.Logger, "Updated contact in DHT routing table",
-						zap.String("contact_id", contactID.HexShort()),
-						zap.Int("port", successfulPort))
-				}
-			}
 		}
 
 		logDebugIfLogger(w.config.Logger, "Contact validation succeeded",
@@ -309,7 +282,7 @@ func (w *DefaultDHTWatchdog) ValidateAndUpdateContact(ctx context.Context, conta
 			zap.String("contact_id", contactID.HexShort()))
 	}
 
-	return success
+	return updatedContact, success
 }
 
 // IsCached checks if a contact is in the successful validation cache

--- a/protocol/watchdog/dht_watchdog_test.go
+++ b/protocol/watchdog/dht_watchdog_test.go
@@ -79,7 +79,7 @@ func TestValidateContactForHash(t *testing.T) {
 	blobHash := bits.Bitmap{9, 8, 7}
 
 	// Should fail due to no actual server
-	result := watchdog.ValidateContactForHash(blobHash, *contact)
+	_, result := watchdog.ValidateContactForHash(blobHash, contact)
 	assert.False(t, result)
 
 	// Contact should be blacklisted
@@ -101,7 +101,7 @@ func TestValidateContact_Cached(t *testing.T) {
 
 	// First validation runs against a non-listening port, so it should fail
 	// and cause the contact to be blacklisted.
-	result := watchdog.ValidateAndUpdateContact(ctx, contact)
+	_, result := watchdog.ValidateAndUpdateContact(ctx, contact)
 	assert.False(t, result) // Should fail due to no actual server
 
 	// Contact should now be blacklisted
@@ -115,7 +115,7 @@ func TestValidateContact_Cached(t *testing.T) {
 	watchdog.AddToCache(contact, time.Now())
 
 	// Now validation should return true due to cache
-	result = watchdog.ValidateAndUpdateContact(ctx, contact)
+	_, result = watchdog.ValidateAndUpdateContact(ctx, contact)
 	assert.True(t, result)
 }
 
@@ -132,14 +132,14 @@ func TestValidateContact_Blacklisted(t *testing.T) {
 	ctx := context.Background()
 
 	// First validation should fail and blacklist
-	result := watchdog.ValidateAndUpdateContact(ctx, contact)
+	_, result := watchdog.ValidateAndUpdateContact(ctx, contact)
 	assert.False(t, result)
 
 	// Contact should be blacklisted
 	assert.True(t, watchdog.IsBlacklisted(contact.ID))
 
 	// Second validation should return false due to blacklist
-	result = watchdog.ValidateAndUpdateContact(ctx, contact)
+	_, result = watchdog.ValidateAndUpdateContact(ctx, contact)
 	assert.False(t, result)
 }
 
@@ -396,7 +396,7 @@ func TestValidateContact_WithRealServer(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	result := watchdog.ValidateAndUpdateContact(ctx, contact)
+	_, result := watchdog.ValidateAndUpdateContact(ctx, contact)
 
 	// Should succeed since we have a server running
 	assert.True(t, result)
@@ -432,7 +432,7 @@ func TestValidateAndUpdateContact_MutationBehavior(t *testing.T) {
 	assert.Equal(t, 0, contact.PeerPort)
 
 	ctx := context.Background()
-	result := watchdog.ValidateAndUpdateContact(ctx, contact)
+	_, result := watchdog.ValidateAndUpdateContact(ctx, contact)
 
 	// Should fail due to no server, but mutation behavior is tested
 	assert.False(t, result)
@@ -465,7 +465,7 @@ func TestValidateContactForHash_UsesValidateAndUpdateContact(t *testing.T) {
 	assert.Equal(t, 0, contact.PeerPort)
 
 	// This should use ValidateAndUpdateContact internally
-	result := watchdog.ValidateContactForHash(blobHash, *contact)
+	_, result := watchdog.ValidateContactForHash(blobHash, contact)
 
 	// Should fail due to no server, but the method should work
 	assert.False(t, result)

--- a/protocol/watchdog/mocks/DHTWatchdog.go
+++ b/protocol/watchdog/mocks/DHTWatchdog.go
@@ -435,46 +435,6 @@ func (_c *MockDHTWatchdog_RemoveFromCache_Call) RunAndReturn(run func(contactID 
 	return _c
 }
 
-// SetDHT provides a mock function for the type MockDHTWatchdog
-func (_mock *MockDHTWatchdog) SetDHT(dht1 watchdog.DHT) {
-	_mock.Called(dht1)
-	return
-}
-
-// MockDHTWatchdog_SetDHT_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'SetDHT'
-type MockDHTWatchdog_SetDHT_Call struct {
-	*mock.Call
-}
-
-// SetDHT is a helper method to define mock.On call
-//   - dht1 watchdog.DHT
-func (_e *MockDHTWatchdog_Expecter) SetDHT(dht1 interface{}) *MockDHTWatchdog_SetDHT_Call {
-	return &MockDHTWatchdog_SetDHT_Call{Call: _e.mock.On("SetDHT", dht1)}
-}
-
-func (_c *MockDHTWatchdog_SetDHT_Call) Run(run func(dht1 watchdog.DHT)) *MockDHTWatchdog_SetDHT_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 watchdog.DHT
-		if args[0] != nil {
-			arg0 = args[0].(watchdog.DHT)
-		}
-		run(
-			arg0,
-		)
-	})
-	return _c
-}
-
-func (_c *MockDHTWatchdog_SetDHT_Call) Return() *MockDHTWatchdog_SetDHT_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockDHTWatchdog_SetDHT_Call) RunAndReturn(run func(dht1 watchdog.DHT)) *MockDHTWatchdog_SetDHT_Call {
-	_c.Run(run)
-	return _c
-}
-
 // Stop provides a mock function for the type MockDHTWatchdog
 func (_mock *MockDHTWatchdog) Stop() {
 	_mock.Called()
@@ -509,20 +469,31 @@ func (_c *MockDHTWatchdog_Stop_Call) RunAndReturn(run func()) *MockDHTWatchdog_S
 }
 
 // ValidateContactForHash provides a mock function for the type MockDHTWatchdog
-func (_mock *MockDHTWatchdog) ValidateContactForHash(blobHash bits.Bitmap, contact dht.Contact) bool {
+func (_mock *MockDHTWatchdog) ValidateContactForHash(blobHash bits.Bitmap, contact *dht.Contact) (*dht.Contact, bool) {
 	ret := _mock.Called(blobHash, contact)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ValidateContactForHash")
 	}
 
-	var r0 bool
-	if returnFunc, ok := ret.Get(0).(func(bits.Bitmap, dht.Contact) bool); ok {
+	var r0 *dht.Contact
+	var r1 bool
+	if returnFunc, ok := ret.Get(0).(func(bits.Bitmap, *dht.Contact) (*dht.Contact, bool)); ok {
+		return returnFunc(blobHash, contact)
+	}
+	if returnFunc, ok := ret.Get(0).(func(bits.Bitmap, *dht.Contact) *dht.Contact); ok {
 		r0 = returnFunc(blobHash, contact)
 	} else {
-		r0 = ret.Get(0).(bool)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*dht.Contact)
+		}
 	}
-	return r0
+	if returnFunc, ok := ret.Get(1).(func(bits.Bitmap, *dht.Contact) bool); ok {
+		r1 = returnFunc(blobHash, contact)
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+	return r0, r1
 }
 
 // MockDHTWatchdog_ValidateContactForHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ValidateContactForHash'
@@ -532,20 +503,20 @@ type MockDHTWatchdog_ValidateContactForHash_Call struct {
 
 // ValidateContactForHash is a helper method to define mock.On call
 //   - blobHash bits.Bitmap
-//   - contact dht.Contact
+//   - contact *dht.Contact
 func (_e *MockDHTWatchdog_Expecter) ValidateContactForHash(blobHash interface{}, contact interface{}) *MockDHTWatchdog_ValidateContactForHash_Call {
 	return &MockDHTWatchdog_ValidateContactForHash_Call{Call: _e.mock.On("ValidateContactForHash", blobHash, contact)}
 }
 
-func (_c *MockDHTWatchdog_ValidateContactForHash_Call) Run(run func(blobHash bits.Bitmap, contact dht.Contact)) *MockDHTWatchdog_ValidateContactForHash_Call {
+func (_c *MockDHTWatchdog_ValidateContactForHash_Call) Run(run func(blobHash bits.Bitmap, contact *dht.Contact)) *MockDHTWatchdog_ValidateContactForHash_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 bits.Bitmap
 		if args[0] != nil {
 			arg0 = args[0].(bits.Bitmap)
 		}
-		var arg1 dht.Contact
+		var arg1 *dht.Contact
 		if args[1] != nil {
-			arg1 = args[1].(dht.Contact)
+			arg1 = args[1].(*dht.Contact)
 		}
 		run(
 			arg0,
@@ -555,12 +526,12 @@ func (_c *MockDHTWatchdog_ValidateContactForHash_Call) Run(run func(blobHash bit
 	return _c
 }
 
-func (_c *MockDHTWatchdog_ValidateContactForHash_Call) Return(b bool) *MockDHTWatchdog_ValidateContactForHash_Call {
-	_c.Call.Return(b)
+func (_c *MockDHTWatchdog_ValidateContactForHash_Call) Return(contact1 *dht.Contact, b bool) *MockDHTWatchdog_ValidateContactForHash_Call {
+	_c.Call.Return(contact1, b)
 	return _c
 }
 
-func (_c *MockDHTWatchdog_ValidateContactForHash_Call) RunAndReturn(run func(blobHash bits.Bitmap, contact dht.Contact) bool) *MockDHTWatchdog_ValidateContactForHash_Call {
+func (_c *MockDHTWatchdog_ValidateContactForHash_Call) RunAndReturn(run func(blobHash bits.Bitmap, contact *dht.Contact) (*dht.Contact, bool)) *MockDHTWatchdog_ValidateContactForHash_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -846,7 +846,6 @@ func TestServerBuilder_WithExistingDHT(t *testing.T) {
 
 	// Setup mock expectations
 	mockDHTNode.EXPECT().Start().Return(nil)
-	mockDHTNode.EXPECT().Watchdog().Return(nil)
 	mockDHTNode.EXPECT().Shutdown().Return()
 	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
 
@@ -1006,7 +1005,6 @@ func TestServerBuilder_Build_AcquirerFactoryIntegration(t *testing.T) {
 	// Create a mock DHT node
 	mockDHTNode := protocolMocks.NewMockDHTNode(t)
 	mockDHTNode.EXPECT().Start().Return(nil)
-	mockDHTNode.EXPECT().Watchdog().Return(nil)
 	mockDHTNode.EXPECT().Shutdown().Return()
 
 	// Create a mock acquirer factory function that tracks calls
@@ -1066,7 +1064,6 @@ func TestServerBuilder_Build_DefaultAcquirerIntegration(t *testing.T) {
 	// Create a mock DHT node
 	mockDHTNode := protocolMocks.NewMockDHTNode(t)
 	mockDHTNode.EXPECT().Start().Return(nil)
-	mockDHTNode.EXPECT().Watchdog().Return(nil)
 	mockDHTNode.EXPECT().Shutdown().Return()
 
 	// Add mock expectation for storage.List() called during DHT blob announcement
@@ -1122,7 +1119,6 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 		// Create a mock DHT node
 		mockDHTNode := protocolMocks.NewMockDHTNode(t)
 		mockDHTNode.EXPECT().Start().Return(nil)
-		mockDHTNode.EXPECT().Watchdog().Return(nil)
 		mockDHTNode.EXPECT().Shutdown().Return()
 
 		// Add mock expectation for storage.List() called during DHT blob announcement

--- a/server/server.go
+++ b/server/server.go
@@ -391,14 +391,6 @@ func (s *DefaultServer) getDhtNode() protocol.DHTNode {
 	return nil
 }
 
-// wireDHTToWatchdog wires the DHT node back to its watchdog for contact updates
-func (s *DefaultServer) wireDHTToWatchdog(dhtNode protocol.DHTNode) {
-	if _watchdog := dhtNode.Watchdog(); _watchdog != nil {
-		_watchdog.SetDHT(dhtNode)
-		s.logger.Debug("Wired DHT to watchdog for contact updates")
-	}
-}
-
 // setupDHTNode sets up the DHT node and related components
 func (s *DefaultServer) setupDHTNode(config *DHTConfig, announcePeerPort int, fixedPeerPort int) error {
 	// Create DHT node using the helper method
@@ -409,9 +401,6 @@ func (s *DefaultServer) setupDHTNode(config *DHTConfig, announcePeerPort int, fi
 
 	// Store the DHT node in servers map for later access
 	s.storeServer(ProtocolDHT, dhtNode)
-
-	// Wire the DHT back to the watchdog for contact updates
-	s.wireDHTToWatchdog(dhtNode)
 
 	// Create DHT announcer using the helper method
 	s.dhtAnnouncer = protocol.NewDefaultDHTAnnouncer(s.getDhtNode())
@@ -439,9 +428,6 @@ func (s *DefaultServer) setupExistingDHTNode(dhtNode protocol.DHTNode) error {
 	if err := dhtNode.Start(); err != nil {
 		return fmt.Errorf("failed to start existing DHT node: %w", err)
 	}
-
-	// Wire the DHT back to the watchdog for contact updates
-	s.wireDHTToWatchdog(dhtNode)
 
 	// Set up DHT announcer and notifier
 	s.dhtAnnouncer = protocol.NewDefaultDHTAnnouncer(dhtNode)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -183,7 +183,6 @@ func TestDefaultServer_Start_WithDHT(t *testing.T) {
 
 	// Setup mock expectations for DHT node methods
 	mockDHTNode.EXPECT().Start().Return(nil)
-	mockDHTNode.EXPECT().Watchdog().Return(nil)
 
 	server := setupServer(t, testMocks, map[string]any{
 		ProtocolDHT: mockDHTNode, // Pass the mock DHT node directly
@@ -216,7 +215,6 @@ func TestDefaultServer_Start_AllProtocols(t *testing.T) {
 
 	// Setup mock expectations for DHT node methods
 	mockDHTNode.EXPECT().Start().Return(nil)
-	mockDHTNode.EXPECT().Watchdog().Return(nil)
 
 	server := setupServer(t, testMocks, map[string]any{
 		ProtocolPeer:      &PeerConfig{Port: 0},
@@ -424,7 +422,6 @@ func TestDefaultServer_startDHT(t *testing.T) {
 
 	// Setup mock expectations for DHT node start
 	mockDHTNode.EXPECT().Start().Return(nil)
-	mockDHTNode.EXPECT().Watchdog().Return(nil)
 
 	// Simulate that the DHT node is already in the servers map (as would happen with WithExistingDHT)
 	server.servers[ProtocolDHT] = mockDHTNode


### PR DESCRIPTION
*   The `ValidateContactForHash` and `ValidateAndUpdateContact` methods now return a pointer to the (possibly updated) contact, or `nil` if no update is needed, along with a boolean indicating validity.
*   The `DHT` interface and `SetDHT` method have been removed from the `DHTWatchdog` interface and its implementation.
*   The responsibility for updating the DHT routing table has been shifted to the DHT library, removing the need for the watchdog to directly manage contact updates.
*   This change simplifies the watchdog's role and improves decoupling between the watchdog and DHT components.
*   Updated tests and mocks to reflect the new method signatures.
---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated LBRY DHT-related dependency package to the latest stable version for improved compatibility and enhanced functionality.

* **Refactor**
  * Improved DHT contact validation mechanism with updated internal handling. Refined system architecture for enhanced code organization and maintainability. Optimized contact data processing for better efficiency and cleaner separation of concerns throughout the validation flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->