### PR TITLE
feat(transfer): track and remove bad peers from DHT hash mapping

### DIFF
--- a/blob/transfer/peer_transfer.go
+++ b/blob/transfer/peer_transfer.go
@@ -623,6 +623,8 @@ func (t *PeerTransfer) Get(ctx context.Context, hash string) ([]byte, error) {
 		// Capture loop variables
 		peerAddrCopy := peerAddr
 		hashCopy := hash
+		contactCopy := contact
+		hashBitmapCopy := hashBitmap
 
 		t.workerPoolMu.RLock()
 		workerPool := t.workerPool
@@ -658,6 +660,9 @@ func (t *PeerTransfer) Get(ctx context.Context, hash string) ([]byte, error) {
 					raceCancel() // This cancels all other in-flight tasks
 				})
 			} else {
+				// Remove bad peer from DHT hash mapping
+				t.dhtNode.RemoveBadPeerFromHash(hashBitmapCopy, contactCopy)
+
 				// Track failed peer
 				completed := atomic.AddInt32(&req.completed, 1)
 				t.logger.Debug("Peer download failed",

--- a/blob/transfer/peer_transfer.go
+++ b/blob/transfer/peer_transfer.go
@@ -660,8 +660,11 @@ func (t *PeerTransfer) Get(ctx context.Context, hash string) ([]byte, error) {
 					raceCancel() // This cancels all other in-flight tasks
 				})
 			} else {
-				// Remove bad peer from DHT hash mapping
-				t.dhtNode.RemoveBadPeerFromHash(hashBitmapCopy, contactCopy)
+				// Only mark peer as bad for non-context errors (connection failures, protocol errors, etc.)
+				// Context cancellation/timeout errors shouldn't penalize the peer
+				if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) {
+					t.dhtNode.RemoveBadPeerFromHash(hashBitmapCopy, contactCopy)
+				}
 
 				// Track failed peer
 				completed := atomic.AddInt32(&req.completed, 1)

--- a/blob/transfer/peer_transfer_test.go
+++ b/blob/transfer/peer_transfer_test.go
@@ -358,6 +358,13 @@ func TestPeerTransfer_Get_AllPeersFail(t *testing.T) {
 		{ID: bits.Rand(), IP: net.ParseIP("127.0.0.1"), Port: 99997, PeerPort: 99997},
 	}
 	dhtNode.EXPECT().Get(mock.AnythingOfType("bits.Bitmap")).Return(contacts, nil)
+
+	// Mock RemoveBadPeerFromHash calls for each failing peer
+	hashBitmap, _ := bits.FromShortHex(testHash)
+	for _, contact := range contacts {
+		dhtNode.EXPECT().RemoveBadPeerFromHash(hashBitmap, contact).Return()
+	}
+
 	transfer.maxPeers = 3
 
 	data, err := transfer.Get(context.Background(), testHash)
@@ -378,6 +385,12 @@ func TestPeerTransfer_Get_AllPeersFail_ImmediateError(t *testing.T) {
 		{ID: bits.Rand(), IP: net.ParseIP("127.0.0.1"), Port: 99997, PeerPort: 99997},
 	}
 	dhtNode.EXPECT().Get(mock.AnythingOfType("bits.Bitmap")).Return(contacts, nil)
+
+	// Mock RemoveBadPeerFromHash calls for each failing peer
+	hashBitmap, _ := bits.FromShortHex(testHash)
+	for _, contact := range contacts {
+		dhtNode.EXPECT().RemoveBadPeerFromHash(hashBitmap, contact).Return()
+	}
 
 	transfer.maxPeers = 3
 
@@ -448,6 +461,12 @@ func TestPeerTransfer_Get_ErrorAggregation(t *testing.T) {
 	}
 	dhtNode.EXPECT().Get(mock.AnythingOfType("bits.Bitmap")).Return(contacts, nil)
 
+	// Mock RemoveBadPeerFromHash calls for each failing peer
+	hashBitmap, _ := bits.FromShortHex(testHash)
+	for _, contact := range contacts {
+		dhtNode.EXPECT().RemoveBadPeerFromHash(hashBitmap, contact).Return()
+	}
+
 	transfer.maxPeers = 2
 
 	data, err := transfer.Get(context.Background(), testHash)
@@ -479,6 +498,10 @@ func TestPeerTransfer_Get_PeerClientFailure(t *testing.T) {
 			}
 			dhtNode.EXPECT().Get(mock.AnythingOfType("bits.Bitmap")).Return([]dht.Contact{contact}, nil)
 
+			// Mock RemoveBadPeerFromHash call for the failing peer
+			hashBitmap, _ := bits.FromShortHex(testHash)
+			dhtNode.EXPECT().RemoveBadPeerFromHash(hashBitmap, contact).Return()
+
 			_, err := transfer.Get(context.Background(), testHash)
 
 			assert.Error(t, err)
