### PR TITLE
feat(server): add support for custom blob store in reflector protocol

### DIFF
--- a/server/builder.go
+++ b/server/builder.go
@@ -115,9 +115,41 @@ func (b *ServerBuilder) WithPeer(port ...int) *ServerBuilder {
 
 // WithReflector adds a Reflector protocol handler on the specified port
 func (b *ServerBuilder) WithReflector(port ...int) *ServerBuilder {
+	// Check if there's an existing config with a custom store to preserve it
+	var existingStore storage.BlobStore
+	if existingConfig, exists := b.config[ProtocolReflector]; exists {
+		if reflectorConfig, ok := existingConfig.(*ReflectorConfig); ok {
+			existingStore = reflectorConfig.Store
+		}
+	}
+
 	return b.withProtocolConfig(ProtocolReflector, DefaultReflectorPort, port, func(p int) any {
-		return &ReflectorConfig{Port: p}
+		config := &ReflectorConfig{Port: p}
+		// Preserve existing custom store if any
+		config.Store = existingStore
+		return config
 	})
+}
+
+// WithReflectorStore sets a custom store for the Reflector protocol handler
+func (b *ServerBuilder) WithReflectorStore(store storage.BlobStore) *ServerBuilder {
+	// Get existing config or create new one
+	var config *ReflectorConfig
+	if existingConfig, exists := b.config[ProtocolReflector]; exists {
+		if reflectorConfig, ok := existingConfig.(*ReflectorConfig); ok {
+			config = reflectorConfig
+		}
+	}
+
+	// If no existing config, create with default port
+	if config == nil {
+		config = &ReflectorConfig{Port: DefaultReflectorPort}
+	}
+
+	// Set the custom store
+	config.Store = store
+	b.config[ProtocolReflector] = config
+	return b
 }
 
 // WithDHT adds a DHT protocol handler on the specified port

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -1224,3 +1224,93 @@ func TestServerBuilder_ChainedMethodsWithDefaultAcquirer(t *testing.T) {
 	require.NoError(t, err)
 	assert.NotNil(t, server)
 }
+
+// TestServerBuilder_WithReflectorStore tests that a custom store can be passed to the reflector
+func TestServerBuilder_WithReflectorStore(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	// Create a custom store for the reflector
+	customStore := storageMocks.NewMockBlobStore(t)
+
+	server, err := NewServerBuilder().
+		WithStorage(testMocks.storage).
+		WithDefaultAcquirer().
+		WithAccessControl(testMocks.accessControl).
+		WithReflector(lbryTesting.GetFreePort(t)).
+		WithReflectorStore(customStore).
+		WithLogger(testMocks.logger).
+		Build()
+
+	require.NoError(t, err)
+	assert.NotNil(t, server)
+
+	// Verify the server was built with the custom store
+	defaultServer := server.(*DefaultServer)
+	require.NotNil(t, defaultServer.config)
+
+	reflectorConfig, exists := defaultServer.config[ProtocolReflector]
+	require.True(t, exists, "Reflector config should exist")
+
+	config, ok := reflectorConfig.(*ReflectorConfig)
+	require.True(t, ok, "Reflector config should be of correct type")
+	require.Equal(t, customStore, config.Store, "Reflector should use custom store")
+}
+
+// TestServerBuilder_WithReflectorDefaultStore tests that the default store is used when no custom store is provided
+func TestServerBuilder_WithReflectorDefaultStore(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	server, err := NewServerBuilder().
+		WithStorage(testMocks.storage).
+		WithDefaultAcquirer().
+		WithAccessControl(testMocks.accessControl).
+		WithReflector(lbryTesting.GetFreePort(t)).
+		WithLogger(testMocks.logger).
+		Build()
+
+	require.NoError(t, err)
+	assert.NotNil(t, server)
+
+	// Verify the server was built with default store (nil in config)
+	defaultServer := server.(*DefaultServer)
+	require.NotNil(t, defaultServer.config)
+
+	reflectorConfig, exists := defaultServer.config[ProtocolReflector]
+	require.True(t, exists, "Reflector config should exist")
+
+	config, ok := reflectorConfig.(*ReflectorConfig)
+	require.True(t, ok, "Reflector config should be of correct type")
+	require.Nil(t, config.Store, "Reflector should use default store when no custom store provided")
+}
+
+// TestServerBuilder_WithReflectorStoreOrder tests that WithReflectorStore works regardless of call order
+func TestServerBuilder_WithReflectorStoreOrder(t *testing.T) {
+	testMocks := setupBuilderMocks(t)
+
+	// Create a custom store for the reflector
+	customStore := storageMocks.NewMockBlobStore(t)
+
+	// Test WithReflectorStore called before WithReflector
+	server1, err := NewServerBuilder().
+		WithStorage(testMocks.storage).
+		WithDefaultAcquirer().
+		WithAccessControl(testMocks.accessControl).
+		WithReflectorStore(customStore).
+		WithReflector(lbryTesting.GetFreePort(t)).
+		WithLogger(testMocks.logger).
+		Build()
+
+	require.NoError(t, err)
+	assert.NotNil(t, server1)
+
+	// Verify the server was built with the custom store
+	defaultServer1 := server1.(*DefaultServer)
+	require.NotNil(t, defaultServer1.config)
+
+	reflectorConfig1, exists := defaultServer1.config[ProtocolReflector]
+	require.True(t, exists, "Reflector config should exist")
+
+	config1, ok := reflectorConfig1.(*ReflectorConfig)
+	require.True(t, ok, "Reflector config should be of correct type")
+	require.Equal(t, customStore, config1.Store, "Reflector should use custom store")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -118,7 +118,8 @@ type PeerConfig struct {
 
 // ReflectorConfig contains configuration for Reflector protocol
 type ReflectorConfig struct {
-	Port int
+	Port  int
+	Store storage.BlobStore // Optional, overrides default store
 }
 
 // DHTConfig contains configuration for DHT protocol
@@ -293,8 +294,14 @@ func (s *DefaultServer) startPeer(config *PeerConfig) error {
 
 // startReflector starts the Reflector protocol handler
 func (s *DefaultServer) startReflector(config *ReflectorConfig) error {
+	// Use custom store if provided, otherwise use default server storage
+	store := config.Store
+	if store == nil {
+		store = s.storage
+	}
+
 	return s.startTCPProtocol(ProtocolReflector, config.Port, func() protocol.ConnectionHandler {
-		return protocol.NewReflectorServer(s.storage,
+		return protocol.NewReflectorServer(store,
 			protocol.WithReflectorAccessControl(s.accessControl),
 			protocol.WithReflectorLogger(s.logger.Named("reflector")),
 			protocol.WithReflectorNotifier(s.notifier),


### PR DESCRIPTION
- Introduces `WithReflectorStore` method to `ServerBuilder` for specifying a custom `BlobStore` for the reflector
- Updates `ReflectorConfig` to include an optional `Store` field
- Modifies `startReflector` to use the custom store if provided, falling back to the default server storage
- Adds comprehensive tests to verify custom store functionality and order independence

---
* Tests can be run with `go test -race ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to configure custom storage for the Reflector protocol
  * Reflector now supports using alternate storage backends

* **Tests**
  * Added comprehensive tests for custom reflector storage configuration, default behavior, and order-independent setup

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->