### PR TITLE
feat(server): add direct blob retrieval methods

### DIFF
--- a/client/mocks/StreamAcquirerFactory.go
+++ b/client/mocks/StreamAcquirerFactory.go
@@ -38,65 +38,6 @@ func (_m *MockStreamAcquirerFactory) EXPECT() *MockStreamAcquirerFactory_Expecte
 	return &MockStreamAcquirerFactory_Expecter{mock: &_m.Mock}
 }
 
-// CreateDefaultStreamAcquirer provides a mock function for the type MockStreamAcquirerFactory
-func (_mock *MockStreamAcquirerFactory) CreateDefaultStreamAcquirer(acquirer liblbry.BlobAcquirer, store storage.BlobStore) client.StreamAcquirer {
-	ret := _mock.Called(acquirer, store)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateDefaultStreamAcquirer")
-	}
-
-	var r0 client.StreamAcquirer
-	if returnFunc, ok := ret.Get(0).(func(liblbry.BlobAcquirer, storage.BlobStore) client.StreamAcquirer); ok {
-		r0 = returnFunc(acquirer, store)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(client.StreamAcquirer)
-		}
-	}
-	return r0
-}
-
-// MockStreamAcquirerFactory_CreateDefaultStreamAcquirer_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CreateDefaultStreamAcquirer'
-type MockStreamAcquirerFactory_CreateDefaultStreamAcquirer_Call struct {
-	*mock.Call
-}
-
-// CreateDefaultStreamAcquirer is a helper method to define mock.On call
-//   - acquirer liblbry.BlobAcquirer
-//   - store storage.BlobStore
-func (_e *MockStreamAcquirerFactory_Expecter) CreateDefaultStreamAcquirer(acquirer interface{}, store interface{}) *MockStreamAcquirerFactory_CreateDefaultStreamAcquirer_Call {
-	return &MockStreamAcquirerFactory_CreateDefaultStreamAcquirer_Call{Call: _e.mock.On("CreateDefaultStreamAcquirer", acquirer, store)}
-}
-
-func (_c *MockStreamAcquirerFactory_CreateDefaultStreamAcquirer_Call) Run(run func(acquirer liblbry.BlobAcquirer, store storage.BlobStore)) *MockStreamAcquirerFactory_CreateDefaultStreamAcquirer_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 liblbry.BlobAcquirer
-		if args[0] != nil {
-			arg0 = args[0].(liblbry.BlobAcquirer)
-		}
-		var arg1 storage.BlobStore
-		if args[1] != nil {
-			arg1 = args[1].(storage.BlobStore)
-		}
-		run(
-			arg0,
-			arg1,
-		)
-	})
-	return _c
-}
-
-func (_c *MockStreamAcquirerFactory_CreateDefaultStreamAcquirer_Call) Return(streamAcquirer client.StreamAcquirer) *MockStreamAcquirerFactory_CreateDefaultStreamAcquirer_Call {
-	_c.Call.Return(streamAcquirer)
-	return _c
-}
-
-func (_c *MockStreamAcquirerFactory_CreateDefaultStreamAcquirer_Call) RunAndReturn(run func(acquirer liblbry.BlobAcquirer, store storage.BlobStore) client.StreamAcquirer) *MockStreamAcquirerFactory_CreateDefaultStreamAcquirer_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // CreateStreamAcquirer provides a mock function for the type MockStreamAcquirerFactory
 func (_mock *MockStreamAcquirerFactory) CreateStreamAcquirer(acquirer liblbry.BlobAcquirer, store storage.BlobStore) client.StreamAcquirer {
 	ret := _mock.Called(acquirer, store)

--- a/server/mocks/BlobManager.go
+++ b/server/mocks/BlobManager.go
@@ -308,6 +308,130 @@ func (_c *MockBlobManager_AddSDBlob_Call) RunAndReturn(run func(hash string, dat
 	return _c
 }
 
+// GetBlob provides a mock function for the type MockBlobManager
+func (_mock *MockBlobManager) GetBlob(hash string) ([]byte, error) {
+	ret := _mock.Called(hash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBlob")
+	}
+
+	var r0 []byte
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]byte, error)); ok {
+		return returnFunc(hash)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []byte); ok {
+		r0 = returnFunc(hash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(hash)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBlobManager_GetBlob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetBlob'
+type MockBlobManager_GetBlob_Call struct {
+	*mock.Call
+}
+
+// GetBlob is a helper method to define mock.On call
+//   - hash string
+func (_e *MockBlobManager_Expecter) GetBlob(hash interface{}) *MockBlobManager_GetBlob_Call {
+	return &MockBlobManager_GetBlob_Call{Call: _e.mock.On("GetBlob", hash)}
+}
+
+func (_c *MockBlobManager_GetBlob_Call) Run(run func(hash string)) *MockBlobManager_GetBlob_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBlobManager_GetBlob_Call) Return(bytes []byte, err error) *MockBlobManager_GetBlob_Call {
+	_c.Call.Return(bytes, err)
+	return _c
+}
+
+func (_c *MockBlobManager_GetBlob_Call) RunAndReturn(run func(hash string) ([]byte, error)) *MockBlobManager_GetBlob_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetSDBlob provides a mock function for the type MockBlobManager
+func (_mock *MockBlobManager) GetSDBlob(hash string) ([]byte, error) {
+	ret := _mock.Called(hash)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSDBlob")
+	}
+
+	var r0 []byte
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(string) ([]byte, error)); ok {
+		return returnFunc(hash)
+	}
+	if returnFunc, ok := ret.Get(0).(func(string) []byte); ok {
+		r0 = returnFunc(hash)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
+		r1 = returnFunc(hash)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockBlobManager_GetSDBlob_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSDBlob'
+type MockBlobManager_GetSDBlob_Call struct {
+	*mock.Call
+}
+
+// GetSDBlob is a helper method to define mock.On call
+//   - hash string
+func (_e *MockBlobManager_Expecter) GetSDBlob(hash interface{}) *MockBlobManager_GetSDBlob_Call {
+	return &MockBlobManager_GetSDBlob_Call{Call: _e.mock.On("GetSDBlob", hash)}
+}
+
+func (_c *MockBlobManager_GetSDBlob_Call) Run(run func(hash string)) *MockBlobManager_GetSDBlob_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 string
+		if args[0] != nil {
+			arg0 = args[0].(string)
+		}
+		run(
+			arg0,
+		)
+	})
+	return _c
+}
+
+func (_c *MockBlobManager_GetSDBlob_Call) Return(bytes []byte, err error) *MockBlobManager_GetSDBlob_Call {
+	_c.Call.Return(bytes, err)
+	return _c
+}
+
+func (_c *MockBlobManager_GetSDBlob_Call) RunAndReturn(run func(hash string) ([]byte, error)) *MockBlobManager_GetSDBlob_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // RemoveBlob provides a mock function for the type MockBlobManager
 func (_mock *MockBlobManager) RemoveBlob(hash string) error {
 	ret := _mock.Called(hash)

--- a/server/server.go
+++ b/server/server.go
@@ -73,6 +73,11 @@ type BlobManager interface {
 	AcquireBlob(ctx context.Context, hash string) ([]byte, error)
 	// AcquireSDBlob retrieves an SD blob and optionally its content blobs
 	AcquireSDBlob(ctx context.Context, hash string, opts ...AcquireSDOption) (*stream.StreamResult, error)
+
+	// GetBlob retrieves a blob directly from the underlying store
+	GetBlob(hash string) ([]byte, error)
+	// GetSDBlob retrieves an SD blob directly from the underlying store
+	GetSDBlob(hash string) ([]byte, error)
 }
 
 // AcquireSDConfig holds configuration for SD blob acquisition
@@ -757,6 +762,26 @@ func (s *DefaultServer) AcquireSDBlob(ctx context.Context, hash string, opts ...
 
 	// Use unified stream acquisition logic
 	return streamAcquirer.GetStreamResult(ctx, hash, acquireOpts...)
+}
+
+// GetBlob retrieves a blob directly from the underlying store
+func (s *DefaultServer) GetBlob(hash string) ([]byte, error) {
+	// Validate hash
+	if err := validateHash(hash); err != nil {
+		return nil, err
+	}
+
+	return s.storage.Get(hash)
+}
+
+// GetSDBlob retrieves an SD blob directly from the underlying store
+func (s *DefaultServer) GetSDBlob(hash string) ([]byte, error) {
+	// Validate hash
+	if err := validateHash(hash); err != nil {
+		return nil, err
+	}
+
+	return s.storage.Get(hash)
 }
 
 // startTCPProtocol starts a generic TCP protocol handler

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1177,6 +1177,8 @@ func TestDefaultServer_AcquireSDBlob_RecursiveSuccess(t *testing.T) {
 	testMocks.acquirer.EXPECT().Acquire(mock.Anything, sdBlobHash).Return(sdBlobData, nil)
 	// Check if content blob exists in storage - it doesn't
 	testMocks.storage.EXPECT().Has(contentBlobHash).Return(false, nil)
+	// Mock the store Name() method call
+	testMocks.storage.EXPECT().Name().Return("mock-store")
 	// Then, acquire the content blob - use Anything for context to be more flexible
 	testMocks.acquirer.EXPECT().Acquire(mock.Anything, contentBlobHash).Return(contentBlobData, nil)
 	// Store the acquired content blob
@@ -1371,6 +1373,118 @@ func TestDefaultServer_AcquireSDBlob_ContentBlobAcquisitionFailure(t *testing.T)
 	assert.Contains(t, err.Error(), "failed to acquire content blob")
 	assert.Contains(t, err.Error(), contentBlobHash)
 	assert.Contains(t, err.Error(), "index 0")
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_GetBlob_Success tests successful blob retrieval from storage
+// Validates that blobs can be successfully retrieved directly from the underlying store
+func TestDefaultServer_GetBlob_Success(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	blobHash := TestBlobHash
+	expectedData := []byte(TestBlobData)
+
+	// Setup mock expectations
+	testMocks.storage.EXPECT().Get(blobHash).Return(expectedData, nil)
+
+	// Test successful blob retrieval
+	result, err := server.GetBlob(blobHash)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedData, result)
+}
+
+// TestDefaultServer_GetBlob_EmptyHash tests error handling for empty hash
+// Validates that blob retrieval properly rejects empty hash values
+func TestDefaultServer_GetBlob_EmptyHash(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	// Test with empty hash
+	result, err := server.GetBlob("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hash cannot be empty")
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_GetBlob_StorageFailure tests error handling when storage.Get fails
+// Validates that blob retrieval properly propagates storage errors
+func TestDefaultServer_GetBlob_StorageFailure(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	blobHash := TestBlobHash
+	storageError := errors.New("storage error")
+
+	// Setup mock expectations
+	testMocks.storage.EXPECT().Get(blobHash).Return(nil, storageError)
+
+	// Test storage failure
+	result, err := server.GetBlob(blobHash)
+	assert.Error(t, err)
+	assert.Equal(t, storageError, err)
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_GetSDBlob_Success tests successful SD blob retrieval from storage
+// Validates that SD blobs can be successfully retrieved directly from the underlying store
+func TestDefaultServer_GetSDBlob_Success(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	sdBlobHash := TestBlobHash
+	expectedData := []byte(TestBlobData)
+
+	// Setup mock expectations
+	testMocks.storage.EXPECT().Get(sdBlobHash).Return(expectedData, nil)
+
+	// Test successful SD blob retrieval
+	result, err := server.GetSDBlob(sdBlobHash)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedData, result)
+}
+
+// TestDefaultServer_GetSDBlob_EmptyHash tests error handling for empty hash
+// Validates that SD blob retrieval properly rejects empty hash values
+func TestDefaultServer_GetSDBlob_EmptyHash(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	// Test with empty hash
+	result, err := server.GetSDBlob("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "hash cannot be empty")
+	assert.Nil(t, result)
+}
+
+// TestDefaultServer_GetSDBlob_StorageFailure tests error handling when storage.Get fails
+// Validates that SD blob retrieval properly propagates storage errors
+func TestDefaultServer_GetSDBlob_StorageFailure(t *testing.T) {
+	t.Parallel()
+
+	testMocks := setupMocks(t)
+	server := setupServer(t, testMocks, map[string]any{})
+
+	sdBlobHash := TestBlobHash
+	storageError := errors.New("storage error")
+
+	// Setup mock expectations
+	testMocks.storage.EXPECT().Get(sdBlobHash).Return(nil, storageError)
+
+	// Test storage failure
+	result, err := server.GetSDBlob(sdBlobHash)
+	assert.Error(t, err)
+	assert.Equal(t, storageError, err)
 	assert.Nil(t, result)
 }
 


### PR DESCRIPTION
- Introduces `GetBlob` and `GetSDBlob` methods to the `BlobManager` interface and `DefaultServer` implementation
- These methods allow direct retrieval of blobs from the underlying storage
- Includes proper hash validation in the server implementation
- Adds comprehensive test coverage for both successful retrieval and error cases (empty hash, storage failures)
- Updates mock definitions in `server/mocks/BlobManager.go` to include the new methods
- Removes unused mock method `CreateDefaultStreamAcquirer` from `client/mocks/StreamAcquirerFactory.go`
---
* Tests can be run with `go test -race ./...`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new methods for direct retrieval of stored blobs and SD blobs with hash validation and error handling

* **Tests**
  * Added extensive unit tests for blob retrieval operations, covering success scenarios, hash validation errors, and storage failure propagation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->