@@ -499,6 +522,10 @@ func TestPeerTransfer_Get_PeerCancellation(t *testing.T) {
 		PeerPort: 99999,
 	}
 	dhtNode.EXPECT().Get(mock.AnythingOfType("bits.Bitmap")).Return([]dht.Contact{contact}, nil)
+
+	// Mock RemoveBadPeerFromHash call for the failing peer
+	hashBitmap, _ := bits.FromShortHex(testHash)
+	dhtNode.EXPECT().RemoveBadPeerFromHash(hashBitmap, contact).Return()
 
 	// Operation should fail with connection error
 	_, err := transfer.Get(context.Background(), testHash)
@@ -667,6 +694,10 @@ func TestPeerTransfer_Get_Timeout(t *testing.T) {
 	}
 	dhtNode.EXPECT().Get(mock.AnythingOfType("bits.Bitmap")).Return([]dht.Contact{contact}, nil)
 
+	// Mock RemoveBadPeerFromHash call for the failing peer
+	hashBitmap, _ := bits.FromShortHex(testHash)
+	dhtNode.EXPECT().RemoveBadPeerFromHash(hashBitmap, contact).Return()
+
 	transfer.timeout = 100 * time.Millisecond
 
 	_, err := transfer.Get(context.Background(), testHash)
@@ -735,7 +766,6 @@ func TestPeerTransfer_Get_FallbackPath(t *testing.T) {
 		{ID: bits.Rand(), IP: net.ParseIP("127.0.0.1"), Port: testServer.port, PeerPort: testServer.port}, // Third succeeds
 	}
 	dhtNode.EXPECT().Get(mock.AnythingOfType("bits.Bitmap")).Return(contacts, nil)
-
 	transfer.maxPeers = 3
 
 	data, err := transfer.Get(context.Background(), testHash)
@@ -899,6 +929,12 @@ func TestPeerTransfer_Get_ConcurrentSameHash(t *testing.T) {
 		{ID: bits.Rand(), IP: net.ParseIP("127.0.0.1"), Port: server.port, PeerPort: server.port},
 	}
 	mockDHT.EXPECT().Get(hashBitmap).Return(contacts, nil).Times(1)
+
+	// Mock RemoveBadPeerFromHash calls for any potentially failing peers
+	// Use Maybe() since these contacts should succeed, but we add them defensively
+	for _, contact := range contacts {
+		mockDHT.EXPECT().RemoveBadPeerFromHash(hashBitmap, contact).Return().Maybe()
+	}
 
 	// Number of concurrent goroutines
 	numGoroutines := 10

--- a/protocol/dht.go
+++ b/protocol/dht.go
@@ -94,6 +94,10 @@ type DHT interface {
 	// Returns:
 	//   - dht.RoutingTable: Live routing table interface for advanced operations
 	GetRoutingTable() dht.RoutingTable
+
+	// RemoveBadPeerFromHash removes a bad peer from the hash-to-peer mapping
+	// This is called when a peer fails to provide a blob for a specific hash
+	RemoveBadPeerFromHash(blobHash bits.Bitmap, contact dht.Contact)
 }
 
 // DHTRoutable provides access to routing table functionality for contact management
@@ -151,6 +155,10 @@ type DHTNode interface {
 
 	// GetRoutingTable returns the routing table for contact updates
 	GetRoutingTable() dht.RoutingTable
+
+	// RemoveBadPeerFromHash removes a bad peer from the hash-to-peer mapping
+	// This is called when a peer fails to provide a blob for a specific hash
+	RemoveBadPeerFromHash(blobHash bits.Bitmap, contact dht.Contact)
 }
 
 // DHTConfig holds configuration for DHT peer operations

--- a/protocol/dht_node.go
+++ b/protocol/dht_node.go
@@ -605,6 +605,20 @@ func (w *managedDHTNode) GetRoutingTable() dht.RoutingTable {
 	return w.dht.GetRoutingTable()
 }
 
+// RemoveBadPeerFromHash removes a bad peer from the hash-to-peer mapping
+// This is called when a peer fails to provide a blob for a specific hash
+func (w *managedDHTNode) RemoveBadPeerFromHash(blobHash bits.Bitmap, contact dht.Contact) {
+	w.mu.RLock()
+	defer w.mu.RUnlock()
+
+	if !w.isActive() {
+		return
+	}
+
+	// Delegate to the underlying DHT implementation
+	w.dht.RemoveBadPeerFromHash(blobHash, contact)
+}
+
 // exploreNetwork performs systematic network exploration to populate routing table
 func (w *managedDHTNode) exploreNetwork() error {
 	// Acquire read lock to safely access stopped and dht fields

--- a/protocol/mocks/DHT.go
+++ b/protocol/mocks/DHT.go
@@ -605,6 +605,52 @@ func (_c *MockDHT_Remove_Call) RunAndReturn(run func(hash bits.Bitmap)) *MockDHT
 	return _c
 }
 
+// RemoveBadPeerFromHash provides a mock function for the type MockDHT
+func (_mock *MockDHT) RemoveBadPeerFromHash(blobHash bits.Bitmap, contact dht.Contact) {
+	_mock.Called(blobHash, contact)
+	return
+}
+
+// MockDHT_RemoveBadPeerFromHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveBadPeerFromHash'
+type MockDHT_RemoveBadPeerFromHash_Call struct {
+	*mock.Call
+}
+
+// RemoveBadPeerFromHash is a helper method to define mock.On call
+//   - blobHash bits.Bitmap
+//   - contact dht.Contact
+func (_e *MockDHT_Expecter) RemoveBadPeerFromHash(blobHash interface{}, contact interface{}) *MockDHT_RemoveBadPeerFromHash_Call {
+	return &MockDHT_RemoveBadPeerFromHash_Call{Call: _e.mock.On("RemoveBadPeerFromHash", blobHash, contact)}
+}
+
+func (_c *MockDHT_RemoveBadPeerFromHash_Call) Run(run func(blobHash bits.Bitmap, contact dht.Contact)) *MockDHT_RemoveBadPeerFromHash_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 bits.Bitmap
+		if args[0] != nil {
+			arg0 = args[0].(bits.Bitmap)
+		}
+		var arg1 dht.Contact
+		if args[1] != nil {
+			arg1 = args[1].(dht.Contact)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDHT_RemoveBadPeerFromHash_Call) Return() *MockDHT_RemoveBadPeerFromHash_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockDHT_RemoveBadPeerFromHash_Call) RunAndReturn(run func(blobHash bits.Bitmap, contact dht.Contact)) *MockDHT_RemoveBadPeerFromHash_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Shutdown provides a mock function for the type MockDHT
 func (_mock *MockDHT) Shutdown() {
 	_mock.Called()

--- a/protocol/mocks/DHTNode.go
+++ b/protocol/mocks/DHTNode.go
@@ -759,6 +759,52 @@ func (_c *MockDHTNode_Remove_Call) RunAndReturn(run func(hash bits.Bitmap)) *Moc
 	return _c
 }
 
+// RemoveBadPeerFromHash provides a mock function for the type MockDHTNode
+func (_mock *MockDHTNode) RemoveBadPeerFromHash(blobHash bits.Bitmap, contact dht.Contact) {
+	_mock.Called(blobHash, contact)
+	return
+}
+
+// MockDHTNode_RemoveBadPeerFromHash_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'RemoveBadPeerFromHash'
+type MockDHTNode_RemoveBadPeerFromHash_Call struct {
+	*mock.Call
+}
+
+// RemoveBadPeerFromHash is a helper method to define mock.On call
+//   - blobHash bits.Bitmap
+//   - contact dht.Contact
+func (_e *MockDHTNode_Expecter) RemoveBadPeerFromHash(blobHash interface{}, contact interface{}) *MockDHTNode_RemoveBadPeerFromHash_Call {
+	return &MockDHTNode_RemoveBadPeerFromHash_Call{Call: _e.mock.On("RemoveBadPeerFromHash", blobHash, contact)}
+}
+
+func (_c *MockDHTNode_RemoveBadPeerFromHash_Call) Run(run func(blobHash bits.Bitmap, contact dht.Contact)) *MockDHTNode_RemoveBadPeerFromHash_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 bits.Bitmap
+		if args[0] != nil {
+			arg0 = args[0].(bits.Bitmap)
+		}
+		var arg1 dht.Contact
+		if args[1] != nil {
+			arg1 = args[1].(dht.Contact)
+		}
+		run(
+			arg0,
+			arg1,
+		)
+	})
+	return _c
+}
+
+func (_c *MockDHTNode_RemoveBadPeerFromHash_Call) Return() *MockDHTNode_RemoveBadPeerFromHash_Call {
+	_c.Call.Return()
+	return _c
+}
+
+func (_c *MockDHTNode_RemoveBadPeerFromHash_Call) RunAndReturn(run func(blobHash bits.Bitmap, contact dht.Contact)) *MockDHTNode_RemoveBadPeerFromHash_Call {
+	_c.Run(run)
+	return _c
+}
+
 // Restart provides a mock function for the type MockDHTNode
 func (_mock *MockDHTNode) Restart() error {
 	ret := _mock.Called()


### PR DESCRIPTION
- Add tracking of bad peers in `PeerTransfer` during blob retrieval failures
- Introduce `RemoveBadPeerFromHash` method to DHT interfaces (`DHT` and `DHTNode`)
- Implement `RemoveBadPeerFromHash` in `managedDHTNode` to delegate to underlying DHT
- Update `PeerTransfer.Get` to call `RemoveBadPeerFromHash` when peer download fails
---
* Tests can be run with `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved peer-failure handling: peers that fail to deliver requested content are now removed from discovery mappings, reducing repeated failures and improving download reliability.

* **Tests**
  * Updated test coverage to validate that failing peers are cleaned up from peer mappings and to tolerate concurrent removal behaviors where applicable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->