### PR TITLE
feat!: add context propagation to storage interfaces and implementations

### DIFF
--- a/acquirer.go
+++ b/acquirer.go
@@ -3,6 +3,7 @@ package liblbry
 import (
 	"context"
 	"errors"
+
 	"go.lumeweb.com/liblbry/blob/transfer"
 	liblbryerrors "go.lumeweb.com/liblbry/errors"
 	"go.lumeweb.com/liblbry/storage"
@@ -38,14 +39,14 @@ func (ba *DefaultBlobAcquirer) Acquire(ctx context.Context, hash string) ([]byte
 	}
 
 	// First check if blob already exists in storage
-	has, err := ba.store.Has(hash)
+	has, err := ba.store.Has(ctx, hash)
 	if err != nil {
 		return nil, err
 	}
 
 	if has {
 		// Blob exists in storage, retrieve it
-		data, err := ba.store.Get(hash)
+		data, err := ba.store.Get(ctx, hash)
 		if err != nil {
 			return nil, err
 		}
@@ -60,7 +61,7 @@ func (ba *DefaultBlobAcquirer) Acquire(ctx context.Context, hash string) ([]byte
 		data, err := transferMethod.Get(ctx, hash)
 		if err == nil {
 			// Successfully acquired blob, store it
-			err = ba.store.Put(hash, data)
+			err = ba.store.Put(ctx, hash, data)
 			if err != nil {
 				return nil, err
 			}

--- a/acquirer_test.go
+++ b/acquirer_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.lumeweb.com/liblbry/blob/transfer"
 	transferMocks "go.lumeweb.com/liblbry/blob/transfer/mocks"
@@ -43,8 +44,8 @@ func TestBlobAcquirer_Acquire_FromStorage(t *testing.T) {
 	hash := "testhash123"
 	expectedData := []byte("test data from storage")
 
-	store.EXPECT().Has(hash).Return(true, nil)
-	store.EXPECT().Get(hash).Return(expectedData, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(true, nil)
+	store.EXPECT().Get(mock.Anything, hash).Return(expectedData, nil)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -63,9 +64,9 @@ func TestBlobAcquirer_Acquire_FromTransfer(t *testing.T) {
 	hash := "testhash123"
 	expectedData := []byte("test data from transfer")
 
-	store.EXPECT().Has(hash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, nil)
 	transferMock.EXPECT().Get(context.Background(), hash).Return(expectedData, nil)
-	store.EXPECT().Put(hash, expectedData).Return(nil)
+	store.EXPECT().Put(mock.Anything, hash, expectedData).Return(nil)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -85,10 +86,10 @@ func TestBlobAcquirer_Acquire_TransferFallback(t *testing.T) {
 	hash := "testhash123"
 	expectedData := []byte("test data from second transfer")
 
-	store.EXPECT().Has(hash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, nil)
 	transferMock1.EXPECT().Get(context.Background(), hash).Return(nil, errors.New("first transfer failed"))
 	transferMock2.EXPECT().Get(context.Background(), hash).Return(expectedData, nil)
-	store.EXPECT().Put(hash, expectedData).Return(nil)
+	store.EXPECT().Put(mock.Anything, hash, expectedData).Return(nil)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -107,7 +108,7 @@ func TestBlobAcquirer_Acquire_AllMethodsFail(t *testing.T) {
 
 	hash := "testhash123"
 
-	store.EXPECT().Has(hash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, nil)
 	transferMock1.EXPECT().Get(context.Background(), hash).Return(nil, errors.New("first transfer failed"))
 	transferMock2.EXPECT().Get(context.Background(), hash).Return(nil, errors.New("second transfer failed"))
 
@@ -128,7 +129,7 @@ func TestBlobAcquirer_Acquire_StorageHasError(t *testing.T) {
 	hash := "testhash123"
 	expectedError := errors.New("storage has error")
 
-	store.EXPECT().Has(hash).Return(false, expectedError)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, expectedError)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -147,8 +148,8 @@ func TestBlobAcquirer_Acquire_StorageGetError(t *testing.T) {
 	hash := "testhash123"
 	expectedError := errors.New("storage get error")
 
-	store.EXPECT().Has(hash).Return(true, nil)
-	store.EXPECT().Get(hash).Return(nil, expectedError)
+	store.EXPECT().Has(mock.Anything, hash).Return(true, nil)
+	store.EXPECT().Get(mock.Anything, hash).Return(nil, expectedError)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -166,7 +167,7 @@ func TestBlobAcquirer_Acquire_EmptyTransfersList(t *testing.T) {
 
 	hash := "testhash123"
 
-	store.EXPECT().Has(hash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, nil)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -187,9 +188,9 @@ func TestBlobAcquirer_Acquire_StoragePutError(t *testing.T) {
 	transferData := []byte("test data from transfer")
 	expectedError := errors.New("storage put error")
 
-	store.EXPECT().Has(hash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, nil)
 	transferMock.EXPECT().Get(context.Background(), hash).Return(transferData, nil)
-	store.EXPECT().Put(hash, transferData).Return(expectedError)
+	store.EXPECT().Put(mock.Anything, hash, transferData).Return(expectedError)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -209,9 +210,9 @@ func TestBlobAcquirer_Acquire_TransferNameCalled(t *testing.T) {
 	hash := "testhash123"
 	expectedData := []byte("test data from transfer")
 
-	store.EXPECT().Has(hash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, nil)
 	transferMock.EXPECT().Get(context.Background(), hash).Return(expectedData, nil)
-	store.EXPECT().Put(hash, expectedData).Return(nil)
+	store.EXPECT().Put(mock.Anything, hash, expectedData).Return(nil)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -228,7 +229,7 @@ func TestBlobAcquirer_Acquire_EmptyHash(t *testing.T) {
 
 	hash := ""
 
-	store.EXPECT().Has(hash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, nil)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -247,9 +248,9 @@ func TestBlobAcquirer_Acquire_EmptyDataFromTransfer(t *testing.T) {
 	hash := "testhash123"
 	expectedData := []byte{} // Empty byte array
 
-	store.EXPECT().Has(hash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, nil)
 	transferMock.EXPECT().Get(context.Background(), hash).Return(expectedData, nil)
-	store.EXPECT().Put(hash, expectedData).Return(nil)
+	store.EXPECT().Put(mock.Anything, hash, expectedData).Return(nil)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -267,9 +268,9 @@ func TestBlobAcquirer_Acquire_NilDataFromTransfer(t *testing.T) {
 
 	hash := "testhash123"
 
-	store.EXPECT().Has(hash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, nil)
 	transferMock.EXPECT().Get(context.Background(), hash).Return(nil, nil) // Nil data but no error
-	store.EXPECT().Put(hash, []byte(nil)).Return(nil)
+	store.EXPECT().Put(mock.Anything, hash, []byte(nil)).Return(nil)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)
@@ -290,10 +291,10 @@ func TestBlobAcquirer_Acquire_MultipleTransfersMixedResults(t *testing.T) {
 	hash := "testhash123"
 	expectedData := []byte{} // Empty data from transfer2
 
-	store.EXPECT().Has(hash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, hash).Return(false, nil)
 	transferMock1.EXPECT().Get(context.Background(), hash).Return(nil, errors.New("first transfer failed"))
 	transferMock2.EXPECT().Get(context.Background(), hash).Return([]byte{}, nil) // Empty data
-	store.EXPECT().Put(hash, []byte{}).Return(nil)
+	store.EXPECT().Put(mock.Anything, hash, []byte{}).Return(nil)
 
 	acquirer, err := NewBlobAcquirer(transfers, store)
 	require.NoError(t, err)

--- a/client/stream_acquirer.go
+++ b/client/stream_acquirer.go
@@ -715,7 +715,7 @@ func (r *streamingReader) ensureCurrentBlob() error {
 		)
 
 		err := WithRetry(r.ctx, r.retryOptions, func() error {
-			has, err := r.store.Has(blobHash)
+			has, err := r.store.Has(r.ctx, blobHash)
 			if err != nil {
 				return NewStreamError(OperationStorageHasCheck, r.sdHash, blobHash, err, 1)
 			}
@@ -723,7 +723,7 @@ func (r *streamingReader) ensureCurrentBlob() error {
 				return ErrStreamNotFound
 			}
 
-			data, err := r.store.Get(blobHash)
+			data, err := r.store.Get(r.ctx, blobHash)
 			if err != nil {
 				return NewStreamError(OperationStorageGet, r.sdHash, blobHash, err, 1)
 			}
@@ -816,7 +816,7 @@ func (r *streamingReader) ensureCurrentBlob() error {
 		go func() {
 			defer r.storageWG.Done()
 			// Non-blocking storage to avoid slowing down reads
-			if err := r.store.Put(blobHash, data); err != nil {
+			if err := r.store.Put(r.ctx, blobHash, data); err != nil {
 				// Log error but don't fail the operation
 				r.logger.Error("failed to store blob in storage",
 					zap.String("blobHash", blobHash),
@@ -978,8 +978,8 @@ func (r *streamingReader) startPrefetcher() {
 						zap.Int("blobIndex", blobIndex),
 					)
 
-					if has, err := r.store.Has(blobHash); err == nil && has {
-						data, err := r.store.Get(blobHash)
+					if has, err := r.store.Has(r.ctx, blobHash); err == nil && has {
+						data, err := r.store.Get(r.ctx, blobHash)
 						if err == nil {
 							// Verify blob hash if verification is enabled
 							if r.config.VerificationEnabled {
@@ -1071,7 +1071,7 @@ func (r *streamingReader) startPrefetcher() {
 					r.storageWG.Add(1)
 					go func(hash string, d []byte) {
 						defer r.storageWG.Done()
-						if err := r.store.Put(hash, d); err != nil {
+						if err := r.store.Put(r.ctx, hash, d); err != nil {
 							r.logger.Debug("Prefetch: failed to store blob in storage",
 								zap.String("sdHash", r.sdHash),
 								zap.String("blobHash", hash),
@@ -1315,14 +1315,14 @@ func (sa *DefaultStreamAcquirer) GetStream(ctx context.Context, sdHash string, o
 func (sa *DefaultStreamAcquirer) acquireBlobWithFallback(ctx context.Context, config *AcquireConfig, sdHash, blobHash string, blobIndex int, blobInfo *stream.BlobInfo) ([]byte, error) {
 	// Try storage first if available
 	if sa.store != nil {
-		if has, err := sa.store.Has(blobHash); err == nil && has {
+		if has, err := sa.store.Has(ctx, blobHash); err == nil && has {
 			sa.logger.Debug("Content blob found in storage",
 				zap.String("sdHash", sdHash),
 				zap.String("blobHash", blobHash),
 				zap.Int("blobIndex", blobIndex),
 			)
 
-			blobData, err := sa.store.Get(blobHash)
+			blobData, err := sa.store.Get(ctx, blobHash)
 			if err != nil {
 				sa.logger.Debug("Failed to retrieve blob from storage, acquiring from network",
 					zap.String("sdHash", sdHash),
@@ -1402,7 +1402,7 @@ func (sa *DefaultStreamAcquirer) acquireBlobWithFallback(ctx context.Context, co
 
 	// Store the blob if we have a store
 	if sa.store != nil {
-		if err := sa.store.Put(blobHash, blobData); err != nil {
+		if err := sa.store.Put(nil, blobHash, blobData); err != nil {
 			sa.logger.Debug("Failed to store acquired blob",
 				zap.String("sdHash", sdHash),
 				zap.String("blobHash", blobHash),

--- a/client/stream_acquirer.go
+++ b/client/stream_acquirer.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/avast/retry-go/v4"
-	liblbry "go.lumeweb.com/liblbry"
+	"go.lumeweb.com/liblbry"
 	"go.lumeweb.com/liblbry/blob"
 	liblbryerrors "go.lumeweb.com/liblbry/errors"
 	"go.lumeweb.com/liblbry/storage"
@@ -815,8 +815,10 @@ func (r *streamingReader) ensureCurrentBlob() error {
 		r.storageWG.Add(1)
 		go func() {
 			defer r.storageWG.Done()
-			// Non-blocking storage to avoid slowing down reads
-			if err := r.store.Put(r.ctx, blobHash, data); err != nil {
+			// Use background context for best-effort storage writes that should complete
+			// regardless of reader state, avoiding cancellation when reader is closed
+			ctx := context.Background()
+			if err := r.store.Put(ctx, blobHash, data); err != nil {
 				// Log error but don't fail the operation
 				r.logger.Error("failed to store blob in storage",
 					zap.String("blobHash", blobHash),
@@ -1402,7 +1404,7 @@ func (sa *DefaultStreamAcquirer) acquireBlobWithFallback(ctx context.Context, co
 
 	// Store the blob if we have a store
 	if sa.store != nil {
-		if err := sa.store.Put(nil, blobHash, blobData); err != nil {
+		if err := sa.store.Put(ctx, blobHash, blobData); err != nil {
 			sa.logger.Debug("Failed to store acquired blob",
 				zap.String("sdHash", sdHash),
 				zap.String("blobHash", blobHash),

--- a/client/stream_acquirer_test.go
+++ b/client/stream_acquirer_test.go
@@ -199,8 +199,8 @@ func (ts *testSetup) setupMockExpectations() {
 	}
 	if len(ts.encryptedContent) > 0 {
 		ts.acquirer.EXPECT().Acquire(ts.ctx, ts.contentHash).Return(ts.encryptedContent, nil).Maybe()
-		ts.store.EXPECT().Has(ts.contentHash).Return(false, nil)
-		ts.store.EXPECT().Put(ts.contentHash, ts.encryptedContent).Return(nil)
+		ts.store.EXPECT().Has(mock.Anything, ts.contentHash).Return(false, nil)
+		ts.store.EXPECT().Put(mock.Anything, ts.contentHash, ts.encryptedContent).Return(nil)
 	}
 }
 
@@ -211,8 +211,8 @@ func (ts *testSetup) setupMockExpectationsForBenchmark() {
 	}
 	if len(ts.encryptedContent) > 0 {
 		ts.acquirer.EXPECT().Acquire(ts.ctx, ts.contentHash).Return(ts.encryptedContent, nil)
-		ts.store.EXPECT().Has(ts.contentHash).Return(false, nil)
-		ts.store.EXPECT().Put(ts.contentHash, ts.encryptedContent).Return(nil).Maybe()
+		ts.store.EXPECT().Has(mock.Anything, ts.contentHash).Return(false, nil)
+		ts.store.EXPECT().Put(mock.Anything, ts.contentHash, ts.encryptedContent).Return(nil).Maybe()
 	}
 }
 
@@ -592,8 +592,8 @@ func TestStreamAcquirer_GetStreamResult(t *testing.T) {
 
 	store := storageMocks.NewMockBlobStore(t)
 	store.EXPECT().Name().Return("mock-store")
-	store.EXPECT().Has(contentBlobHash).Return(false, nil)
-	store.EXPECT().Put(contentBlobHash, contentBlobData).Return(nil)
+	store.EXPECT().Has(mock.Anything, contentBlobHash).Return(false, nil)
+	store.EXPECT().Put(mock.Anything, contentBlobHash, contentBlobData).Return(nil)
 
 	streamAcquirer := NewStreamAcquirer(acquirer, store, zaptest.NewLogger(t))
 
@@ -1163,7 +1163,7 @@ func TestStreamReader_WithRetryOnBlobAcquisition(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pre-populate memory store with SD blob
-	err = store.PutSD(sdHash, sdBlobData)
+	err = store.PutSD(context.Background(), sdHash, sdBlobData)
 	require.NoError(t, err)
 
 	// Create mock transfer that fails initially then succeeds
@@ -1317,8 +1317,8 @@ func createVerifiedTestSetup(t *testing.T, contentSize int) *testSetup {
 	// Set up mock expectations with correct hashes
 	acquirer.EXPECT().Acquire(ctx, sdHash).Return(sdBlobData, nil)
 	acquirer.EXPECT().Acquire(ctx, blobHashHex).Return(encryptedContent, nil)
-	store.EXPECT().Has(blobHashHex).Return(false, nil)
-	store.EXPECT().Put(blobHashHex, encryptedContent).Return(nil).Maybe() // May be called multiple times (main + prefetcher)
+	store.EXPECT().Has(mock.Anything, blobHashHex).Return(false, nil)
+	store.EXPECT().Put(mock.Anything, blobHashHex, encryptedContent).Return(nil).Maybe() // May be called multiple times (main + prefetcher)
 	store.EXPECT().Name().Return("mock-store").Maybe()
 
 	streamAcquirer := NewStreamAcquirer(acquirer, store, zaptest.NewLogger(t))
@@ -1410,9 +1410,9 @@ func setupVerificationFailureMocks(t *testing.T, ctx context.Context, sdBlobHash
 	// Set up mocks - SD blob is correct and hashes to sdHash, but verification should fail
 	acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return(sdBlobData, nil)
 	// Content blob acquisition should be called since blob hash doesn't exist in storage
-	store.EXPECT().Has(contentHash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, contentHash).Return(false, nil)
 	acquirer.EXPECT().Acquire(ctx, contentHash).Return(contentData, nil)
-	store.EXPECT().Put(contentHash, contentData).Return(nil).Maybe()
+	store.EXPECT().Put(mock.Anything, contentHash, contentData).Return(nil).Maybe()
 
 	streamAcquirer := NewStreamAcquirer(acquirer, store, zaptest.NewLogger(t))
 	return acquirer, store, streamAcquirer

--- a/internal/testing/concurrency.go
+++ b/internal/testing/concurrency.go
@@ -1,8 +1,10 @@
 package testing
 
 import (
+	"context"
 	"fmt"
 	"sync"
+	"testing"
 
 	"github.com/gammazero/workerpool"
 	"github.com/stretchr/testify/assert"
@@ -23,11 +25,11 @@ import (
 // Storage implementations should satisfy this interface to work with the test helpers.
 type StoreOperations interface {
 	// Has checks if a blob exists in the store
-	Has(hash string) (bool, error)
+	Has(ctx context.Context, hash string) (bool, error)
 	// Get retrieves a blob from the store
-	Get(hash string) ([]byte, error)
+	Get(ctx context.Context, hash string) ([]byte, error)
 	// Put stores a blob in the store
-	Put(hash string, data []byte) error
+	Put(ctx context.Context, hash string, data []byte) error
 }
 
 // RunConcurrentTasks executes multiple tasks concurrently using a worker pool and
@@ -48,7 +50,7 @@ type StoreOperations interface {
 //	    }
 //	}
 //	RunConcurrentTasks(t, 5, tasks)
-func RunConcurrentTasks(t assert.TestingT, maxWorkers int, tasks []func() error) {
+func RunConcurrentTasks(t testing.TB, maxWorkers int, tasks []func() error) {
 	if maxWorkers <= 0 {
 		maxWorkers = 1
 	}
@@ -94,11 +96,11 @@ func RunConcurrentTasks(t assert.TestingT, maxWorkers int, tasks []func() error)
 //	store := NewMemoryStore()
 //	store.Put("testhash", []byte("data"))
 //	TestConcurrentHas(t, store, "testhash", true, 100, 10)
-func TestConcurrentHas(t assert.TestingT, store StoreOperations, hash string, expectedExists bool, tasks int, maxWorkers int) {
+func TestConcurrentHas(t testing.TB, store StoreOperations, hash string, expectedExists bool, tasks int, maxWorkers int) {
 	concurrentTasks := make([]func() error, tasks)
 	for i := 0; i < tasks; i++ {
 		concurrentTasks[i] = func() error {
-			exists, err := store.Has(hash)
+			exists, err := store.Has(t.Context(), hash)
 			if err != nil {
 				return fmt.Errorf("Has error: %v", err)
 			}
@@ -131,11 +133,11 @@ func TestConcurrentHas(t assert.TestingT, store StoreOperations, hash string, ex
 //	store := NewMemoryStore()
 //	store.Put("testhash", []byte("data"))
 //	TestConcurrentGet(t, store, "testhash", []byte("data"), 100, 10)
-func TestConcurrentGet(t assert.TestingT, store StoreOperations, hash string, expectedData []byte, tasks int, maxWorkers int) {
+func TestConcurrentGet(t testing.TB, store StoreOperations, hash string, expectedData []byte, tasks int, maxWorkers int) {
 	concurrentTasks := make([]func() error, tasks)
 	for i := 0; i < tasks; i++ {
 		concurrentTasks[i] = func() error {
-			data, err := store.Get(hash)
+			data, err := store.Get(t.Context(), hash)
 			if err != nil {
 				return fmt.Errorf("Get error: %v", err)
 			}
@@ -170,7 +172,7 @@ func TestConcurrentGet(t assert.TestingT, store StoreOperations, hash string, ex
 //	hashGen := func(i int) string { return fmt.Sprintf("hash%d", i) }
 //	dataGen := func(i int) []byte { return []byte(fmt.Sprintf("data%d", i)) }
 //	TestConcurrentPut(t, store, hashGen, dataGen, 100, 10)
-func TestConcurrentPut(t assert.TestingT, store StoreOperations, hashGen func(int) string, dataGen func(int) []byte, tasks int, maxWorkers int) {
+func TestConcurrentPut(t testing.TB, store StoreOperations, hashGen func(int) string, dataGen func(int) []byte, tasks int, maxWorkers int) {
 	concurrentTasks := make([]func() error, tasks)
 	for i := 0; i < tasks; i++ {
 		id := i // Capture loop variable
@@ -178,11 +180,11 @@ func TestConcurrentPut(t assert.TestingT, store StoreOperations, hashGen func(in
 			hash := hashGen(id)
 			data := dataGen(id)
 
-			if err := store.Put(hash, data); err != nil {
+			if err := store.Put(t.Context(), hash, data); err != nil {
 				return fmt.Errorf("Put error: %v", err)
 			}
 
-			storedData, err := store.Get(hash)
+			storedData, err := store.Get(t.Context(), hash)
 			if err != nil {
 				return fmt.Errorf("Get after Put error: %v", err)
 			}
@@ -206,12 +208,12 @@ func TestConcurrentPut(t assert.TestingT, store StoreOperations, hashGen func(in
 //   - expectedExists: Expected result of Has operation
 //   - tasks: Number of concurrent Has operations to perform
 //   - maxWorkers: Maximum number of concurrent workers
-func TestConcurrentHasMultiple(t assert.TestingT, storeFactory func() StoreOperations, hash string, expectedExists bool, tasks int, maxWorkers int) {
+func TestConcurrentHasMultiple(t testing.TB, storeFactory func() StoreOperations, hash string, expectedExists bool, tasks int, maxWorkers int) {
 	concurrentTasks := make([]func() error, tasks)
 	for i := 0; i < tasks; i++ {
 		concurrentTasks[i] = func() error {
 			store := storeFactory()
-			exists, err := store.Has(hash)
+			exists, err := store.Has(t.Context(), hash)
 			if err != nil {
 				return fmt.Errorf("Has error: %v", err)
 			}
@@ -253,7 +255,7 @@ func TestConcurrentHasMultiple(t assert.TestingT, storeFactory func() StoreOpera
 //	dataGen := func(i int) []byte { return []byte(fmt.Sprintf("data%d", i)) }
 //	TestConcurrentAccess(t, store, "testhash", []byte("data"), hashGen, dataGen, 100, 10)
 func TestConcurrentAccess(
-	t assert.TestingT,
+	t testing.TB,
 	store StoreOperations,
 	hash string,
 	expectedData []byte,
@@ -263,7 +265,7 @@ func TestConcurrentAccess(
 	maxWorkers int,
 ) {
 	// Put initial data
-	err := store.Put(hash, expectedData)
+	err := store.Put(t.Context(), hash, expectedData)
 	assert.NoError(t, err)
 
 	// Test concurrent operations

--- a/protocol/e2e/client_peer_test.go
+++ b/protocol/e2e/client_peer_test.go
@@ -315,16 +315,14 @@ type PeerClientAdapter struct {
 // which is not supported by PeerClient
 var ErrPutNotSupported = errors.New("Put operation not supported by PeerClient")
 
-func (a *PeerClientAdapter) Has(hash string) (bool, error) {
-	ctx := context.Background()
+func (a *PeerClientAdapter) Has(ctx context.Context, hash string) (bool, error) {
 	return a.client.HasBlob(ctx, hash)
 }
 
-func (a *PeerClientAdapter) Get(hash string) ([]byte, error) {
-	ctx := context.Background()
+func (a *PeerClientAdapter) Get(ctx context.Context, hash string) ([]byte, error) {
 	return a.client.GetBlob(ctx, hash)
 }
 
-func (a *PeerClientAdapter) Put(_ string, _ []byte) error {
+func (a *PeerClientAdapter) Put(_ context.Context, _ string, _ []byte) error {
 	return ErrPutNotSupported
 }

--- a/protocol/peer.go
+++ b/protocol/peer.go
@@ -216,12 +216,12 @@ func (p *DefaultPeerServer) HandleConnection(conn net.Conn) {
 
 		// Create context for this request with timeout, preserving source and IP info
 		ctx, cancel := context.WithTimeout(ctx, p.connectionTimeout)
-		defer cancel()
 
 		// Handle request
 		response, blobData, err := p.handleRequest(ctx, request, peerIP)
 		if err != nil {
 			p.sendError(conn, err.Error())
+			cancel()
 			continue
 		}
 
@@ -229,6 +229,7 @@ func (p *DefaultPeerServer) HandleConnection(conn net.Conn) {
 		err = conn.SetWriteDeadline(time.Now().Add(p.connectionTimeout))
 		if err != nil {
 			p.logger.Error("Error setting write deadline", zap.Error(err))
+			cancel()
 			return
 		}
 
@@ -237,6 +238,7 @@ func (p *DefaultPeerServer) HandleConnection(conn net.Conn) {
 			if !strings.Contains(err.Error(), "connection reset by peer") && !strings.Contains(err.Error(), "broken pipe") {
 				p.logger.Error("Error sending response", zap.Error(err))
 			}
+			cancel()
 			return
 		}
 
@@ -244,8 +246,12 @@ func (p *DefaultPeerServer) HandleConnection(conn net.Conn) {
 		err = conn.SetWriteDeadline(time.Time{})
 		if err != nil {
 			p.logger.Error("Error clearing write deadline", zap.Error(err))
+			cancel()
 			return
 		}
+
+		// Cancel the context for this iteration
+		cancel()
 	}
 }
 

--- a/protocol/peer.go
+++ b/protocol/peer.go
@@ -12,6 +12,7 @@ package protocol
 
 import (
 	"bufio"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -32,6 +33,14 @@ import (
 // PeerServer defines the interface for handling peer connections
 type PeerServer interface {
 	ConnectionHandler
+}
+
+// wrapPeerContext creates a new context with peer source and IP address information
+func wrapPeerContext(ctx context.Context, conn net.Conn) context.Context {
+	ip := GetConnectionIP(conn)
+	ctx = context.WithValue(ctx, SourceContextKey, SourcePeer)
+	ctx = context.WithValue(ctx, IPAddressContextKey, ip)
+	return ctx
 }
 
 // getPeerIP extracts the peer IP address from a connection
@@ -157,12 +166,19 @@ func WithPeerNotifier(notifier Notifier) ServerOption {
 func (p *DefaultPeerServer) HandleConnection(conn net.Conn) {
 	defer conn.Close()
 
+	// Wrap context with peer source and IP address information
+	ctx := wrapPeerContext(context.Background(), conn)
+
 	reader := bufio.NewReader(conn)
 	for {
 		// Set read deadline before reading message
 		err := conn.SetReadDeadline(time.Now().Add(p.connectionTimeout))
 		if err != nil {
-			p.logger.Error("Error setting read deadline", zap.Error(err))
+			ip, _ := GetIPAddressFromContext(ctx)
+			p.logger.Error("Error setting read deadline",
+				zap.Error(err),
+				zap.String("source", string(SourcePeer)),
+				zap.String("ip", ip))
 			return
 		}
 
@@ -198,8 +214,12 @@ func (p *DefaultPeerServer) HandleConnection(conn net.Conn) {
 		// Get peer IP for access control
 		peerIP := getPeerIP(conn)
 
+		// Create context for this request with timeout, preserving source and IP info
+		ctx, cancel := context.WithTimeout(ctx, p.connectionTimeout)
+		defer cancel()
+
 		// Handle request
-		response, blobData, err := p.handleRequest(request, peerIP)
+		response, blobData, err := p.handleRequest(ctx, request, peerIP)
 		if err != nil {
 			p.sendError(conn, err.Error())
 			continue
@@ -296,14 +316,14 @@ func (p *DefaultPeerServer) parseRequest(data []byte) (CompositeRequest, error) 
 }
 
 // handleRequest processes a parsed request and returns a response
-func (p *DefaultPeerServer) handleRequest(request CompositeRequest, peerIP string) (CompositeResponse, []byte, error) {
+func (p *DefaultPeerServer) handleRequest(ctx context.Context, request CompositeRequest, peerIP string) (CompositeResponse, []byte, error) {
 	response := CompositeResponse{
 		AvailableBlobs: []string{}, // Always initialize as empty slice
 	}
 
 	// Handle blob data request (highest priority)
 	if request.RequestedBlob != "" {
-		incomingBlob, blobData, err := p.handleBlobDataRequest(request.RequestedBlob, peerIP)
+		incomingBlob, blobData, err := p.handleBlobDataRequest(ctx, request.RequestedBlob, peerIP)
 		if err != nil {
 			return CompositeResponse{}, nil, err
 		}
@@ -313,7 +333,7 @@ func (p *DefaultPeerServer) handleRequest(request CompositeRequest, peerIP strin
 
 	// Handle payment rate request
 	if request.BlobDataPaymentRate != nil {
-		paymentRateResponse, err := p.handleBlobPaymentRateRequest(request.RequestedBlobs, *request.BlobDataPaymentRate, peerIP)
+		paymentRateResponse, err := p.handleBlobPaymentRateRequest(ctx, request.RequestedBlobs, *request.BlobDataPaymentRate, peerIP)
 		if err != nil {
 			return CompositeResponse{}, nil, err
 		}
@@ -321,12 +341,12 @@ func (p *DefaultPeerServer) handleRequest(request CompositeRequest, peerIP strin
 		response.BlobDataPaymentRate = paymentRateResponse
 
 		// Also handle availability if requested_blobs is present
-		return p.handleBlobAvailabilityInResponse(request.RequestedBlobs, response, peerIP)
+		return p.handleBlobAvailabilityInResponse(ctx, request.RequestedBlobs, response, peerIP)
 	}
 
 	// Handle blob availability request
 	if len(request.RequestedBlobs) > 0 {
-		availableBlobs, err := p.handleBlobAvailabilityRequest(request.RequestedBlobs, peerIP)
+		availableBlobs, err := p.handleBlobAvailabilityRequest(ctx, request.RequestedBlobs, peerIP)
 		if err != nil {
 			return CompositeResponse{}, nil, err
 		}
@@ -339,7 +359,7 @@ func (p *DefaultPeerServer) handleRequest(request CompositeRequest, peerIP strin
 }
 
 // handleBlobAvailabilityRequest processes a blob availability check request
-func (p *DefaultPeerServer) handleBlobAvailabilityRequest(blobHashes []string, peerIP string) ([]string, error) {
+func (p *DefaultPeerServer) handleBlobAvailabilityRequest(ctx context.Context, blobHashes []string, peerIP string) ([]string, error) {
 	availableBlobs := make([]string, 0)
 
 	// Process each blob hash - handle both nil and empty slice cases
@@ -367,7 +387,7 @@ func (p *DefaultPeerServer) handleBlobAvailabilityRequest(blobHashes []string, p
 		}
 
 		// Check if blob exists
-		available, err := p.store.Has(hash)
+		available, err := p.store.Has(ctx, hash)
 		if err != nil {
 			continue
 		}
@@ -389,7 +409,7 @@ func (p *DefaultPeerServer) isProtected(hash string) bool {
 }
 
 // handleBlobDataRequest processes a blob data request
-func (p *DefaultPeerServer) handleBlobDataRequest(blobHash string, peerIP string) (*IncomingBlob, []byte, error) {
+func (p *DefaultPeerServer) handleBlobDataRequest(ctx context.Context, blobHash string, peerIP string) (*IncomingBlob, []byte, error) {
 	// Validate hash length
 	if len(blobHash) != blob.BlobHashHexLength {
 		return p.createIncomingBlobError(blobHash, liblbryerrors.ErrInvalidHashLen.Error()), nil, nil
@@ -411,7 +431,7 @@ func (p *DefaultPeerServer) handleBlobDataRequest(blobHash string, peerIP string
 	}
 
 	// Get blob data
-	data, err := p.store.Get(blobHash)
+	data, err := p.store.Get(ctx, blobHash)
 	if err != nil {
 		// Log detailed error server-side
 		p.logger.Error("Failed to retrieve blob", zap.String("blobHash", blobHash), zap.Error(err))
@@ -439,7 +459,7 @@ func (p *DefaultPeerServer) handleBlobDataRequest(blobHash string, peerIP string
 }
 
 // handleBlobPaymentRateRequest processes a payment rate negotiation request
-func (p *DefaultPeerServer) handleBlobPaymentRateRequest(blobHashes []string, paymentRate float64, peerIP string) (string, error) {
+func (p *DefaultPeerServer) handleBlobPaymentRateRequest(ctx context.Context, blobHashes []string, paymentRate float64, peerIP string) (string, error) {
 	// Check if payment rate is negative
 	if paymentRate < 0 {
 		return PaymentRateTooLow, nil
@@ -473,7 +493,7 @@ func (p *DefaultPeerServer) handleBlobPaymentRateRequest(blobHashes []string, pa
 	}
 
 	// Check if blob exists
-	available, err := p.store.Has(blobHash)
+	available, err := p.store.Has(ctx, blobHash)
 	if err != nil || !available {
 		return PaymentRateTooLow, nil
 	}
@@ -547,9 +567,9 @@ func (p *DefaultPeerServer) createIncomingBlobError(blobHash string, errorMsg st
 }
 
 // handleBlobAvailabilityInResponse handles blob availability checking and updates response
-func (p *DefaultPeerServer) handleBlobAvailabilityInResponse(blobHashes []string, response CompositeResponse, peerIP string) (CompositeResponse, []byte, error) {
+func (p *DefaultPeerServer) handleBlobAvailabilityInResponse(ctx context.Context, blobHashes []string, response CompositeResponse, peerIP string) (CompositeResponse, []byte, error) {
 	if len(blobHashes) > 0 {
-		availableBlobs, err := p.handleBlobAvailabilityRequest(blobHashes, peerIP)
+		availableBlobs, err := p.handleBlobAvailabilityRequest(ctx, blobHashes, peerIP)
 		if err != nil {
 			return response, nil, err
 		}

--- a/protocol/peer_client_integration_test.go
+++ b/protocol/peer_client_integration_test.go
@@ -116,7 +116,7 @@ func setupPeerTestClient(t *testing.T, addr string, logger *zap.Logger, timeout 
 // createAndStoreTestBlob creates a blob and stores it in the memory store
 func createAndStoreTestBlob(t *testing.T, store *memory.MemoryStore, testData []byte) (blob.Blob, string) {
 	testBlob, blobHash, _, _ := createPeerTestBlob(t, testData)
-	err := store.Put(blobHash, testBlob)
+	err := store.Put(t.Context(), blobHash, testBlob)
 	require.NoError(t, err)
 	return testBlob, blobHash
 }
@@ -187,7 +187,7 @@ func TestPeerBlobOperations(t *testing.T) {
 	retrievedData, err := client.GetBlob(ctx, blobHash)
 	require.NoError(t, err)
 	// Verify the retrieved data matches what we stored
-	storedData, err := store.Get(blobHash)
+	storedData, err := store.Get(t.Context(), blobHash)
 	require.NoError(t, err)
 	assert.Equal(t, storedData, retrievedData)
 
@@ -222,7 +222,7 @@ func TestPeerStreamOperations(t *testing.T) {
 
 	// Add the blobs to the server's store so it can serve them
 	for _, blobItem := range resultStream {
-		err = store.Put(blobItem.HashHex(), blobItem)
+		err = store.Put(t.Context(), blobItem.HashHex(), blobItem)
 		require.NoError(t, err)
 	}
 
@@ -587,7 +587,7 @@ func TestPeerEmptyBlobHandling(t *testing.T) {
 	testData := make([]byte, 1)
 	testData[0] = 0x00
 	testBlob, blobHash, key, iv := createPeerTestBlob(t, testData)
-	err := store.Put(blobHash, testBlob)
+	err := store.Put(t.Context(), blobHash, testBlob)
 	require.NoError(t, err)
 
 	client := setupPeerTestClient(t, addr, logger)

--- a/protocol/peer_test.go
+++ b/protocol/peer_test.go
@@ -102,17 +102,17 @@ func setupMockStore(t *testing.T, withBlobs bool) *storagemocks.MockBlobStore {
 	if withBlobs {
 		for k, v := range blobs {
 			// Set up mock behavior for Has method - use Maybe() to make it flexible
-			mockStore.On("Has", k).Maybe().Return(true, nil)
+			mockStore.On("Has", mock.Anything, k).Maybe().Return(true, nil)
 			// Set up mock behavior for Get method - use Maybe() to make it flexible
-			mockStore.On("Get", k).Maybe().Return(v, nil)
+			mockStore.On("Get", mock.Anything, k).Maybe().Return(v, nil)
 		}
 
 		// For non-existent blobs, Has should return false
-		mockStore.On("Has", mock.AnythingOfType("string")).Maybe().Return(false, nil)
-		mockStore.On("Get", mock.AnythingOfType("string")).Maybe().Return([]byte(nil), nil)
+		mockStore.On("Has", mock.Anything, mock.AnythingOfType("string")).Maybe().Return(false, nil)
+		mockStore.On("Get", mock.Anything, mock.AnythingOfType("string")).Maybe().Return([]byte(nil), nil)
 	} else {
-		mockStore.On("Has", mock.AnythingOfType("string")).Maybe().Return(false, nil)
-		mockStore.On("Get", mock.AnythingOfType("string")).Maybe().Return([]byte(nil), nil)
+		mockStore.On("Has", mock.Anything, mock.AnythingOfType("string")).Maybe().Return(false, nil)
+		mockStore.On("Get", mock.Anything, mock.AnythingOfType("string")).Maybe().Return([]byte(nil), nil)
 	}
 
 	// Set up mock behavior for Name method - use Maybe() to make it flexible
@@ -161,7 +161,7 @@ func handleRequestAndCompareWithIP(t *testing.T, server PeerServer, requestJSON,
 		return
 	}
 
-	response, blobData, err := server.(*DefaultPeerServer).handleRequest(req, peerIP)
+	response, blobData, err := server.(*DefaultPeerServer).handleRequest(t.Context(), req, peerIP)
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 		return
@@ -206,7 +206,7 @@ func unmarshalExpectedResponse(t *testing.T, expectedJSON []byte) CompositeRespo
 // Helper function to handle request with error handling
 func handleTestRequest(t *testing.T, server PeerServer, request CompositeRequest) (CompositeResponse, []byte) {
 	t.Helper()
-	response, blobData, err := server.(*DefaultPeerServer).handleRequest(request, testLocalIP)
+	response, blobData, err := server.(*DefaultPeerServer).handleRequest(t.Context(), request, testLocalIP)
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -1,8 +1,74 @@
 package protocol
 
 import (
+	"context"
 	"net"
+	"net/netip"
 )
+
+// Context key types to avoid collisions
+type contextKey string
+
+const (
+	// SourceContextKey is the context key for the request source (peer or reflector)
+	SourceContextKey contextKey = "source"
+
+	// IPAddressContextKey is the context key for the client IP address
+	IPAddressContextKey contextKey = "ip_address"
+)
+
+// Source represents the source of a request
+type Source string
+
+const (
+	// SourcePeer indicates the request came from a peer
+	SourcePeer Source = "peer"
+
+	// SourceReflector indicates the request came from a reflector
+	SourceReflector Source = "reflector"
+)
+
+// GetConnectionIP extracts the IP address from a net.Conn
+func GetConnectionIP(conn net.Conn) string {
+	addr := conn.RemoteAddr().String()
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// If we can't split the address, try to parse it as an IP directly
+		if ip, err := netip.ParseAddr(addr); err == nil {
+			return ip.String()
+		}
+		return ""
+	}
+
+	// Validate that the host is a proper IP address
+	if ip, err := netip.ParseAddr(host); err == nil {
+		return ip.String()
+	}
+
+	return ""
+}
+
+// GetSourceFromContext safely extracts the Source from a context
+func GetSourceFromContext(ctx context.Context) (Source, bool) {
+	value := ctx.Value(SourceContextKey)
+	if value == nil {
+		return "", false
+	}
+
+	source, ok := value.(Source)
+	return source, ok
+}
+
+// GetIPAddressFromContext safely extracts the IP address from a context
+func GetIPAddressFromContext(ctx context.Context) (string, bool) {
+	value := ctx.Value(IPAddressContextKey)
+	if value == nil {
+		return "", false
+	}
+
+	ip, ok := value.(string)
+	return ip, ok
+}
 
 // Protocol port constants
 const (

--- a/protocol/reflector.go
+++ b/protocol/reflector.go
@@ -12,6 +12,7 @@ package protocol
 
 import (
 	"bufio"
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -31,6 +32,14 @@ import (
 // ReflectorServer defines the interface for handling reflector connections
 type ReflectorServer interface {
 	ConnectionHandler
+}
+
+// wrapReflectorContext creates a new context with reflector source and IP address information
+func wrapReflectorContext(ctx context.Context, conn net.Conn) context.Context {
+	ip := GetConnectionIP(conn)
+	ctx = context.WithValue(ctx, SourceContextKey, SourceReflector)
+	ctx = context.WithValue(ctx, IPAddressContextKey, ip)
+	return ctx
 }
 
 // Protocol constants
@@ -120,18 +129,30 @@ func WithReflectorNotifier(notifier Notifier) ReflectorServerOption {
 func (r *DefaultReflectorServer) HandleConnection(conn net.Conn) {
 	defer conn.Close()
 
+	// Wrap context with reflector source and IP address information
+	ctx := wrapReflectorContext(context.Background(), conn)
+
 	reader := bufio.NewReader(conn)
 
 	// Perform handshake
 	if err := r.doHandshake(conn, reader); err != nil {
-		r.logger.Error("Handshake failed", zap.Error(err))
+		ip, _ := GetIPAddressFromContext(ctx)
+		r.logger.Error("Handshake failed",
+			zap.Error(err),
+			zap.String("source", string(SourceReflector)),
+			zap.String("ip", ip))
 		r.sendError(conn, err)
 		return
 	}
 
 	// Handle blob uploads
 	for {
-		err := r.receiveBlob(conn, reader)
+		// Create context for each blob operation with timeout, preserving source and IP info
+		ctx, cancel := context.WithTimeout(ctx, r.connectionTimeout)
+
+		err := r.receiveBlob(ctx, conn, reader)
+		cancel() // Cancel context when done with this blob
+
 		if err != nil {
 			if err == io.EOF {
 				return // Normal connection close
@@ -164,7 +185,7 @@ func (r *DefaultReflectorServer) doHandshake(conn net.Conn, reader *bufio.Reader
 }
 
 // receiveBlob handles a blob upload request
-func (r *DefaultReflectorServer) receiveBlob(conn net.Conn, reader *bufio.Reader) error {
+func (r *DefaultReflectorServer) receiveBlob(ctx context.Context, conn net.Conn, reader *bufio.Reader) error {
 	// Read blob request
 	blobSize, blobHash, isSdBlob, err := r.readBlobRequest(conn, reader)
 	if err != nil {
@@ -177,7 +198,7 @@ func (r *DefaultReflectorServer) receiveBlob(conn net.Conn, reader *bufio.Reader
 	}
 
 	// Check if we want this blob
-	shouldSend, neededBlobs, err := r.shouldAcceptBlob(blobHash, isSdBlob, peerIP)
+	shouldSend, neededBlobs, err := r.shouldAcceptBlob(ctx, blobHash, isSdBlob, peerIP)
 	if err != nil {
 		return err
 	}
@@ -215,9 +236,9 @@ func (r *DefaultReflectorServer) receiveBlob(conn net.Conn, reader *bufio.Reader
 
 	// Store blob
 	if isSdBlob {
-		err = r.store.PutSD(blobHash, blobData)
+		err = r.store.PutSD(ctx, blobHash, blobData)
 	} else {
-		err = r.store.Put(blobHash, blobData)
+		err = r.store.Put(ctx, blobHash, blobData)
 	}
 	if err != nil {
 		return errors.Join(liblbryerrors.ErrFailedToStoreBlob, fmt.Errorf("failed to store blob %s: %w", safeHashPrefix(blobHash), err))
@@ -269,7 +290,7 @@ func (r *DefaultReflectorServer) readBlobRequest(conn net.Conn, reader *bufio.Re
 }
 
 // shouldAcceptBlob determines if the server should accept a blob
-func (r *DefaultReflectorServer) shouldAcceptBlob(blobHash string, isSdBlob bool, peerIP string) (bool, []string, error) {
+func (r *DefaultReflectorServer) shouldAcceptBlob(ctx context.Context, blobHash string, isSdBlob bool, peerIP string) (bool, []string, error) {
 	// Check access control
 	if r.accessControl != nil && !r.accessControl.Allow(blobHash, peerIP) {
 		return false, []string{}, nil
@@ -288,7 +309,7 @@ func (r *DefaultReflectorServer) shouldAcceptBlob(blobHash string, isSdBlob bool
 		decidedByBlocklister = true
 	} else {
 		// Fall back to Has() method
-		blobExists, err := r.store.Has(blobHash)
+		blobExists, err := r.store.Has(ctx, blobHash)
 		if err != nil {
 			return false, nil, errors.Join(liblbryerrors.ErrFailedToCheckBlobExistence, err)
 		}

--- a/protocol/reflector_client_test.go
+++ b/protocol/reflector_client_test.go
@@ -216,7 +216,7 @@ func TestReflectorClientConnectAndClose(t *testing.T) {
 	// Add blob to store to test upload
 	testData := []byte("test blob data")
 	testBlob, blobHash, _, _ := createReflectorTestBlob(t, testData)
-	err := store.Put(blobHash, testBlob)
+	err := store.Put(t.Context(), blobHash, testBlob)
 	require.NoError(t, err)
 }
 
@@ -237,7 +237,7 @@ func TestReflectorClientSendBlob_DuplicateHandling(t *testing.T) {
 	require.NoError(t, err)
 
 	// Store blob to test duplicate handling
-	err = store.Put(blobHash, testBlob)
+	err = store.Put(t.Context(), blobHash, testBlob)
 	require.NoError(t, err)
 
 	// Second upload should return ErrBlobExists
@@ -282,7 +282,7 @@ func TestReflectorClientSendSDBlob_DuplicateHandling_StoreWithoutNeededBlobCheck
 	require.NoError(t, err)
 
 	// Store SD blob to test duplicate handling
-	err = sdStore.Put(sdBlobHash, sdTestBlob)
+	err = sdStore.Put(t.Context(), sdBlobHash, sdTestBlob)
 	require.NoError(t, err)
 
 	// Second SD blob upload should succeed (not return error) because MemoryStore
@@ -401,7 +401,7 @@ func TestReflectorClientConcurrentClients(t *testing.T) {
 	// Create ONE blob that all clients will try to upload
 	testData := []byte("This is test blob data for concurrent access")
 	testBlob, blobHash, _, _ := createReflectorTestBlob(t, testData)
-	err := store.Put(blobHash, testBlob)
+	err := store.Put(t.Context(), blobHash, testBlob)
 	require.NoError(t, err)
 
 	// Create tasks for concurrent execution
@@ -464,14 +464,14 @@ func TestReflectorClientLargeBlobHandling(t *testing.T) {
 	require.NoError(t, err)
 
 	// NOW put the blob in the store to test duplicate handling
-	err = store.Put(blobHash, largeBlob)
+	err = store.Put(t.Context(), blobHash, largeBlob)
 	require.NoError(t, err)
 
 	// Create a fresh client and server for testing duplicate upload
 	store2, logger2, _, addr2 := setupReflectorIntegrationTest(t)
 
 	// Put the same blob in the new store
-	err = store2.Put(blobHash, largeBlob)
+	err = store2.Put(t.Context(), blobHash, largeBlob)
 	require.NoError(t, err)
 
 	client2 := setupReflectorTestClient(t, addr2, logger2)
@@ -533,7 +533,7 @@ func TestReflectorClientNetworkFailureRecovery(t *testing.T) {
 	require.NoError(t, err)
 
 	// Now put the blob in the store to test duplicate handling after recovery
-	err = store.Put(blobHash, testBlob)
+	err = store.Put(t.Context(), blobHash, testBlob)
 	require.NoError(t, err)
 
 	// Simulate network failure by closing connection
@@ -592,7 +592,7 @@ func TestReflectorClientPartialBlobTransfer(t *testing.T) {
 	// Create test data
 	testData := []byte("This is a test blob for partial transfer")
 	testBlob, blobHash, _, _ := createReflectorTestBlob(t, testData)
-	err := store.Put(blobHash, testBlob)
+	err := store.Put(t.Context(), blobHash, testBlob)
 	require.NoError(t, err)
 
 	// Set up a custom dial function that returns our stall connection

--- a/protocol/reflector_test.go
+++ b/protocol/reflector_test.go
@@ -122,14 +122,14 @@ func setupReflectorMockStore(t *testing.T, withBlobs bool) *storageMocks.MockBlo
 	if withBlobs {
 		for k, v := range reflectorTestBlobs {
 			// Set up mock behavior for Has method
-			mockStore.On("Has", k).Return(true, nil)
+			mockStore.On("Has", mock.Anything, k).Return(true, nil)
 			// Set up mock behavior for Get method
 			mockStore.On("Get", k).Return(v, nil)
 		}
 	}
 
 	// For non-existent blobs, Has should return false
-	mockStore.On("Has", mock.AnythingOfType("string")).Return(false, nil)
+	mockStore.On("Has", mock.Anything, mock.AnythingOfType("string")).Return(false, nil)
 	mockStore.On("Get", mock.AnythingOfType("string")).Return([]byte(nil), errors.New("blob not found"))
 
 	// Set up mock behavior for Name method
@@ -326,9 +326,9 @@ func TestShouldAcceptBlob_NewBlob(t *testing.T) {
 	server := NewReflectorServer(store)
 
 	// Mock store methods
-	store.On("Has", validBlobHash1).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, validBlobHash1).Return(false, nil)
 
-	shouldSend, neededBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(validBlobHash1, false, testLocalIP)
+	shouldSend, neededBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), validBlobHash1, false, testLocalIP)
 
 	assert.NoError(t, err, "Expected shouldAcceptBlob to succeed")
 	assert.True(t, shouldSend, "Expected shouldSend to be true for new blob")
@@ -341,9 +341,9 @@ func TestShouldAcceptBlob_ExistingRegularBlob_WithNeededBlobChecker(t *testing.T
 	server := NewReflectorServer(mockStore)
 
 	// Mock store methods - regular blob already exists
-	mockStore.On("Has", validBlobHash1).Return(true, nil)
+	mockStore.EXPECT().Has(mock.Anything, validBlobHash1).Return(true, nil)
 
-	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(validBlobHash1, false, testLocalIP)
+	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), validBlobHash1, false, testLocalIP)
 
 	assert.NoError(t, err, "Expected shouldAcceptBlob to succeed")
 	assert.False(t, shouldSend, "Expected shouldSend to be false for existing regular blob")
@@ -359,9 +359,9 @@ func TestShouldAcceptBlob_ExistingRegularBlob_WithoutNeededBlobChecker(t *testin
 	server := NewReflectorServer(mockStore)
 
 	// Mock store methods - regular blob already exists
-	mockStore.On("Has", validBlobHash1).Return(true, nil)
+	mockStore.EXPECT().Has(mock.Anything, validBlobHash1).Return(true, nil)
 
-	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(validBlobHash1, false, testLocalIP)
+	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), validBlobHash1, false, testLocalIP)
 
 	assert.NoError(t, err, "Expected shouldAcceptBlob to succeed")
 	assert.False(t, shouldSend, "Expected shouldSend to be false for existing regular blob")
@@ -377,12 +377,12 @@ func TestShouldAcceptBlob_ExistingRegularBlob_NeededBlobCheckerError(t *testing.
 	server := NewReflectorServer(mockStore)
 
 	// Mock store methods - regular blob already exists
-	mockStore.On("Has", validBlobHash1).Return(true, nil)
+	mockStore.EXPECT().Has(mock.Anything, validBlobHash1).Return(true, nil)
 
 	// For regular blobs (isSdBlob=false), MissingBlobsForKnownStream should NOT be called
 	// Remove the expectation that it gets called since it's only called for SD blobs
 
-	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(validBlobHash1, false, testLocalIP)
+	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), validBlobHash1, false, testLocalIP)
 
 	// For regular blobs, shouldAcceptBlob should return false without error
 	// because the blob already exists and we don't want to re-upload it
@@ -402,13 +402,13 @@ func TestShouldAcceptBlob_ExistingSDBlob_WithNeededBlobChecker(t *testing.T) {
 	server := NewReflectorServer(mockStore)
 
 	// Mock store methods - SD blob already exists
-	mockStore.On("Has", validBlobHash1).Return(true, nil)
+	mockStore.EXPECT().Has(mock.Anything, validBlobHash1).Return(true, nil)
 
 	// Mock NeededBlobChecker methods
 	neededBlobs := []string{"blob1", "blob2"}
-	mockStore.On("MissingBlobsForKnownStream", validBlobHash1).Return(neededBlobs, nil)
+	mockStore.EXPECT().MissingBlobsForKnownStream(validBlobHash1).Return(neededBlobs, nil)
 
-	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(validBlobHash1, true, testLocalIP)
+	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), validBlobHash1, true, testLocalIP)
 
 	assert.NoError(t, err, "Expected shouldAcceptBlob to succeed")
 	assert.False(t, shouldSend, "Expected shouldSend to be false for existing SD blob")
@@ -424,9 +424,9 @@ func TestShouldAcceptBlob_ExistingSDBlob_WithoutNeededBlobChecker(t *testing.T) 
 	server := NewReflectorServer(mockStore)
 
 	// Mock store methods - SD blob already exists
-	mockStore.On("Has", validBlobHash1).Return(true, nil)
+	mockStore.EXPECT().Has(mock.Anything, validBlobHash1).Return(true, nil)
 
-	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(validBlobHash1, true, testLocalIP)
+	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), validBlobHash1, true, testLocalIP)
 
 	assert.NoError(t, err, "Expected shouldAcceptBlob to succeed")
 	assert.True(t, shouldSend, "Expected shouldSend to be true for existing SD blob")
@@ -442,13 +442,13 @@ func TestShouldAcceptBlob_ExistingSDBlob_NeededBlobCheckerError(t *testing.T) {
 	server := NewReflectorServer(mockStore)
 
 	// Mock store methods - SD blob already exists
-	mockStore.On("Has", validBlobHash1).Return(true, nil)
+	mockStore.EXPECT().Has(mock.Anything, validBlobHash1).Return(true, nil)
 
 	// Mock NeededBlobChecker methods with error
 	expectedError := errors.New("needed blob checker error")
 	mockStore.EXPECT().MissingBlobsForKnownStream(validBlobHash1).Return(nil, expectedError)
 
-	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(validBlobHash1, true, testLocalIP)
+	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), validBlobHash1, true, testLocalIP)
 
 	assert.Error(t, err, "Expected shouldAcceptBlob to fail with error")
 	assert.False(t, shouldSend, "Expected shouldSend to remain false when MissingBlobsForKnownStream errors")
@@ -466,9 +466,9 @@ func TestShouldAcceptBlob_WithBlocklister_WantsTrue(t *testing.T) {
 	server := NewReflectorServer(mockStore)
 
 	// Mock Blocklister methods - wants returns true
-	mockStore.On("Wants", validBlobHash1).Return(true, nil)
+	mockStore.EXPECT().Wants(validBlobHash1).Return(true, nil)
 
-	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(validBlobHash1, false, testLocalIP)
+	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), validBlobHash1, false, testLocalIP)
 
 	assert.NoError(t, err, "Expected shouldAcceptBlob to succeed")
 	assert.True(t, shouldSend, "Expected shouldSend to be true when Wants returns true")
@@ -484,9 +484,9 @@ func TestShouldAcceptBlob_WithBlocklister_WantsFalse(t *testing.T) {
 	server := NewReflectorServer(mockStore)
 
 	// Mock Blocklister methods - wants returns false
-	mockStore.On("Wants", validBlobHash1).Return(false, nil)
+	mockStore.EXPECT().Wants(validBlobHash1).Return(false, nil)
 
-	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(validBlobHash1, false, testLocalIP)
+	shouldSend, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), validBlobHash1, false, testLocalIP)
 
 	assert.NoError(t, err, "Expected shouldAcceptBlob to succeed")
 	assert.False(t, shouldSend, "Expected shouldSend to be false when Wants returns false")
@@ -503,9 +503,9 @@ func TestShouldAcceptBlob_WithBlocklister_Error(t *testing.T) {
 
 	// Mock Blocklister methods - wants returns error
 	expectedError := errors.New("blocklister error")
-	mockStore.On("Wants", validBlobHash1).Return(false, expectedError)
+	mockStore.EXPECT().Wants(validBlobHash1).Return(false, expectedError)
 
-	_, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(validBlobHash1, false, testLocalIP)
+	_, returnedBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), validBlobHash1, false, testLocalIP)
 
 	assert.Error(t, err, "Expected shouldAcceptBlob to fail with error")
 	// Check if the wrapped error matches
@@ -673,10 +673,10 @@ func TestReceiveBlob_Success(t *testing.T) {
 	blobHash := server.(*DefaultReflectorServer).calculateBlobHash(blobData)
 
 	// Mock store methods
-	store.On("Has", blobHash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, blobHash).Return(false, nil)
 
 	// Test shouldAcceptBlob first
-	shouldSend, neededBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(blobHash, false, "127.0.0.1")
+	shouldSend, neededBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), blobHash, false, "127.0.0.1")
 	assert.NoError(t, err, "Expected shouldAcceptBlob to succeed")
 	assert.True(t, shouldSend, "Expected shouldSend to be true for new blob")
 	assert.Empty(t, neededBlobs, "Expected no needed blobs for regular blob")
@@ -713,10 +713,10 @@ func TestReceiveBlob_SDBlob(t *testing.T) {
 	sdHash := server.(*DefaultReflectorServer).calculateBlobHash(sdBlobData)
 
 	// Mock store methods
-	store.On("Has", sdHash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, sdHash).Return(false, nil)
 
 	// Test shouldAcceptBlob for SD blob
-	shouldSend, _, err := server.(*DefaultReflectorServer).shouldAcceptBlob(sdHash, true, "127.0.0.1")
+	shouldSend, _, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), sdHash, true, "127.0.0.1")
 	assert.NoError(t, err, "Expected shouldAcceptBlob to succeed")
 	assert.True(t, shouldSend, "Expected shouldSend to be true for new SD blob")
 
@@ -735,7 +735,7 @@ func TestReceiveBlob_ExistingBlob(t *testing.T) {
 	blobHash := server.(*DefaultReflectorServer).calculateBlobHash(blobData)
 
 	// Mock store methods - blob already exists
-	store.On("Has", blobHash).Return(true, nil)
+	store.EXPECT().Has(mock.Anything, blobHash).Return(true, nil)
 
 	// Write blob request
 	request := SendBlobRequest{
@@ -747,12 +747,12 @@ func TestReceiveBlob_ExistingBlob(t *testing.T) {
 
 	// Receive blob (should not read blob data since we don't want it)
 	reader := bufio.NewReader(conn)
-	err := server.(*DefaultReflectorServer).receiveBlob(conn, reader)
+	err := server.(*DefaultReflectorServer).receiveBlob(t.Context(), conn, reader)
 
 	assert.NoError(t, err, "Expected receiveBlob to succeed for existing blob")
 
 	// Verify only Has was called, not Put
-	store.AssertCalled(t, "Has", blobHash)
+	store.AssertCalled(t, "Has", mock.Anything, blobHash)
 	store.AssertNotCalled(t, "Put", mock.Anything, mock.Anything)
 }
 
@@ -766,10 +766,10 @@ func TestReceiveBlob_Integration(t *testing.T) {
 	blobHash := server.(*DefaultReflectorServer).calculateBlobHash(blobData)
 
 	// Mock store expectations - we only test Has since we're not testing full blob storage
-	store.On("Has", blobHash).Return(false, nil)
+	store.EXPECT().Has(mock.Anything, blobHash).Return(false, nil)
 
 	// Test shouldAcceptBlob first - this is called by receiveBlob
-	shouldSend, neededBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(blobHash, false, testLocalIP)
+	shouldSend, neededBlobs, err := server.(*DefaultReflectorServer).shouldAcceptBlob(t.Context(), blobHash, false, testLocalIP)
 	assert.NoError(t, err)
 	assert.True(t, shouldSend)
 	assert.Empty(t, neededBlobs)
@@ -786,7 +786,7 @@ func TestReceiveBlob_Integration(t *testing.T) {
 	assert.Contains(t, string(conn.GetWrittenData()), `"received_blob":true`)
 
 	// Verify only Has was called, not Put since we're not testing full blob storage
-	store.AssertCalled(t, "Has", blobHash)
+	store.AssertCalled(t, "Has", mock.Anything, blobHash)
 	store.AssertNotCalled(t, "Put", mock.Anything, mock.Anything)
 }
 
@@ -805,7 +805,7 @@ func TestReceiveBlob_NegativeSize(t *testing.T) {
 
 	// Receive blob
 	reader := bufio.NewReader(conn)
-	err := server.(*DefaultReflectorServer).receiveBlob(conn, reader)
+	err := server.(*DefaultReflectorServer).receiveBlob(t.Context(), conn, reader)
 
 	assert.Error(t, err, "Expected receiveBlob to fail with negative size")
 	assert.True(t, errors.Is(err, ErrNegativeBlobSize), "Expected ErrNegativeBlobSize")

--- a/server/builder_test.go
+++ b/server/builder_test.go
@@ -406,7 +406,7 @@ func TestWithTransferOptions(t *testing.T) {
 		testMocks := setupBuilderMocks(t)
 
 		// Set up mock expectations for List method calls during DHT blob announcement
-		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+		testMocks.storage.EXPECT().List(mock.Anything, mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
 
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).
@@ -440,7 +440,7 @@ func TestWithTransferOptions(t *testing.T) {
 		testMocks := setupBuilderMocks(t)
 
 		// Set up mock expectations for List method calls during DHT blob announcement
-		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+		testMocks.storage.EXPECT().List(mock.Anything, mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
 
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).
@@ -462,7 +462,7 @@ func TestWithTransferOptions(t *testing.T) {
 		testMocks := setupBuilderMocks(t)
 
 		// Set up mock expectations for List method calls during DHT blob announcement
-		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+		testMocks.storage.EXPECT().List(mock.Anything, mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
 
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).
@@ -486,7 +486,7 @@ func TestWithTransferOptions(t *testing.T) {
 		testMocks := setupBuilderMocks(t)
 
 		// Set up mock expectations for List method calls during DHT blob announcement
-		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+		testMocks.storage.EXPECT().List(mock.Anything, mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
 
 		// Transfer options should be stored even without default acquirer
 		builder := NewServerBuilder().
@@ -551,7 +551,7 @@ func TestWithTransferOptions(t *testing.T) {
 		testMocks := setupBuilderMocks(t)
 
 		// Set up mock expectations for List method calls during DHT blob announcement
-		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+		testMocks.storage.EXPECT().List(mock.Anything, mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
 
 		// Test that invalid options don't break the build process
 		builder := NewServerBuilder().
@@ -583,7 +583,7 @@ func TestWithTransferOptions(t *testing.T) {
 		testMocks := setupBuilderMocks(t)
 
 		// Set up mock expectations for List method calls during DHT blob announcement
-		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+		testMocks.storage.EXPECT().List(mock.Anything, mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
 
 		// Test that nil options are handled gracefully (ignored and logged)
 		builder := NewServerBuilder().
@@ -668,7 +668,7 @@ func TestTransferOptionsIntegration(t *testing.T) {
 		testMocks := setupBuilderMocks(t)
 
 		// Set up mock expectations for List method calls during DHT blob announcement
-		testMocks.storage.EXPECT().List(mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+		testMocks.storage.EXPECT().List(mock.Anything, mock.AnythingOfType("int"), mock.AnythingOfType("int")).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
 
 		// Test creating a custom transfer option
 		customOption, err := peer_transfer.NewPeerTransferOptionAdapter(
@@ -847,7 +847,7 @@ func TestServerBuilder_WithExistingDHT(t *testing.T) {
 	// Setup mock expectations
 	mockDHTNode.EXPECT().Start().Return(nil)
 	mockDHTNode.EXPECT().Shutdown().Return()
-	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
+	testMocks.storage.EXPECT().List(mock.Anything, 0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList).Maybe()
 
 	// Create server with existing DHT
 	server, err := NewServerBuilder().
@@ -1020,7 +1020,7 @@ func TestServerBuilder_Build_AcquirerFactoryIntegration(t *testing.T) {
 	}
 
 	// Mock the storage.List call that happens during DHT blob announcement
-	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil).Times(1)
+	testMocks.storage.EXPECT().List(mock.Anything, 0, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil).Times(1)
 
 	builder := NewServerBuilder().
 		WithStorage(testMocks.storage).
@@ -1067,7 +1067,7 @@ func TestServerBuilder_Build_DefaultAcquirerIntegration(t *testing.T) {
 	mockDHTNode.EXPECT().Shutdown().Return()
 
 	// Add mock expectation for storage.List() called during DHT blob announcement
-	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList).Times(1)
+	testMocks.storage.EXPECT().List(mock.Anything, 0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList).Times(1)
 
 	builder := NewServerBuilder().
 		WithStorage(testMocks.storage).
@@ -1122,7 +1122,7 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 		mockDHTNode.EXPECT().Shutdown().Return()
 
 		// Add mock expectation for storage.List() called during DHT blob announcement
-		testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList).Times(1)
+		testMocks.storage.EXPECT().List(mock.Anything, 0, DefaultDHTAnnouncementBatchSize).Return([]string{}, liblbryerrors.ErrEndOfList).Times(1)
 
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).
@@ -1155,7 +1155,7 @@ func TestServerBuilder_Build_DefaultAcquirerDHTUsage(t *testing.T) {
 
 	t.Run("Without DHT node", func(t *testing.T) {
 		// Ensure storage.List is not called when no DHT node is configured
-		testMocks.storage.EXPECT().List(mock.Anything, mock.Anything).Times(0)
+		testMocks.storage.EXPECT().List(mock.Anything, mock.Anything, mock.Anything).Times(0)
 
 		builder := NewServerBuilder().
 			WithStorage(testMocks.storage).

--- a/server/mocks/BlobManager.go
+++ b/server/mocks/BlobManager.go
@@ -309,8 +309,8 @@ func (_c *MockBlobManager_AddSDBlob_Call) RunAndReturn(run func(hash string, dat
 }
 
 // GetBlob provides a mock function for the type MockBlobManager
-func (_mock *MockBlobManager) GetBlob(hash string) ([]byte, error) {
-	ret := _mock.Called(hash)
+func (_mock *MockBlobManager) GetBlob(ctx context.Context, hash string) ([]byte, error) {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetBlob")
@@ -318,18 +318,18 @@ func (_mock *MockBlobManager) GetBlob(hash string) ([]byte, error) {
 
 	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) ([]byte, error)); ok {
-		return returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]byte, error)); ok {
+		return returnFunc(ctx, hash)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) []byte); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, hash)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -342,19 +342,25 @@ type MockBlobManager_GetBlob_Call struct {
 }
 
 // GetBlob is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockBlobManager_Expecter) GetBlob(hash interface{}) *MockBlobManager_GetBlob_Call {
-	return &MockBlobManager_GetBlob_Call{Call: _e.mock.On("GetBlob", hash)}
+func (_e *MockBlobManager_Expecter) GetBlob(ctx interface{}, hash interface{}) *MockBlobManager_GetBlob_Call {
+	return &MockBlobManager_GetBlob_Call{Call: _e.mock.On("GetBlob", ctx, hash)}
 }
 
-func (_c *MockBlobManager_GetBlob_Call) Run(run func(hash string)) *MockBlobManager_GetBlob_Call {
+func (_c *MockBlobManager_GetBlob_Call) Run(run func(ctx context.Context, hash string)) *MockBlobManager_GetBlob_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -365,14 +371,14 @@ func (_c *MockBlobManager_GetBlob_Call) Return(bytes []byte, err error) *MockBlo
 	return _c
 }
 
-func (_c *MockBlobManager_GetBlob_Call) RunAndReturn(run func(hash string) ([]byte, error)) *MockBlobManager_GetBlob_Call {
+func (_c *MockBlobManager_GetBlob_Call) RunAndReturn(run func(ctx context.Context, hash string) ([]byte, error)) *MockBlobManager_GetBlob_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // GetSDBlob provides a mock function for the type MockBlobManager
-func (_mock *MockBlobManager) GetSDBlob(hash string) ([]byte, error) {
-	ret := _mock.Called(hash)
+func (_mock *MockBlobManager) GetSDBlob(ctx context.Context, hash string) ([]byte, error) {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetSDBlob")
@@ -380,18 +386,18 @@ func (_mock *MockBlobManager) GetSDBlob(hash string) ([]byte, error) {
 
 	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) ([]byte, error)); ok {
-		return returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]byte, error)); ok {
+		return returnFunc(ctx, hash)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) []byte); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, hash)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -404,19 +410,25 @@ type MockBlobManager_GetSDBlob_Call struct {
 }
 
 // GetSDBlob is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockBlobManager_Expecter) GetSDBlob(hash interface{}) *MockBlobManager_GetSDBlob_Call {
-	return &MockBlobManager_GetSDBlob_Call{Call: _e.mock.On("GetSDBlob", hash)}
+func (_e *MockBlobManager_Expecter) GetSDBlob(ctx interface{}, hash interface{}) *MockBlobManager_GetSDBlob_Call {
+	return &MockBlobManager_GetSDBlob_Call{Call: _e.mock.On("GetSDBlob", ctx, hash)}
 }
 
-func (_c *MockBlobManager_GetSDBlob_Call) Run(run func(hash string)) *MockBlobManager_GetSDBlob_Call {
+func (_c *MockBlobManager_GetSDBlob_Call) Run(run func(ctx context.Context, hash string)) *MockBlobManager_GetSDBlob_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -427,7 +439,7 @@ func (_c *MockBlobManager_GetSDBlob_Call) Return(bytes []byte, err error) *MockB
 	return _c
 }
 
-func (_c *MockBlobManager_GetSDBlob_Call) RunAndReturn(run func(hash string) ([]byte, error)) *MockBlobManager_GetSDBlob_Call {
+func (_c *MockBlobManager_GetSDBlob_Call) RunAndReturn(run func(ctx context.Context, hash string) ([]byte, error)) *MockBlobManager_GetSDBlob_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/mocks/BlobManager.go
+++ b/server/mocks/BlobManager.go
@@ -195,16 +195,16 @@ func (_c *MockBlobManager_AcquireSDBlob_Call) RunAndReturn(run func(ctx context.
 }
 
 // AddBlob provides a mock function for the type MockBlobManager
-func (_mock *MockBlobManager) AddBlob(hash string, data []byte) error {
-	ret := _mock.Called(hash, data)
+func (_mock *MockBlobManager) AddBlob(ctx context.Context, hash string, data []byte) error {
+	ret := _mock.Called(ctx, hash, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddBlob")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
-		r0 = returnFunc(hash, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte) error); ok {
+		r0 = returnFunc(ctx, hash, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -217,25 +217,31 @@ type MockBlobManager_AddBlob_Call struct {
 }
 
 // AddBlob is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
 //   - data []byte
-func (_e *MockBlobManager_Expecter) AddBlob(hash interface{}, data interface{}) *MockBlobManager_AddBlob_Call {
-	return &MockBlobManager_AddBlob_Call{Call: _e.mock.On("AddBlob", hash, data)}
+func (_e *MockBlobManager_Expecter) AddBlob(ctx interface{}, hash interface{}, data interface{}) *MockBlobManager_AddBlob_Call {
+	return &MockBlobManager_AddBlob_Call{Call: _e.mock.On("AddBlob", ctx, hash, data)}
 }
 
-func (_c *MockBlobManager_AddBlob_Call) Run(run func(hash string, data []byte)) *MockBlobManager_AddBlob_Call {
+func (_c *MockBlobManager_AddBlob_Call) Run(run func(ctx context.Context, hash string, data []byte)) *MockBlobManager_AddBlob_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []byte
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]byte)
+			arg1 = args[1].(string)
+		}
+		var arg2 []byte
+		if args[2] != nil {
+			arg2 = args[2].([]byte)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -246,22 +252,22 @@ func (_c *MockBlobManager_AddBlob_Call) Return(err error) *MockBlobManager_AddBl
 	return _c
 }
 
-func (_c *MockBlobManager_AddBlob_Call) RunAndReturn(run func(hash string, data []byte) error) *MockBlobManager_AddBlob_Call {
+func (_c *MockBlobManager_AddBlob_Call) RunAndReturn(run func(ctx context.Context, hash string, data []byte) error) *MockBlobManager_AddBlob_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // AddSDBlob provides a mock function for the type MockBlobManager
-func (_mock *MockBlobManager) AddSDBlob(hash string, data []byte) error {
-	ret := _mock.Called(hash, data)
+func (_mock *MockBlobManager) AddSDBlob(ctx context.Context, hash string, data []byte) error {
+	ret := _mock.Called(ctx, hash, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AddSDBlob")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
-		r0 = returnFunc(hash, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte) error); ok {
+		r0 = returnFunc(ctx, hash, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -274,25 +280,31 @@ type MockBlobManager_AddSDBlob_Call struct {
 }
 
 // AddSDBlob is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
 //   - data []byte
-func (_e *MockBlobManager_Expecter) AddSDBlob(hash interface{}, data interface{}) *MockBlobManager_AddSDBlob_Call {
-	return &MockBlobManager_AddSDBlob_Call{Call: _e.mock.On("AddSDBlob", hash, data)}
+func (_e *MockBlobManager_Expecter) AddSDBlob(ctx interface{}, hash interface{}, data interface{}) *MockBlobManager_AddSDBlob_Call {
+	return &MockBlobManager_AddSDBlob_Call{Call: _e.mock.On("AddSDBlob", ctx, hash, data)}
 }
 
-func (_c *MockBlobManager_AddSDBlob_Call) Run(run func(hash string, data []byte)) *MockBlobManager_AddSDBlob_Call {
+func (_c *MockBlobManager_AddSDBlob_Call) Run(run func(ctx context.Context, hash string, data []byte)) *MockBlobManager_AddSDBlob_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []byte
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]byte)
+			arg1 = args[1].(string)
+		}
+		var arg2 []byte
+		if args[2] != nil {
+			arg2 = args[2].([]byte)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -303,7 +315,7 @@ func (_c *MockBlobManager_AddSDBlob_Call) Return(err error) *MockBlobManager_Add
 	return _c
 }
 
-func (_c *MockBlobManager_AddSDBlob_Call) RunAndReturn(run func(hash string, data []byte) error) *MockBlobManager_AddSDBlob_Call {
+func (_c *MockBlobManager_AddSDBlob_Call) RunAndReturn(run func(ctx context.Context, hash string, data []byte) error) *MockBlobManager_AddSDBlob_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -445,16 +457,16 @@ func (_c *MockBlobManager_GetSDBlob_Call) RunAndReturn(run func(ctx context.Cont
 }
 
 // RemoveBlob provides a mock function for the type MockBlobManager
-func (_mock *MockBlobManager) RemoveBlob(hash string) error {
-	ret := _mock.Called(hash)
+func (_mock *MockBlobManager) RemoveBlob(ctx context.Context, hash string) error {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RemoveBlob")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -467,19 +479,25 @@ type MockBlobManager_RemoveBlob_Call struct {
 }
 
 // RemoveBlob is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockBlobManager_Expecter) RemoveBlob(hash interface{}) *MockBlobManager_RemoveBlob_Call {
-	return &MockBlobManager_RemoveBlob_Call{Call: _e.mock.On("RemoveBlob", hash)}
+func (_e *MockBlobManager_Expecter) RemoveBlob(ctx interface{}, hash interface{}) *MockBlobManager_RemoveBlob_Call {
+	return &MockBlobManager_RemoveBlob_Call{Call: _e.mock.On("RemoveBlob", ctx, hash)}
 }
 
-func (_c *MockBlobManager_RemoveBlob_Call) Run(run func(hash string)) *MockBlobManager_RemoveBlob_Call {
+func (_c *MockBlobManager_RemoveBlob_Call) Run(run func(ctx context.Context, hash string)) *MockBlobManager_RemoveBlob_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -490,7 +508,7 @@ func (_c *MockBlobManager_RemoveBlob_Call) Return(err error) *MockBlobManager_Re
 	return _c
 }
 
-func (_c *MockBlobManager_RemoveBlob_Call) RunAndReturn(run func(hash string) error) *MockBlobManager_RemoveBlob_Call {
+func (_c *MockBlobManager_RemoveBlob_Call) RunAndReturn(run func(ctx context.Context, hash string) error) *MockBlobManager_RemoveBlob_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/server/server.go
+++ b/server/server.go
@@ -75,9 +75,9 @@ type BlobManager interface {
 	AcquireSDBlob(ctx context.Context, hash string, opts ...AcquireSDOption) (*stream.StreamResult, error)
 
 	// GetBlob retrieves a blob directly from the underlying store
-	GetBlob(hash string) ([]byte, error)
+	GetBlob(ctx context.Context, hash string) ([]byte, error)
 	// GetSDBlob retrieves an SD blob directly from the underlying store
-	GetSDBlob(hash string) ([]byte, error)
+	GetSDBlob(ctx context.Context, hash string) ([]byte, error)
 }
 
 // AcquireSDConfig holds configuration for SD blob acquisition
@@ -493,7 +493,7 @@ func (s *DefaultServer) announceBlobsToDHT(workerCount int, batchSize int) {
 
 	for {
 		// Get a batch of blob hashes using pagination
-		blobHashes, err := s.storage.List(offset, batchSize)
+		blobHashes, err := s.storage.List(s.ctx, offset, batchSize)
 		if err != nil {
 			if liblbryerrors.IsEndOfListError(err) {
 				// Reached end of list, break the loop
@@ -576,7 +576,7 @@ func (s *DefaultServer) AddBlob(hash string, data []byte) error {
 	}
 
 	// Store the blob
-	err := s.storage.Put(hash, data)
+	err := s.storage.Put(nil, hash, data)
 	if err != nil {
 		s.logger.Error("Failed to store blob",
 			zap.String("hash", hash),
@@ -600,7 +600,7 @@ func (s *DefaultServer) AddSDBlob(hash string, data []byte) error {
 	}
 
 	// Store the SD blob
-	err := s.storage.PutSD(hash, data)
+	err := s.storage.PutSD(nil, hash, data)
 	if err != nil {
 		s.logger.Error("Failed to store SD blob",
 			zap.String("hash", hash),
@@ -624,7 +624,7 @@ func (s *DefaultServer) RemoveBlob(hash string) error {
 	}
 
 	// Delete the blob from storage
-	err := s.storage.Delete(hash)
+	err := s.storage.Delete(nil, hash)
 	if err != nil {
 		s.logger.Error("Failed to delete blob",
 			zap.String("hash", hash),
@@ -772,23 +772,23 @@ func (s *DefaultServer) AcquireSDBlob(ctx context.Context, hash string, opts ...
 }
 
 // GetBlob retrieves a blob directly from the underlying store
-func (s *DefaultServer) GetBlob(hash string) ([]byte, error) {
+func (s *DefaultServer) GetBlob(ctx context.Context, hash string) ([]byte, error) {
 	// Validate hash
 	if err := validateHash(hash); err != nil {
 		return nil, err
 	}
 
-	return s.storage.Get(hash)
+	return s.storage.Get(ctx, hash)
 }
 
 // GetSDBlob retrieves an SD blob directly from the underlying store
-func (s *DefaultServer) GetSDBlob(hash string) ([]byte, error) {
+func (s *DefaultServer) GetSDBlob(ctx context.Context, hash string) ([]byte, error) {
 	// Validate hash
 	if err := validateHash(hash); err != nil {
 		return nil, err
 	}
 
-	return s.storage.Get(hash)
+	return s.storage.Get(ctx, hash)
 }
 
 // startTCPProtocol starts a generic TCP protocol handler

--- a/server/server.go
+++ b/server/server.go
@@ -63,11 +63,11 @@ const (
 // BlobManager defines the interface for blob management operations
 type BlobManager interface {
 	// AddBlob stores a blob and notifies about the addition
-	AddBlob(hash string, data []byte) error
+	AddBlob(ctx context.Context, hash string, data []byte) error
 	// AddSDBlob stores an SD blob and notifies about the addition
-	AddSDBlob(hash string, data []byte) error
+	AddSDBlob(ctx context.Context, hash string, data []byte) error
 	// RemoveBlob deletes a blob and notifies about the removal
-	RemoveBlob(hash string) error
+	RemoveBlob(ctx context.Context, hash string) error
 
 	// AcquireBlob retrieves a blob using available transfer methods
 	AcquireBlob(ctx context.Context, hash string) ([]byte, error)
@@ -569,14 +569,14 @@ func validateBlobInput(hash string, data []byte) error {
 }
 
 // AddBlob stores a blob and notifies about the addition
-func (s *DefaultServer) AddBlob(hash string, data []byte) error {
+func (s *DefaultServer) AddBlob(ctx context.Context, hash string, data []byte) error {
 	// Validate input
 	if err := validateBlobInput(hash, data); err != nil {
 		return err
 	}
 
 	// Store the blob
-	err := s.storage.Put(nil, hash, data)
+	err := s.storage.Put(ctx, hash, data)
 	if err != nil {
 		s.logger.Error("Failed to store blob",
 			zap.String("hash", hash),
@@ -593,14 +593,14 @@ func (s *DefaultServer) AddBlob(hash string, data []byte) error {
 }
 
 // AddSDBlob stores an SD blob and notifies about the addition
-func (s *DefaultServer) AddSDBlob(hash string, data []byte) error {
+func (s *DefaultServer) AddSDBlob(ctx context.Context, hash string, data []byte) error {
 	// Validate input
 	if err := validateBlobInput(hash, data); err != nil {
 		return err
 	}
 
 	// Store the SD blob
-	err := s.storage.PutSD(nil, hash, data)
+	err := s.storage.PutSD(ctx, hash, data)
 	if err != nil {
 		s.logger.Error("Failed to store SD blob",
 			zap.String("hash", hash),
@@ -617,14 +617,14 @@ func (s *DefaultServer) AddSDBlob(hash string, data []byte) error {
 }
 
 // RemoveBlob deletes a blob and notifies about the removal
-func (s *DefaultServer) RemoveBlob(hash string) error {
+func (s *DefaultServer) RemoveBlob(ctx context.Context, hash string) error {
 	// Validate hash
 	if err := validateHash(hash); err != nil {
 		return err
 	}
 
 	// Delete the blob from storage
-	err := s.storage.Delete(nil, hash)
+	err := s.storage.Delete(ctx, hash)
 	if err != nil {
 		s.logger.Error("Failed to delete blob",
 			zap.String("hash", hash),

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -573,7 +573,7 @@ func TestDefaultServer_AddBlob_Success(t *testing.T) {
 	testMocks.storage.EXPECT().Put(mock.Anything, blobHash, blobData).Return(nil)
 
 	// Test successful blob addition
-	err := server.AddBlob(blobHash, blobData)
+	err := server.AddBlob(t.Context(), blobHash, blobData)
 	assert.NoError(t, err)
 }
 
@@ -588,7 +588,7 @@ func TestDefaultServer_AddBlob_EmptyHash(t *testing.T) {
 	blobData := []byte(TestBlobData)
 
 	// Test with empty hash
-	err := server.AddBlob("", blobData)
+	err := server.AddBlob(t.Context(), "", blobData)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "hash cannot be empty")
 }
@@ -604,7 +604,7 @@ func TestDefaultServer_AddBlob_EmptyData(t *testing.T) {
 	blobHash := TestBlobHash
 
 	// Test with empty data
-	err := server.AddBlob(blobHash, []byte{})
+	err := server.AddBlob(t.Context(), blobHash, []byte{})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "blob data cannot be empty")
 }
@@ -625,7 +625,7 @@ func TestDefaultServer_AddBlob_StorageFailure(t *testing.T) {
 	testMocks.storage.EXPECT().Put(mock.Anything, blobHash, blobData).Return(storageError)
 
 	// Test storage failure
-	err := server.AddBlob(blobHash, blobData)
+	err := server.AddBlob(t.Context(), blobHash, blobData)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to store blob")
 	assert.Contains(t, err.Error(), blobHash)
@@ -649,7 +649,7 @@ func TestDefaultServer_AddBlob_WithNotifier(t *testing.T) {
 	mockNotifier.EXPECT().Notify(protocol.NOTIFY_BLOB_ADDED, TestNotificationHash).Return(nil)
 
 	// Test blob addition with notification
-	err := server.AddBlob(blobHash, blobData)
+	err := server.AddBlob(t.Context(), blobHash, blobData)
 	assert.NoError(t, err)
 }
 
@@ -737,7 +737,7 @@ func TestDefaultServer_AddSDBlob(t *testing.T) {
 			// Setup test-specific mocks
 			tc.setupMocks(testMocks, server)
 
-			err := server.AddSDBlob(tc.hash, tc.data)
+			err := server.AddSDBlob(t.Context(), tc.hash, tc.data)
 
 			if tc.expectErr {
 				assert.Error(t, err)
@@ -766,7 +766,7 @@ func TestDefaultServer_ConcurrentAddSDBlob(t *testing.T) {
 
 	// Test concurrent AddSDBlob operations using helper
 	runConcurrentTest(t, numGoroutines, func(index int) error {
-		return server.AddSDBlob(blobHash, blobData)
+		return server.AddSDBlob(t.Context(), blobHash, blobData)
 	})
 }
 
@@ -784,7 +784,7 @@ func TestDefaultServer_RemoveBlob_Success(t *testing.T) {
 	testMocks.storage.EXPECT().Delete(mock.Anything, blobHash).Return(nil)
 
 	// Test successful blob removal
-	err := server.RemoveBlob(blobHash)
+	err := server.RemoveBlob(t.Context(), blobHash)
 	assert.NoError(t, err)
 }
 
@@ -797,7 +797,7 @@ func TestDefaultServer_RemoveBlob_EmptyHash(t *testing.T) {
 	server := setupServer(t, testMocks, map[string]any{})
 
 	// Test with empty hash
-	err := server.RemoveBlob("")
+	err := server.RemoveBlob(t.Context(), "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "hash cannot be empty")
 }
@@ -817,7 +817,7 @@ func TestDefaultServer_RemoveBlob_StorageFailure(t *testing.T) {
 	testMocks.storage.EXPECT().Delete(mock.Anything, blobHash).Return(storageError)
 
 	// Test storage failure
-	err := server.RemoveBlob(blobHash)
+	err := server.RemoveBlob(t.Context(), blobHash)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to delete blob")
 	assert.Contains(t, err.Error(), blobHash)
@@ -840,7 +840,7 @@ func TestDefaultServer_RemoveBlob_WithNotifier(t *testing.T) {
 	mockNotifier.EXPECT().Notify(protocol.NOTIFY_BLOB_REMOVED, TestNotificationHash).Return(nil)
 
 	// Test blob removal with notification
-	err := server.RemoveBlob(blobHash)
+	err := server.RemoveBlob(t.Context(), blobHash)
 	assert.NoError(t, err)
 }
 
@@ -874,7 +874,7 @@ func TestDefaultServer_ConcurrentAddBlob(t *testing.T) {
 	runConcurrentTest(t, numGoroutines, func(index int) error {
 		blobHash := generateTestBlobHash(index)
 		blobData := generateSimpleTestBlobData(index)
-		return server.AddBlob(blobHash, blobData)
+		return server.AddBlob(t.Context(), blobHash, blobData)
 	})
 }
 
@@ -897,7 +897,7 @@ func TestDefaultServer_ConcurrentRemoveBlob(t *testing.T) {
 	// Test concurrent RemoveBlob operations using helper
 	runConcurrentTest(t, numGoroutines, func(index int) error {
 		blobHash := generateTestBlobHash(index)
-		return server.RemoveBlob(blobHash)
+		return server.RemoveBlob(t.Context(), blobHash)
 	})
 }
 
@@ -928,13 +928,13 @@ func TestDefaultServer_ConcurrentBlobOperations(t *testing.T) {
 	runConcurrentTest(t, numOperations, func(index int) error {
 		blobHash := generateNamedTestBlobHash("add_hash", index)
 		blobData := generateTestBlobData("add data", index)
-		return server.AddBlob(blobHash, blobData)
+		return server.AddBlob(t.Context(), blobHash, blobData)
 	})
 
 	// Test concurrent Remove operations using helper
 	runConcurrentTest(t, numOperations, func(index int) error {
 		blobHash := generateNamedTestBlobHash("remove_hash", index)
-		return server.RemoveBlob(blobHash)
+		return server.RemoveBlob(t.Context(), blobHash)
 	})
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -176,7 +176,7 @@ func TestDefaultServer_Start_WithDHT(t *testing.T) {
 
 	// Setup mock expectations for List method (called during DHT blob announcement)
 	// When storage is empty, List(0, batchSize) returns empty slice and loop breaks
-	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil)
+	testMocks.storage.EXPECT().List(mock.Anything, 0, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil)
 
 	// Create a mock DHT node
 	mockDHTNode := protocolMocks.NewMockDHTNode(t)
@@ -208,7 +208,7 @@ func TestDefaultServer_Start_AllProtocols(t *testing.T) {
 
 	// Setup mock expectations for List method (called during DHT blob announcement)
 	// When storage is empty, List(0, batchSize) returns empty slice and loop breaks
-	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil)
+	testMocks.storage.EXPECT().List(mock.Anything, 0, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil)
 
 	// Create a mock DHT node
 	mockDHTNode := protocolMocks.NewMockDHTNode(t)
@@ -570,7 +570,7 @@ func TestDefaultServer_AddBlob_Success(t *testing.T) {
 	blobData := []byte(TestBlobData)
 
 	// Setup mock expectations
-	testMocks.storage.EXPECT().Put(blobHash, blobData).Return(nil)
+	testMocks.storage.EXPECT().Put(mock.Anything, blobHash, blobData).Return(nil)
 
 	// Test successful blob addition
 	err := server.AddBlob(blobHash, blobData)
@@ -622,7 +622,7 @@ func TestDefaultServer_AddBlob_StorageFailure(t *testing.T) {
 	storageError := errors.New("storage error")
 
 	// Setup mock expectations
-	testMocks.storage.EXPECT().Put(blobHash, blobData).Return(storageError)
+	testMocks.storage.EXPECT().Put(mock.Anything, blobHash, blobData).Return(storageError)
 
 	// Test storage failure
 	err := server.AddBlob(blobHash, blobData)
@@ -645,7 +645,7 @@ func TestDefaultServer_AddBlob_WithNotifier(t *testing.T) {
 	blobData := []byte(TestBlobData)
 
 	// Setup mock expectations
-	testMocks.storage.EXPECT().Put(blobHash, blobData).Return(nil)
+	testMocks.storage.EXPECT().Put(mock.Anything, blobHash, blobData).Return(nil)
 	mockNotifier.EXPECT().Notify(protocol.NOTIFY_BLOB_ADDED, TestNotificationHash).Return(nil)
 
 	// Test blob addition with notification
@@ -672,7 +672,7 @@ func TestDefaultServer_AddSDBlob(t *testing.T) {
 			hash: TestBlobHash,
 			data: []byte(TestBlobData),
 			setupMocks: func(m *testMocks, s *DefaultServer) {
-				m.storage.EXPECT().PutSD(TestBlobHash, []byte(TestBlobData)).Return(nil)
+				m.storage.EXPECT().PutSD(mock.Anything, TestBlobHash, []byte(TestBlobData)).Return(nil)
 			},
 			expectErr:   false,
 			description: "Successfully stores SD blob",
@@ -705,7 +705,7 @@ func TestDefaultServer_AddSDBlob(t *testing.T) {
 			data: []byte(TestBlobData),
 			setupMocks: func(m *testMocks, s *DefaultServer) {
 				storageError := errors.New("storage error")
-				m.storage.EXPECT().PutSD(TestBlobHash, []byte(TestBlobData)).Return(storageError)
+				m.storage.EXPECT().PutSD(mock.Anything, TestBlobHash, []byte(TestBlobData)).Return(storageError)
 			},
 			expectErr:      true,
 			expectedErrMsg: "failed to store SD blob",
@@ -718,7 +718,7 @@ func TestDefaultServer_AddSDBlob(t *testing.T) {
 			setupMocks: func(m *testMocks, s *DefaultServer) {
 				mockNotifier := protocolMocks.NewMockNotifier(t)
 				s.notifier = mockNotifier
-				m.storage.EXPECT().PutSD(TestBlobHash, []byte(TestBlobData)).Return(nil)
+				m.storage.EXPECT().PutSD(mock.Anything, TestBlobHash, []byte(TestBlobData)).Return(nil)
 				mockNotifier.EXPECT().Notify(protocol.NOTIFY_BLOB_ADDED, TestNotificationHash).Return(nil)
 			},
 			expectErr:   false,
@@ -762,7 +762,7 @@ func TestDefaultServer_ConcurrentAddSDBlob(t *testing.T) {
 	numGoroutines := 10
 
 	// Pre-register mock expectations to avoid concurrent registration fragility
-	testMocks.storage.EXPECT().PutSD(blobHash, blobData).Times(numGoroutines).Return(nil)
+	testMocks.storage.EXPECT().PutSD(mock.Anything, blobHash, blobData).Times(numGoroutines).Return(nil)
 
 	// Test concurrent AddSDBlob operations using helper
 	runConcurrentTest(t, numGoroutines, func(index int) error {
@@ -781,7 +781,7 @@ func TestDefaultServer_RemoveBlob_Success(t *testing.T) {
 	blobHash := TestBlobHash
 
 	// Setup mock expectations
-	testMocks.storage.EXPECT().Delete(blobHash).Return(nil)
+	testMocks.storage.EXPECT().Delete(mock.Anything, blobHash).Return(nil)
 
 	// Test successful blob removal
 	err := server.RemoveBlob(blobHash)
@@ -814,7 +814,7 @@ func TestDefaultServer_RemoveBlob_StorageFailure(t *testing.T) {
 	storageError := errors.New("storage error")
 
 	// Setup mock expectations
-	testMocks.storage.EXPECT().Delete(blobHash).Return(storageError)
+	testMocks.storage.EXPECT().Delete(mock.Anything, blobHash).Return(storageError)
 
 	// Test storage failure
 	err := server.RemoveBlob(blobHash)
@@ -836,7 +836,7 @@ func TestDefaultServer_RemoveBlob_WithNotifier(t *testing.T) {
 	blobHash := TestBlobHash
 
 	// Setup mock expectations
-	testMocks.storage.EXPECT().Delete(blobHash).Return(nil)
+	testMocks.storage.EXPECT().Delete(mock.Anything, blobHash).Return(nil)
 	mockNotifier.EXPECT().Notify(protocol.NOTIFY_BLOB_REMOVED, TestNotificationHash).Return(nil)
 
 	// Test blob removal with notification
@@ -867,7 +867,7 @@ func TestDefaultServer_ConcurrentAddBlob(t *testing.T) {
 	for i := 0; i < numGoroutines; i++ {
 		blobHash := generateTestBlobHash(i)
 		blobData := generateSimpleTestBlobData(i)
-		testMocks.storage.EXPECT().Put(blobHash, blobData).Return(nil)
+		testMocks.storage.EXPECT().Put(mock.Anything, blobHash, blobData).Return(nil)
 	}
 
 	// Test concurrent AddBlob operations using helper
@@ -891,7 +891,7 @@ func TestDefaultServer_ConcurrentRemoveBlob(t *testing.T) {
 	// Pre-register mock expectations for all goroutines
 	for i := 0; i < numGoroutines; i++ {
 		blobHash := generateTestBlobHash(i)
-		testMocks.storage.EXPECT().Delete(blobHash).Return(nil)
+		testMocks.storage.EXPECT().Delete(mock.Anything, blobHash).Return(nil)
 	}
 
 	// Test concurrent RemoveBlob operations using helper
@@ -915,13 +915,13 @@ func TestDefaultServer_ConcurrentBlobOperations(t *testing.T) {
 	for i := 0; i < numOperations; i++ {
 		addBlobHash := generateNamedTestBlobHash("add_hash", i)
 		addBlobData := generateTestBlobData("add data", i)
-		testMocks.storage.EXPECT().Put(addBlobHash, addBlobData).Return(nil)
+		testMocks.storage.EXPECT().Put(mock.Anything, addBlobHash, addBlobData).Return(nil)
 	}
 
 	// Pre-register mock expectations for all remove operations
 	for i := 0; i < numOperations; i++ {
 		removeBlobHash := generateNamedTestBlobHash("remove_hash", i)
-		testMocks.storage.EXPECT().Delete(removeBlobHash).Return(nil)
+		testMocks.storage.EXPECT().Delete(mock.Anything, removeBlobHash).Return(nil)
 	}
 
 	// Test concurrent Add operations using helper
@@ -961,8 +961,8 @@ func TestDefaultServer_announceBlobsToDHT_UsesLBRYHash(t *testing.T) {
 
 	// Set up mock expectations for storage List calls
 	// Note: offset increments by batchSize, not by actual number of blobs processed
-	testMocks.storage.EXPECT().List(0, DefaultDHTAnnouncementBatchSize).Return(testBlobHashes, nil)
-	testMocks.storage.EXPECT().List(DefaultDHTAnnouncementBatchSize, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil)
+	testMocks.storage.EXPECT().List(mock.Anything, 0, DefaultDHTAnnouncementBatchSize).Return(testBlobHashes, nil)
+	testMocks.storage.EXPECT().List(mock.Anything, DefaultDHTAnnouncementBatchSize, DefaultDHTAnnouncementBatchSize).Return([]string{}, nil)
 
 	// Set up mock expectations for DHT announcer - expect LBRY hashes, not multihashes
 	for _, hash := range testBlobHashes {
@@ -1176,13 +1176,13 @@ func TestDefaultServer_AcquireSDBlob_RecursiveSuccess(t *testing.T) {
 	// First, acquire the SD blob
 	testMocks.acquirer.EXPECT().Acquire(mock.Anything, sdBlobHash).Return(sdBlobData, nil)
 	// Check if content blob exists in storage - it doesn't
-	testMocks.storage.EXPECT().Has(contentBlobHash).Return(false, nil)
+	testMocks.storage.EXPECT().Has(mock.Anything, contentBlobHash).Return(false, nil)
 	// Mock the store Name() method call
 	testMocks.storage.EXPECT().Name().Return("mock-store")
 	// Then, acquire the content blob - use Anything for context to be more flexible
 	testMocks.acquirer.EXPECT().Acquire(mock.Anything, contentBlobHash).Return(contentBlobData, nil)
 	// Store the acquired content blob
-	testMocks.storage.EXPECT().Put(contentBlobHash, contentBlobData).Return(nil)
+	testMocks.storage.EXPECT().Put(mock.Anything, contentBlobHash, contentBlobData).Return(nil)
 
 	// Test successful recursive SD blob acquisition
 	result, err := server.AcquireSDBlob(ctx, sdBlobHash, WithAcquireRecursive(true))
@@ -1309,9 +1309,9 @@ func TestDefaultServer_AcquireSDBlob_StorageHit(t *testing.T) {
 	// Setup mock expectations - SD blob acquisition, then storage hit for content blob
 	testMocks.acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return(sdBlobData, nil)
 	// Content blob exists in storage
-	testMocks.storage.EXPECT().Has(contentBlobHash).Return(true, nil)
+	testMocks.storage.EXPECT().Has(mock.Anything, contentBlobHash).Return(true, nil)
 	// Retrieve from storage (acquirer should NOT be called for content blob)
-	testMocks.storage.EXPECT().Get(contentBlobHash).Return(contentBlobData, nil)
+	testMocks.storage.EXPECT().Get(mock.Anything, contentBlobHash).Return(contentBlobData, nil)
 
 	// Test successful recursive SD blob acquisition with storage hit
 	result, err := server.AcquireSDBlob(ctx, sdBlobHash, WithAcquireRecursive(true))
@@ -1363,7 +1363,7 @@ func TestDefaultServer_AcquireSDBlob_ContentBlobAcquisitionFailure(t *testing.T)
 	// Setup mock expectations - SD blob acquisition succeeds, but content blob acquisition fails
 	testMocks.acquirer.EXPECT().Acquire(ctx, sdBlobHash).Return(sdBlobData, nil)
 	// Content blob doesn't exist in storage
-	testMocks.storage.EXPECT().Has(contentBlobHash).Return(false, nil)
+	testMocks.storage.EXPECT().Has(mock.Anything, contentBlobHash).Return(false, nil)
 	// Content blob acquisition fails
 	testMocks.acquirer.EXPECT().Acquire(mock.Anything, contentBlobHash).Return(nil, acquirerError)
 
@@ -1388,10 +1388,10 @@ func TestDefaultServer_GetBlob_Success(t *testing.T) {
 	expectedData := []byte(TestBlobData)
 
 	// Setup mock expectations
-	testMocks.storage.EXPECT().Get(blobHash).Return(expectedData, nil)
+	testMocks.storage.EXPECT().Get(mock.Anything, blobHash).Return(expectedData, nil)
 
 	// Test successful blob retrieval
-	result, err := server.GetBlob(blobHash)
+	result, err := server.GetBlob(t.Context(), blobHash)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedData, result)
 }
@@ -1405,7 +1405,7 @@ func TestDefaultServer_GetBlob_EmptyHash(t *testing.T) {
 	server := setupServer(t, testMocks, map[string]any{})
 
 	// Test with empty hash
-	result, err := server.GetBlob("")
+	result, err := server.GetBlob(t.Context(), "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "hash cannot be empty")
 	assert.Nil(t, result)
@@ -1423,10 +1423,10 @@ func TestDefaultServer_GetBlob_StorageFailure(t *testing.T) {
 	storageError := errors.New("storage error")
 
 	// Setup mock expectations
-	testMocks.storage.EXPECT().Get(blobHash).Return(nil, storageError)
+	testMocks.storage.EXPECT().Get(mock.Anything, blobHash).Return(nil, storageError)
 
 	// Test storage failure
-	result, err := server.GetBlob(blobHash)
+	result, err := server.GetBlob(t.Context(), blobHash)
 	assert.Error(t, err)
 	assert.Equal(t, storageError, err)
 	assert.Nil(t, result)
@@ -1444,10 +1444,10 @@ func TestDefaultServer_GetSDBlob_Success(t *testing.T) {
 	expectedData := []byte(TestBlobData)
 
 	// Setup mock expectations
-	testMocks.storage.EXPECT().Get(sdBlobHash).Return(expectedData, nil)
+	testMocks.storage.EXPECT().Get(mock.Anything, sdBlobHash).Return(expectedData, nil)
 
 	// Test successful SD blob retrieval
-	result, err := server.GetSDBlob(sdBlobHash)
+	result, err := server.GetSDBlob(t.Context(), sdBlobHash)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedData, result)
 }
@@ -1461,7 +1461,7 @@ func TestDefaultServer_GetSDBlob_EmptyHash(t *testing.T) {
 	server := setupServer(t, testMocks, map[string]any{})
 
 	// Test with empty hash
-	result, err := server.GetSDBlob("")
+	result, err := server.GetSDBlob(t.Context(), "")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "hash cannot be empty")
 	assert.Nil(t, result)
@@ -1479,10 +1479,10 @@ func TestDefaultServer_GetSDBlob_StorageFailure(t *testing.T) {
 	storageError := errors.New("storage error")
 
 	// Setup mock expectations
-	testMocks.storage.EXPECT().Get(sdBlobHash).Return(nil, storageError)
+	testMocks.storage.EXPECT().Get(mock.Anything, sdBlobHash).Return(nil, storageError)
 
 	// Test storage failure
-	result, err := server.GetSDBlob(sdBlobHash)
+	result, err := server.GetSDBlob(t.Context(), sdBlobHash)
 	assert.Error(t, err)
 	assert.Equal(t, storageError, err)
 	assert.Nil(t, result)

--- a/storage/blob.go
+++ b/storage/blob.go
@@ -1,22 +1,24 @@
 package storage
 
+import "context"
+
 // BlobStore defines the interface for blob storage operations
 type BlobStore interface {
-	Has(hash string) (bool, error)
-	Get(hash string) ([]byte, error)
-	Put(hash string, data []byte) error
-	PutSD(hash string, data []byte) error
+	Has(ctx context.Context, hash string) (bool, error)
+	Get(ctx context.Context, hash string) ([]byte, error)
+	Put(ctx context.Context, hash string, data []byte) error
+	PutSD(ctx context.Context, hash string, data []byte) error
 	Name() string
 	// List returns a paginated list of blob hashes starting at the given offset.
 	// The order of hashes is implementation-defined and may vary between calls.
 	// If the same hash exists in both regular and SD blob stores, it may appear once or twice depending on the implementation.
 	// Returns an empty slice if offset is beyond the available data.
-	List(offset, limit int) ([]string, error)
+	List(ctx context.Context, offset, limit int) ([]string, error)
 	// Delete removes a blob from storage.
 	// If the blob exists in both regular and SD blob stores, it removes both.
 	// If the blob is not found, it returns nil (no-op).
 	// Only returns an error for invalid hash format or other unknown errors.
-	Delete(hash string) error
+	Delete(ctx context.Context, hash string) error
 }
 
 // Blocklister defines the interface for checking if a blob is wanted

--- a/storage/disk/disk.go
+++ b/storage/disk/disk.go
@@ -81,10 +81,17 @@ func validateHashWithError(hash string, operation string) error {
 // For small data, it writes directly. For larger data, it writes in chunks
 // to allow context cancellation during the write operation.
 func writeWithContext(ctx context.Context, file *os.File, data []byte) error {
-	// For small data, write directly
+	// For small data, write directly with retry for partial writes
 	if len(data) <= 4096 {
-		if _, err := file.Write(data); err != nil {
-			return err
+		for written := 0; written < len(data); {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			n, err := file.Write(data[written:])
+			if err != nil {
+				return err
+			}
+			written += n
 		}
 		return nil
 	}
@@ -102,8 +109,16 @@ func writeWithContext(ctx context.Context, file *os.File, data []byte) error {
 			end = len(data)
 		}
 
-		if _, err := file.Write(data[i:end]); err != nil {
-			return err
+		// Write the chunk with retry for partial writes
+		for written := 0; written < end-i; {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			n, err := file.Write(data[i+written : end])
+			if err != nil {
+				return err
+			}
+			written += n
 		}
 	}
 

--- a/storage/disk/disk.go
+++ b/storage/disk/disk.go
@@ -20,7 +20,9 @@
 package disk
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -74,18 +76,63 @@ func validateHashWithError(hash string, operation string) error {
 	return nil
 }
 
+// writeWithContext writes data to a file while respecting context cancellation.
+//
+// For small data, it writes directly. For larger data, it writes in chunks
+// to allow context cancellation during the write operation.
+func writeWithContext(ctx context.Context, file *os.File, data []byte) error {
+	// For small data, write directly
+	if len(data) <= 4096 {
+		if _, err := file.Write(data); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	// For larger data, write in chunks to allow context cancellation
+	const chunkSize = 4096
+	for i := 0; i < len(data); i += chunkSize {
+		// Check context before each chunk
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		end := i + chunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+
+		if _, err := file.Write(data[i:end]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // atomicWrite handles the atomic write pattern used in Put/PutSD.
 //
 // It writes data to a temporary file first and then renames it to the final path,
 // ensuring that the file is either completely written or not written at all.
 // The operation parameter is used for logging purposes.
-func atomicWrite(path string, data []byte, logger *zap.Logger, operation string) error {
+// Respects context cancellation during file operations.
+func atomicWrite(ctx context.Context, path string, data []byte, logger *zap.Logger, operation string) error {
+	// Check context before starting operation
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Create directory if it doesn't exist
 	dir := filepath.Dir(path)
 
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		logErrorIfLogger(logger, "failed to create directory for "+operation+" operation", err, zap.String("dir", dir))
 		return fmt.Errorf("failed to create directory: %w", err)
+	}
+
+	// Check context before creating temp file
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	// Create temporary file in the same directory as the final file
@@ -105,16 +152,26 @@ func atomicWrite(path string, data []byte, logger *zap.Logger, operation string)
 		}
 	}()
 
-	// Write data to temporary file
-	if _, err := tmp.Write(data); err != nil {
+	// Write data to temporary file with context cancellation support
+	if err := writeWithContext(ctx, tmp, data); err != nil {
 		logErrorIfLogger(logger, "failed to write temporary file for "+operation+" operation", err, zap.String("tmpPath", tmpPath))
 		return fmt.Errorf("failed to write temporary file: %w", err)
+	}
+
+	// Check context before sync
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	// Sync file to disk
 	if err := tmp.Sync(); err != nil {
 		logErrorIfLogger(logger, "failed to sync temporary file for "+operation+" operation", err, zap.String("tmpPath", tmpPath))
 		return fmt.Errorf("failed to sync temporary file: %w", err)
+	}
+
+	// Check context before close
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	// Close file before rename (required on Windows)
@@ -127,6 +184,11 @@ func atomicWrite(path string, data []byte, logger *zap.Logger, operation string)
 	if err := os.Chmod(tmpPath, 0600); err != nil {
 		logErrorIfLogger(logger, "failed to set permissions on temporary file for "+operation+" operation", err, zap.String("tmpPath", tmpPath))
 		return fmt.Errorf("failed to set file permissions: %w", err)
+	}
+
+	// Check context before rename
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	// Rename temporary file to final path
@@ -147,12 +209,72 @@ func atomicWrite(path string, data []byte, logger *zap.Logger, operation string)
 	return nil
 }
 
+// readWithContext reads a file while respecting context cancellation.
+//
+// For small files, it reads directly. For larger files, it reads in chunks
+// to allow context cancellation during the read operation.
+func readWithContext(ctx context.Context, path string) ([]byte, error) {
+	// Get file info to determine size
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, err
+	}
+
+	// For small files, read directly
+	if info.Size() <= 4096 {
+		return os.ReadFile(path)
+	}
+
+	// For larger files, open and read in chunks
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	// Check context after opening file
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// Read in chunks to allow context cancellation
+	const chunkSize = 4096
+	var data []byte
+	buffer := make([]byte, chunkSize)
+
+	for {
+		// Check context before each read
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		n, err := file.Read(buffer)
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		if n == 0 {
+			break
+		}
+
+		data = append(data, buffer[:n]...)
+	}
+
+	return data, nil
+}
+
 // checkBlobPaths checks both regular and SD blob paths, returns data if found.
 //
 // It first attempts to find a regular blob, and if not found, tries to find an SD blob.
 // Returns the data, any error encountered, and a boolean indicating if the blob was found.
 // The operation parameter is used for logging purposes.
-func checkBlobPaths(basePath, hash string, logger *zap.Logger, operation string) ([]byte, error, bool) {
+// Respects context cancellation during file operations.
+func checkBlobPaths(ctx context.Context, basePath, hash string, logger *zap.Logger, operation string) ([]byte, error, bool) {
+	// Check context before starting operation
+	if err := ctx.Err(); err != nil {
+		return nil, err, false
+	}
+
 	// Try to get regular blob with safe path construction
 	blobPath, err := safeJoin(basePath, hash)
 	if err != nil {
@@ -160,13 +282,23 @@ func checkBlobPaths(basePath, hash string, logger *zap.Logger, operation string)
 		return nil, err, false
 	}
 
-	data, err := os.ReadFile(blobPath)
+	// Check context before reading file
+	if err := ctx.Err(); err != nil {
+		return nil, err, false
+	}
+
+	data, err := readWithContext(ctx, blobPath)
 	if err == nil {
 		logDebugIfLogger(logger, "retrieved regular blob", zap.String("hash", hash), zap.String("path", blobPath))
 		return data, nil, true
 	}
 	if !os.IsNotExist(err) {
 		logErrorIfLogger(logger, "failed to read regular blob", err, zap.String("hash", hash), zap.String("path", blobPath))
+		return nil, err, false
+	}
+
+	// Check context before trying SD blob
+	if err := ctx.Err(); err != nil {
 		return nil, err, false
 	}
 
@@ -177,7 +309,12 @@ func checkBlobPaths(basePath, hash string, logger *zap.Logger, operation string)
 		return nil, err, false
 	}
 
-	data, err = os.ReadFile(sdBlobPath)
+	// Check context before reading SD file
+	if err := ctx.Err(); err != nil {
+		return nil, err, false
+	}
+
+	data, err = readWithContext(ctx, sdBlobPath)
 	if err == nil {
 		logDebugIfLogger(logger, "retrieved SD blob", zap.String("hash", hash), zap.String("path", sdBlobPath))
 		return data, nil, true
@@ -381,17 +518,32 @@ func (f *DiskStoreFactory) GetLogger() *zap.Logger {
 // Returns:
 //   - bool: True if the blob exists, false otherwise
 //   - error: Any error encountered during the check operation
-func (d *DiskStore) Has(hash string) (bool, error) {
+func (d *DiskStore) Has(ctx context.Context, hash string) (bool, error) {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
 	// Validate hash format
 	if !validateHash(hash) {
 		logDebugIfLogger(d.logger, "invalid hash format for Has operation", zap.String("hash", hash))
 		return false, nil
 	}
 
+	// Check context before checking regular blob
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
 	// Check regular blob with safe path construction
 	blobPath, err := safeJoin(d.path, hash)
 	if err != nil {
 		logErrorIfLogger(d.logger, "unsafe path detected for Has operation", err, zap.String("hash", hash))
+		return false, err
+	}
+
+	// Check context before stat operation
+	if err := ctx.Err(); err != nil {
 		return false, err
 	}
 
@@ -403,10 +555,20 @@ func (d *DiskStore) Has(hash string) (bool, error) {
 		return false, err
 	}
 
+	// Check context before checking SD blob
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
 	// Check SD blob with safe path construction
 	sdBlobPath, err := safeJoinSD(d.path, hash)
 	if err != nil {
 		logErrorIfLogger(d.logger, "unsafe path detected for Has operation (SD blob)", err, zap.String("hash", hash))
+		return false, err
+	}
+
+	// Check context before SD stat operation
+	if err := ctx.Err(); err != nil {
 		return false, err
 	}
 
@@ -433,14 +595,19 @@ func (d *DiskStore) Has(hash string) (bool, error) {
 // Returns:
 //   - []byte: The blob data
 //   - error: Any error encountered during retrieval, or an error if the hash format is invalid
-func (d *DiskStore) Get(hash string) ([]byte, error) {
+func (d *DiskStore) Get(ctx context.Context, hash string) ([]byte, error) {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	// Validate hash format
 	if err := validateHashWithError(hash, "Get"); err != nil {
 		logDebugIfLogger(d.logger, "invalid hash format for Get operation", zap.String("hash", hash))
 		return nil, err
 	}
 
-	data, err, found := checkBlobPaths(d.path, hash, d.logger, "Get")
+	data, err, found := checkBlobPaths(ctx, d.path, hash, d.logger, "Get")
 	if found {
 		return data, err
 	}
@@ -460,10 +627,20 @@ func (d *DiskStore) Get(hash string) ([]byte, error) {
 //
 // Returns:
 //   - error: Any error encountered during storage, or an error if the hash format is invalid
-func (d *DiskStore) Put(hash string, data []byte) error {
+func (d *DiskStore) Put(ctx context.Context, hash string, data []byte) error {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Validate hash format
 	if err := validateHashWithError(hash, "Put"); err != nil {
 		logDebugIfLogger(d.logger, "invalid hash format for Put operation", zap.String("hash", hash))
+		return err
+	}
+
+	// Check context before path creation
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 
@@ -474,7 +651,7 @@ func (d *DiskStore) Put(hash string, data []byte) error {
 		return err
 	}
 
-	if err := atomicWrite(blobPath, data, d.logger, "Put"); err != nil {
+	if err := atomicWrite(ctx, blobPath, data, d.logger, "Put"); err != nil {
 		return err
 	}
 
@@ -495,10 +672,20 @@ func (d *DiskStore) Put(hash string, data []byte) error {
 //
 // Returns:
 //   - error: Any error encountered during storage, or an error if the hash format is invalid
-func (d *DiskStore) PutSD(hash string, data []byte) error {
+func (d *DiskStore) PutSD(ctx context.Context, hash string, data []byte) error {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Validate hash format
 	if err := validateHashWithError(hash, "PutSD"); err != nil {
 		logDebugIfLogger(d.logger, "invalid hash format for PutSD operation", zap.String("hash", hash))
+		return err
+	}
+
+	// Check context before path creation
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 
@@ -509,7 +696,7 @@ func (d *DiskStore) PutSD(hash string, data []byte) error {
 		return err
 	}
 
-	if err := atomicWrite(sdBlobPath, data, d.logger, "PutSD"); err != nil {
+	if err := atomicWrite(ctx, sdBlobPath, data, d.logger, "PutSD"); err != nil {
 		return err
 	}
 
@@ -529,7 +716,12 @@ func (d *DiskStore) Name() string {
 }
 
 // List returns a list of blob hashes with pagination support
-func (d *DiskStore) List(offset, limit int) ([]string, error) {
+func (d *DiskStore) List(ctx context.Context, offset, limit int) ([]string, error) {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	if offset < 0 {
 		return nil, liblbryerrors.ErrInvalidOffset
 	}
@@ -538,7 +730,7 @@ func (d *DiskStore) List(offset, limit int) ([]string, error) {
 	}
 
 	// Collect all blob hashes from the disk store
-	allHashes, err := d.collectBlobHashes()
+	allHashes, err := d.collectBlobHashes(ctx)
 	if err != nil {
 		return nil, liblbryerrors.Err("failed to collect blob hashes: %w", err)
 	}
@@ -557,13 +749,35 @@ func (d *DiskStore) List(offset, limit int) ([]string, error) {
 	return allHashes[start:end], nil
 }
 
+// walkWithContext is a context-aware version of filepath.Walk.
+//
+// It checks for context cancellation before processing each path entry
+// and returns context.Canceled if the context is cancelled during traversal.
+func walkWithContext(ctx context.Context, root string, walkFn filepath.WalkFunc) error {
+	// Check context before starting
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		// Check context before processing each path
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		// Call the original walk function
+		return walkFn(path, info, err)
+	})
+}
+
 // collectBlobHashes walks the disk store directory structure and collects all blob hashes
-func (d *DiskStore) collectBlobHashes() ([]string, error) {
+// Respects context cancellation during directory traversal.
+func (d *DiskStore) collectBlobHashes(ctx context.Context) ([]string, error) {
 	// Use a map to track unique hashes for deduplication
 	hashSet := make(map[string]struct{})
 
-	// Walk the directory structure to find all blobs
-	err := filepath.Walk(d.path, func(path string, info os.FileInfo, err error) error {
+	// Walk the directory structure to find all blobs with context cancellation support
+	err := walkWithContext(ctx, d.path, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
@@ -602,10 +816,20 @@ func (d *DiskStore) collectBlobHashes() ([]string, error) {
 // If the blob exists in both regular and SD blob stores, it removes both.
 // If the blob is not found, it returns nil (no-op).
 // Only returns an error for invalid hash format or other unknown errors.
-func (d *DiskStore) Delete(hash string) error {
+func (d *DiskStore) Delete(ctx context.Context, hash string) error {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Validate hash format
 	if err := validateHashWithError(hash, "Delete"); err != nil {
 		logDebugIfLogger(d.logger, "invalid hash format for Delete operation", zap.String("hash", hash))
+		return err
+	}
+
+	// Check context before deleting regular blob
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 
@@ -616,15 +840,30 @@ func (d *DiskStore) Delete(hash string) error {
 		return err
 	}
 
+	// Check context before remove operation
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if err := os.Remove(blobPath); err != nil && !os.IsNotExist(err) {
 		logErrorIfLogger(d.logger, "failed to delete regular blob", err, zap.String("hash", hash), zap.String("path", blobPath))
 		return fmt.Errorf("failed to delete regular blob: %w", err)
+	}
+
+	// Check context before deleting SD blob
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	// Try to delete SD blob
 	sdBlobPath, err := safeJoinSD(d.path, hash)
 	if err != nil {
 		logErrorIfLogger(d.logger, "unsafe path detected for Delete operation (SD blob)", err, zap.String("hash", hash))
+		return err
+	}
+
+	// Check context before SD remove operation
+	if err := ctx.Err(); err != nil {
 		return err
 	}
 

--- a/storage/disk/disk_test.go
+++ b/storage/disk/disk_test.go
@@ -488,7 +488,7 @@ func TestDiskStore_ContextCancellation(t *testing.T) {
 
 		_, err := store.Has(ctx, "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59")
 		require.Error(t, err)
-		assert.Equal(t, context.Canceled, err)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	// Test Get with cancelled context
@@ -498,7 +498,7 @@ func TestDiskStore_ContextCancellation(t *testing.T) {
 
 		_, err := store.Get(ctx, "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59")
 		require.Error(t, err)
-		assert.Equal(t, context.Canceled, err)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	// Test Put with cancelled context
@@ -508,7 +508,7 @@ func TestDiskStore_ContextCancellation(t *testing.T) {
 
 		err := store.Put(ctx, "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59", []byte("test data"))
 		require.Error(t, err)
-		assert.Equal(t, context.Canceled, err)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	// Test PutSD with cancelled context
@@ -518,7 +518,7 @@ func TestDiskStore_ContextCancellation(t *testing.T) {
 
 		err := store.PutSD(ctx, "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59", []byte("test data"))
 		require.Error(t, err)
-		assert.Equal(t, context.Canceled, err)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	// Test List with cancelled context
@@ -528,7 +528,7 @@ func TestDiskStore_ContextCancellation(t *testing.T) {
 
 		_, err := store.List(ctx, 0, 10)
 		require.Error(t, err)
-		assert.Equal(t, context.Canceled, err)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 
 	// Test Delete with cancelled context
@@ -538,7 +538,7 @@ func TestDiskStore_ContextCancellation(t *testing.T) {
 
 		err := store.Delete(ctx, "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59")
 		require.Error(t, err)
-		assert.Equal(t, context.Canceled, err)
+		assert.ErrorIs(t, err, context.Canceled)
 	})
 }
 

--- a/storage/disk/disk_test.go
+++ b/storage/disk/disk_test.go
@@ -1,6 +1,7 @@
 package disk
 
 import (
+	"context"
 	"crypto/rand"
 	"fmt"
 	"os"
@@ -72,19 +73,19 @@ func testInvalidHashes(t *testing.T, store *DiskStore) {
 		t.Run(fmt.Sprintf("InvalidHash_%d_%s", i, tc.desc), func(t *testing.T) {
 			hash := tc.hash
 			// Test Put with invalid hash
-			err := store.Put(hash, []byte("test"))
+			err := store.Put(t.Context(), hash, []byte("test"))
 			require.Error(t, err, "Expected error for invalid hash: %s", hash)
 
 			// Test PutSD with invalid hash
-			err = store.PutSD(hash, []byte("test"))
+			err = store.PutSD(t.Context(), hash, []byte("test"))
 			require.Error(t, err, "Expected error for invalid hash: %s", hash)
 
 			// Test Get with invalid hash
-			_, err = store.Get(hash)
+			_, err = store.Get(t.Context(), hash)
 			require.Error(t, err, "Expected error for invalid hash: %s", hash)
 
 			// Test Has with invalid hash - should return false, nil (not an error)
-			exists, err := store.Has(hash)
+			exists, err := store.Has(t.Context(), hash)
 			require.NoError(t, err, "Has should not return an error for invalid hash: %s", hash)
 			require.False(t, exists, "Has should return false for invalid hash: %s", hash)
 		})
@@ -109,11 +110,11 @@ func testPathTraversal(t *testing.T, store *DiskStore) {
 	for _, attempt := range traversalAttempts {
 		t.Run(attempt.name, func(t *testing.T) {
 			// Test Put with path traversal attempt
-			err := store.Put(attempt.hash, []byte("test"))
+			err := store.Put(t.Context(), attempt.hash, []byte("test"))
 			require.Error(t, err, "Expected error for path traversal attempt: %s", attempt.name)
 
 			// Test PutSD with path traversal attempt
-			err = store.PutSD(attempt.hash, []byte("test"))
+			err = store.PutSD(t.Context(), attempt.hash, []byte("test"))
 			require.Error(t, err, "Expected error for path traversal attempt: %s", attempt.name)
 		})
 	}
@@ -277,7 +278,7 @@ func TestDiskStore_PutAndGet(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Test Put
-			err := store.Put(tc.hash, tc.data)
+			err := store.Put(t.Context(), tc.hash, tc.data)
 			if tc.expectErr {
 				require.Error(t, err, "Expected error but got none")
 				return
@@ -285,7 +286,7 @@ func TestDiskStore_PutAndGet(t *testing.T) {
 			require.NoError(t, err, "Unexpected error")
 
 			// Test Get
-			retrievedData, err := store.Get(tc.hash)
+			retrievedData, err := store.Get(t.Context(), tc.hash)
 			require.NoError(t, err, "Get failed")
 
 			if string(retrievedData) != string(tc.data) {
@@ -333,7 +334,7 @@ func TestDiskStore_PutSDAndGet(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			// Test PutSD
-			err := store.PutSD(tc.hash, tc.data)
+			err := store.PutSD(t.Context(), tc.hash, tc.data)
 			if tc.expectErr {
 				require.Error(t, err, "Expected error but got none")
 				return
@@ -341,7 +342,7 @@ func TestDiskStore_PutSDAndGet(t *testing.T) {
 			require.NoError(t, err, "Unexpected error")
 
 			// Test Get for SD blob
-			retrievedData, err := store.Get(tc.hash)
+			retrievedData, err := store.Get(t.Context(), tc.hash)
 			require.NoError(t, err, "Get failed for SD blob")
 
 			if string(retrievedData) != string(tc.data) {
@@ -357,13 +358,13 @@ func TestDiskStore_Has(t *testing.T) {
 	// Put a test blob first
 	testHash := "beb16f4ce7f9a4da1fb83a45c057ea4c2929c82603b9e20dd74487bd7bbb130d2d681ffe6fe1458a6cba2066ef9ef07e"
 	testData := []byte("test data for Has method")
-	err := store.Put(testHash, testData)
+	err := store.Put(t.Context(), testHash, testData)
 	require.NoError(t, err, "Failed to put test blob")
 
 	// Put a test SD blob
 	testSDHash := "dfe481fab5bead9258379952fcc0cee2d729a7e4e8e3e2e03a955d3453dbc7bf3d028ceb6ea94517522ca7f8561b01c3"
 	testSDData := []byte("test sd data for Has method")
-	err = store.PutSD(testSDHash, testSDData)
+	err = store.PutSD(t.Context(), testSDHash, testSDData)
 	require.NoError(t, err, "Failed to put test SD blob")
 
 	testCases := []struct {
@@ -395,7 +396,7 @@ func TestDiskStore_Has(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			exists, err := store.Has(tc.hash)
+			exists, err := store.Has(t.Context(), tc.hash)
 			require.NoError(t, err, "Has method failed")
 
 			if exists != tc.expected {
@@ -424,7 +425,7 @@ func TestDiskStore_DirectoryStructure(t *testing.T) {
 	data := []byte("test data")
 
 	// Test regular blob directory structure
-	err := store.Put(regularHash, data)
+	err := store.Put(t.Context(), regularHash, data)
 	require.NoError(t, err, "Put failed")
 
 	expectedRegularPath := filepath.Join(store.path, regularHash[:2], regularHash)
@@ -433,7 +434,7 @@ func TestDiskStore_DirectoryStructure(t *testing.T) {
 	}
 
 	// Test SD blob directory structure
-	err = store.PutSD(sdHash, data)
+	err = store.PutSD(t.Context(), sdHash, data)
 	require.NoError(t, err, "PutSD failed")
 
 	expectedSDPath := filepath.Join(store.path, "sd", sdHash[:2], sdHash)
@@ -445,14 +446,14 @@ func TestDiskStore_DirectoryStructure(t *testing.T) {
 func TestDiskStore_GetNonExistentBlob(t *testing.T) {
 	store, _ := setupTestStore(t)
 
-	_, err := store.Get("6e58057919edc5f4830ae6520d965979d25126f6dd0508c3c08742d936131813fe2876b589aafda8a5bf38130e5665e5")
+	_, err := store.Get(t.Context(), "6e58057919edc5f4830ae6520d965979d25126f6dd0508c3c08742d936131813fe2876b589aafda8a5bf38130e5665e5")
 	require.Error(t, err, "Expected error when getting non-existent blob, but got none")
 }
 
 func TestDiskStore_HasNonExistentBlob(t *testing.T) {
 	store, _ := setupTestStore(t)
 
-	exists, err := store.Has("dae0fe98c8c3a773b6e68f1081350cbbc0fb6de799d13520148e1c6fe8dbc461cc6b6bbc1be51600cd71db5a50a91f1a")
+	exists, err := store.Has(t.Context(), "dae0fe98c8c3a773b6e68f1081350cbbc0fb6de799d13520148e1c6fe8dbc461cc6b6bbc1be51600cd71db5a50a91f1a")
 	require.NoError(t, err, "Has failed")
 
 	if exists {
@@ -474,6 +475,71 @@ func generateLargeData(size int) []byte {
 func TestDiskStore_Interface(t *testing.T) {
 	store, _ := setupTestStore(t)
 	var _ storage.BlobStore = store
+}
+
+// Test context cancellation support
+func TestDiskStore_ContextCancellation(t *testing.T) {
+	store, _ := setupTestStore(t)
+
+	// Test Has with cancelled context
+	t.Run("Has_CancelledContext", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		_, err := store.Has(ctx, "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59")
+		require.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	// Test Get with cancelled context
+	t.Run("Get_CancelledContext", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		_, err := store.Get(ctx, "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59")
+		require.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	// Test Put with cancelled context
+	t.Run("Put_CancelledContext", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		err := store.Put(ctx, "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59", []byte("test data"))
+		require.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	// Test PutSD with cancelled context
+	t.Run("PutSD_CancelledContext", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		err := store.PutSD(ctx, "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59", []byte("test data"))
+		require.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	// Test List with cancelled context
+	t.Run("List_CancelledContext", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		_, err := store.List(ctx, 0, 10)
+		require.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
+
+	// Test Delete with cancelled context
+	t.Run("Delete_CancelledContext", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+
+		err := store.Delete(ctx, "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59")
+		require.Error(t, err)
+		assert.Equal(t, context.Canceled, err)
+	})
 }
 
 // Test that the StoreFactory interface is properly implemented
@@ -504,7 +570,7 @@ func TestDiskStore_SymlinkAttack(t *testing.T) {
 	defer os.RemoveAll(symlinkTarget)
 
 	// Test that Put properly rejects symlinks in directory path
-	err := store.Put(validHash, []byte("test data"))
+	err := store.Put(t.Context(), validHash, []byte("test data"))
 	require.Error(t, err, "Expected error when trying to write to path with symlink directory")
 
 	// Test symlink in SD blob path
@@ -528,7 +594,7 @@ func TestDiskStore_SymlinkAttack(t *testing.T) {
 	require.NoError(t, err)
 
 	// Test that PutSD properly rejects symlinks in directory path
-	err = store.PutSD(sdValidHash, []byte("test data"))
+	err = store.PutSD(t.Context(), sdValidHash, []byte("test data"))
 	require.Error(t, err, "Expected error when trying to write to SD path with symlink directory")
 }
 
@@ -577,17 +643,17 @@ func TestDiskStore_List(t *testing.T) {
 	store, _ := setupTestStore(t)
 
 	// Test with empty store
-	hashes, err := store.List(0, 10)
+	hashes, err := store.List(t.Context(), 0, 10)
 	require.NoError(t, err)
 	assert.Empty(t, hashes)
 
 	for _, blob := range testBlobs {
-		err := store.Put(blob.hash, blob.data)
+		err := store.Put(t.Context(), blob.hash, blob.data)
 		require.NoError(t, err)
 	}
 
 	// Test listing all blobs
-	hashes, err = store.List(0, 10)
+	hashes, err = store.List(t.Context(), 0, 10)
 	require.NoError(t, err)
 	require.Len(t, hashes, 4)
 
@@ -604,29 +670,29 @@ func TestDiskStore_List(t *testing.T) {
 	}
 
 	// Test pagination - first page
-	hashes, err = store.List(0, 2)
+	hashes, err = store.List(t.Context(), 0, 2)
 	require.NoError(t, err)
 	require.Len(t, hashes, 2)
 
 	// Test pagination - second page
-	hashes, err = store.List(2, 2)
+	hashes, err = store.List(t.Context(), 2, 2)
 	require.NoError(t, err)
 	require.Len(t, hashes, 2)
 
 	// Test with offset beyond available data
-	hashes, err = store.List(10, 5)
+	hashes, err = store.List(t.Context(), 10, 5)
 	require.Error(t, err)
 	assert.True(t, liblbryerrors.IsEndOfListError(err))
 	assert.Nil(t, hashes)
 
 	// Test error conditions
-	_, err = store.List(-1, 5)
+	_, err = store.List(t.Context(), -1, 5)
 	require.Error(t, err)
 
-	_, err = store.List(0, 0)
+	_, err = store.List(t.Context(), 0, 0)
 	require.Error(t, err)
 
-	_, err = store.List(0, -5)
+	_, err = store.List(t.Context(), 0, -5)
 	require.Error(t, err)
 
 	// Test with SD blobs
@@ -639,18 +705,18 @@ func TestDiskStore_List(t *testing.T) {
 	}
 
 	for _, blob := range sdBlobs {
-		err := store.PutSD(blob.hash, blob.data)
+		err := store.PutSD(t.Context(), blob.hash, blob.data)
 		require.NoError(t, err)
 	}
 
 	// Test listing all blobs (regular + SD)
-	hashes, err = store.List(0, 20)
+	hashes, err = store.List(t.Context(), 0, 20)
 	require.NoError(t, err)
 	require.Len(t, hashes, 6) // 4 regular + 2 SD
 
 	// Test that we can retrieve all the blobs we listed
 	for _, hash := range hashes {
-		_, err := store.Get(hash)
+		_, err := store.Get(t.Context(), hash)
 		require.NoError(t, err, "Should be able to retrieve blob with hash %s", hash)
 	}
 
@@ -659,13 +725,13 @@ func TestDiskStore_List(t *testing.T) {
 		store, _ := setupTestStore(t)
 
 		hash := "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59"
-		err := store.Put(hash, []byte("regular data"))
+		err := store.Put(t.Context(), hash, []byte("regular data"))
 		require.NoError(t, err)
 
-		err = store.PutSD(hash, []byte("sd data"))
+		err = store.PutSD(t.Context(), hash, []byte("sd data"))
 		require.NoError(t, err)
 
-		hashes, err := store.List(0, 10)
+		hashes, err := store.List(t.Context(), 0, 10)
 		require.NoError(t, err)
 
 		// Count occurrences of the hash
@@ -731,20 +797,20 @@ func TestDiskStore_Delete(t *testing.T) {
 		hash := "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59"
 		data := []byte("test data 1")
 
-		err := store.Put(hash, data)
+		err := store.Put(t.Context(), hash, data)
 		require.NoError(t, err)
 
 		// Verify blob exists
-		exists, err := store.Has(hash)
+		exists, err := store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete the blob
-		err = store.Delete(hash)
+		err = store.Delete(t.Context(), hash)
 		require.NoError(t, err)
 
 		// Verify blob is deleted
-		exists, err = store.Has(hash)
+		exists, err = store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -755,20 +821,20 @@ func TestDiskStore_Delete(t *testing.T) {
 		hash := "89a232a9036e84b6b1608d39466563ae2b51b25d04e67a9a7abc00cf0474d48d454ac204e4109f2b198a8debb5fb8fe8"
 		data := []byte("test data 2")
 
-		err := store.PutSD(hash, data)
+		err := store.PutSD(t.Context(), hash, data)
 		require.NoError(t, err)
 
 		// Verify blob exists
-		exists, err := store.Has(hash)
+		exists, err := store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete the blob
-		err = store.Delete(hash)
+		err = store.Delete(t.Context(), hash)
 		require.NoError(t, err)
 
 		// Verify blob is deleted
-		exists, err = store.Has(hash)
+		exists, err = store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -780,23 +846,23 @@ func TestDiskStore_Delete(t *testing.T) {
 		regularData := []byte("regular data")
 		sdData := []byte("sd data")
 
-		err := store.Put(hash, regularData)
+		err := store.Put(t.Context(), hash, regularData)
 		require.NoError(t, err)
 
-		err = store.PutSD(hash, sdData)
+		err = store.PutSD(t.Context(), hash, sdData)
 		require.NoError(t, err)
 
 		// Verify blob exists
-		exists, err := store.Has(hash)
+		exists, err := store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete the blob
-		err = store.Delete(hash)
+		err = store.Delete(t.Context(), hash)
 		require.NoError(t, err)
 
 		// Verify blob is deleted
-		exists, err = store.Has(hash)
+		exists, err = store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -807,11 +873,11 @@ func TestDiskStore_Delete(t *testing.T) {
 		hash := "09d3cceaaebe1c051c2d80b9e9a7391af3ee95dcbb861ed811ef4d4e914bdf7b8bfd310ee0065e0c2f6fc4f31abf1a57"
 
 		// Delete non-existent blob (should be no-op)
-		err := store.Delete(hash)
+		err := store.Delete(t.Context(), hash)
 		require.NoError(t, err)
 
 		// Verify blob still doesn't exist
-		exists, err := store.Has(hash)
+		exists, err := store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -833,7 +899,7 @@ func TestDiskStore_Delete(t *testing.T) {
 
 		for _, tc := range invalidHashes {
 			t.Run(tc.desc, func(t *testing.T) {
-				err := store.Delete(tc.hash)
+				err := store.Delete(t.Context(), tc.hash)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "invalid hash")
 			})
@@ -845,7 +911,7 @@ func TestDiskStore_Delete(t *testing.T) {
 		store, _ := setupTestStore(t)
 
 		// Delete from empty store (should be no-op)
-		err := store.Delete("adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59")
+		err := store.Delete(t.Context(), "adabf83a9b41323d9ea4a3e91debe037d20733d88af579076a37e024123f24f869d9a2e27f958bb293b179d141a27f59")
 		require.NoError(t, err)
 	})
 
@@ -858,48 +924,48 @@ func TestDiskStore_Delete(t *testing.T) {
 		blob2 := "89a232a9036e84b6b1608d39466563ae2b51b25d04e67a9a7abc00cf0474d48d454ac204e4109f2b198a8debb5fb8fe8"
 		blob3 := "212798e26cf95ae045fbdc11ebcc6fd5efdba65aa274758d10fe3f68021514fe6c3b2b28a320bf162eb06b4cf0fddbe1"
 
-		err := store.Put(blob1, []byte("data1"))
+		err := store.Put(t.Context(), blob1, []byte("data1"))
 		require.NoError(t, err)
 
-		err = store.PutSD(blob2, []byte("data2"))
+		err = store.PutSD(t.Context(), blob2, []byte("data2"))
 		require.NoError(t, err)
 
-		err = store.Put(blob3, []byte("data3"))
+		err = store.Put(t.Context(), blob3, []byte("data3"))
 		require.NoError(t, err)
 
 		// Verify all blobs exist
-		exists, err := store.Has(blob1)
+		exists, err := store.Has(t.Context(), blob1)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = store.Has(blob2)
+		exists, err = store.Has(t.Context(), blob2)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = store.Has(blob3)
+		exists, err = store.Has(t.Context(), blob3)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete blobs sequentially
-		err = store.Delete(blob1)
+		err = store.Delete(t.Context(), blob1)
 		require.NoError(t, err)
 
-		err = store.Delete(blob2)
+		err = store.Delete(t.Context(), blob2)
 		require.NoError(t, err)
 
-		err = store.Delete(blob3)
+		err = store.Delete(t.Context(), blob3)
 		require.NoError(t, err)
 
 		// Verify all blobs are deleted
-		exists, err = store.Has(blob1)
+		exists, err = store.Has(t.Context(), blob1)
 		require.NoError(t, err)
 		assert.False(t, exists)
 
-		exists, err = store.Has(blob2)
+		exists, err = store.Has(t.Context(), blob2)
 		require.NoError(t, err)
 		assert.False(t, exists)
 
-		exists, err = store.Has(blob3)
+		exists, err = store.Has(t.Context(), blob3)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -910,7 +976,7 @@ func TestDiskStore_Delete(t *testing.T) {
 		hash := "09d3cceaaebe1c051c2d80b9e9a7391af3ee95dcbb861ed811ef4d4e914bdf7b8bfd310ee0065e0c2f6fc4f31abf1a57"
 		data := []byte("test data")
 
-		err := store.Put(hash, data)
+		err := store.Put(t.Context(), hash, data)
 		require.NoError(t, err)
 
 		// Verify file exists before deletion
@@ -919,7 +985,7 @@ func TestDiskStore_Delete(t *testing.T) {
 		require.NoError(t, err, "File should exist before deletion")
 
 		// Delete the blob
-		err = store.Delete(hash)
+		err = store.Delete(t.Context(), hash)
 		require.NoError(t, err)
 
 		// Verify file is actually deleted
@@ -936,43 +1002,43 @@ func TestDiskStore_Delete(t *testing.T) {
 		blob2 := "89a232a9036e84b6b1608d39466563ae2b51b25d04e67a9a7abc00cf0474d48d454ac204e4109f2b198a8debb5fb8fe8"
 		blob3 := "212798e26cf95ae045fbdc11ebcc6fd5efdba65aa274758d10fe3f68021514fe6c3b2b28a320bf162eb06b4cf0fddbe1"
 
-		err := store.Put(blob1, []byte("data1"))
+		err := store.Put(t.Context(), blob1, []byte("data1"))
 		require.NoError(t, err)
 
-		err = store.PutSD(blob2, []byte("data2"))
+		err = store.PutSD(t.Context(), blob2, []byte("data2"))
 		require.NoError(t, err)
 
-		err = store.Put(blob3, []byte("data3"))
+		err = store.Put(t.Context(), blob3, []byte("data3"))
 		require.NoError(t, err)
 
 		// Verify all blobs exist
-		exists, err := store.Has(blob1)
+		exists, err := store.Has(t.Context(), blob1)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = store.Has(blob2)
+		exists, err = store.Has(t.Context(), blob2)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = store.Has(blob3)
+		exists, err = store.Has(t.Context(), blob3)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete one blob
-		err = store.Delete(blob2)
+		err = store.Delete(t.Context(), blob2)
 		require.NoError(t, err)
 
 		// Verify other blobs still exist
-		exists, err = store.Has(blob1)
+		exists, err = store.Has(t.Context(), blob1)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = store.Has(blob3)
+		exists, err = store.Has(t.Context(), blob3)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Verify deleted blob doesn't exist
-		exists, err = store.Has(blob2)
+		exists, err = store.Has(t.Context(), blob2)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -988,10 +1054,10 @@ func TestDiskStore_Delete(t *testing.T) {
 		sdData := []byte("sd data")
 
 		// Store blobs
-		err := store.Put(regularHash, regularData)
+		err := store.Put(t.Context(), regularHash, regularData)
 		require.NoError(t, err)
 
-		err = store.PutSD(sdHash, sdData)
+		err = store.PutSD(t.Context(), sdHash, sdData)
 		require.NoError(t, err)
 
 		// Verify directories exist
@@ -1005,18 +1071,18 @@ func TestDiskStore_Delete(t *testing.T) {
 		require.NoError(t, err, "SD blob directory should exist")
 
 		// Delete blobs
-		err = store.Delete(regularHash)
+		err = store.Delete(t.Context(), regularHash)
 		require.NoError(t, err)
 
-		err = store.Delete(sdHash)
+		err = store.Delete(t.Context(), sdHash)
 		require.NoError(t, err)
 
 		// Verify blobs are deleted
-		exists, err := store.Has(regularHash)
+		exists, err := store.Has(t.Context(), regularHash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 
-		exists, err = store.Has(sdHash)
+		exists, err = store.Has(t.Context(), sdHash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 

--- a/storage/disk/logger_test.go
+++ b/storage/disk/logger_test.go
@@ -34,7 +34,7 @@ func TestLoggerIntegration(t *testing.T) {
 	testData := []byte("test data")
 	testHash := "84eaddedccac7c406994a857e6c821f5ab3f0e700a81d716afd2570d11d5ef0e963152e95459ddc3637b4011ba3b38c2"
 
-	err = store.Put(testHash, testData)
+	err = store.Put(t.Context(), testHash, testData)
 	require.NoError(t, err, "Failed to put data")
 
 	// Test 2: Logger properly configured from config
@@ -48,7 +48,7 @@ func TestLoggerIntegration(t *testing.T) {
 	require.NoError(t, err, "Failed to create store with logger")
 
 	// Test putting and getting data with actual logger
-	err = storeWithLogger.Put(testHash, testData)
+	err = storeWithLogger.Put(t.Context(), testHash, testData)
 	require.NoError(t, err, "Failed to put data with logger")
 
 	// Test 3: Verify both stores implement the interface

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -69,28 +69,15 @@ func (m *MemoryStore) acquireWriteLock(ctx context.Context) error {
 
 // copyWithContext creates a copy of data while respecting context cancellation
 func (m *MemoryStore) copyWithContext(ctx context.Context, data []byte) ([]byte, error) {
+	// Check context before the copy operation
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	// For in-memory operations, direct copy is optimal
+	// Memory copies complete in microseconds, making chunked copying unnecessary
 	dst := make([]byte, len(data))
-
-	// For small data, copy directly
-	if len(data) <= 1024 {
-		copy(dst, data)
-		return dst, nil
-	}
-
-	// For larger data, copy in chunks to allow context cancellation
-	const chunkSize = 4096
-	for i := 0; i < len(data); i += chunkSize {
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
-
-		end := i + chunkSize
-		if end > len(data) {
-			end = len(data)
-		}
-
-		copy(dst[i:end], data[i:end])
-	}
+	copy(dst, data)
 
 	return dst, nil
 }
@@ -274,13 +261,8 @@ func (m *MemoryStore) List(ctx context.Context, offset, limit int) ([]string, er
 		hashSlice = append(hashSlice, hash)
 	}
 
-	// Sort with context cancellation checks
-	sort.Slice(hashSlice, func(i, j int) bool {
-		if err := ctx.Err(); err != nil {
-			return false // This will be caught by the outer context check
-		}
-		return hashSlice[i] < hashSlice[j]
-	})
+	// Sort for deterministic ordering
+	sort.Strings(hashSlice)
 
 	// Final context check before pagination
 	if err := ctx.Err(); err != nil {

--- a/storage/memory/memory.go
+++ b/storage/memory/memory.go
@@ -2,6 +2,7 @@
 package memory
 
 import (
+	"context"
 	"sort"
 	"sync"
 
@@ -44,19 +45,78 @@ func (m *MemoryStore) validate(hash string, data []byte, kind string) error {
 	return nil
 }
 
+// acquireReadLock acquires a read lock with context cancellation support
+func (m *MemoryStore) acquireReadLock(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		m.mutex.RLock()
+		return nil
+	}
+}
+
+// acquireWriteLock acquires a write lock with context cancellation support
+func (m *MemoryStore) acquireWriteLock(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		m.mutex.Lock()
+		return nil
+	}
+}
+
+// copyWithContext creates a copy of data while respecting context cancellation
+func (m *MemoryStore) copyWithContext(ctx context.Context, data []byte) ([]byte, error) {
+	dst := make([]byte, len(data))
+
+	// For small data, copy directly
+	if len(data) <= 1024 {
+		copy(dst, data)
+		return dst, nil
+	}
+
+	// For larger data, copy in chunks to allow context cancellation
+	const chunkSize = 4096
+	for i := 0; i < len(data); i += chunkSize {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		end := i + chunkSize
+		if end > len(data) {
+			end = len(data)
+		}
+
+		copy(dst[i:end], data[i:end])
+	}
+
+	return dst, nil
+}
+
 // Has checks if a blob exists in the store.
 //
 // It checks for regular blobs first, then SD blobs. If the same hash exists in both
 // maps, this method returns true (indicating the blob exists) regardless of which
 // type contains it. This behavior is consistent with the Get method's priority
 // system where regular blobs are prioritized over SD blobs.
-func (m *MemoryStore) Has(hash string) (bool, error) {
+// Respects context cancellation during validation and lock acquisition.
+func (m *MemoryStore) Has(ctx context.Context, hash string) (bool, error) {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return false, err
+	}
+
 	// Validate hash format
 	if !stream.ValidateHash(hash) {
 		return false, liblbryerrors.ErrInvalidHash
 	}
 
-	m.mutex.RLock()
+	// Acquire read lock with context awareness
+	if err := m.acquireReadLock(ctx); err != nil {
+		return false, err
+	}
 	defer m.mutex.RUnlock()
 
 	// Check in both regular blobs and SD blobs
@@ -76,27 +136,32 @@ func (m *MemoryStore) Has(hash string) (bool, error) {
 // This priority system ensures that regular content takes precedence over metadata
 // (SD blobs) in hash collision scenarios. The returned data is a defensive copy
 // to prevent callers from mutating the stored data.
-func (m *MemoryStore) Get(hash string) ([]byte, error) {
+// Respects context cancellation during lock acquisition and data copying.
+func (m *MemoryStore) Get(ctx context.Context, hash string) ([]byte, error) {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	// Validate hash format
 	if !stream.ValidateHash(hash) {
 		return nil, liblbryerrors.ErrInvalidHash
 	}
 
-	m.mutex.RLock()
+	// Acquire read lock with context awareness
+	if err := m.acquireReadLock(ctx); err != nil {
+		return nil, err
+	}
 	defer m.mutex.RUnlock()
 
 	// Check in regular blobs first (priority over SD blobs)
 	if data, exists := m.blobs[hash]; exists {
-		dst := make([]byte, len(data))
-		copy(dst, data)
-		return dst, nil
+		return m.copyWithContext(ctx, data)
 	}
 
 	// Check in SD blobs (lower priority)
 	if data, exists := m.sdBlobs[hash]; exists {
-		dst := make([]byte, len(data))
-		copy(dst, data)
-		return dst, nil
+		return m.copyWithContext(ctx, data)
 	}
 
 	// Blob not found
@@ -104,34 +169,56 @@ func (m *MemoryStore) Get(hash string) ([]byte, error) {
 }
 
 // Put stores a regular blob in the store
-func (m *MemoryStore) Put(hash string, data []byte) error {
+// Respects context cancellation during validation, lock acquisition, and data copying.
+func (m *MemoryStore) Put(ctx context.Context, hash string, data []byte) error {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if err := m.validate(hash, data, ""); err != nil {
 		return err
 	}
 
-	// Create defensive copy of the data
-	dataCopy := make([]byte, len(data))
-	copy(dataCopy, data)
-
-	m.mutex.Lock()
+	// Acquire write lock with context awareness
+	if err := m.acquireWriteLock(ctx); err != nil {
+		return err
+	}
 	defer m.mutex.Unlock()
+
+	// Create defensive copy of the data with context awareness
+	dataCopy, err := m.copyWithContext(ctx, data)
+	if err != nil {
+		return err
+	}
 
 	m.blobs[hash] = dataCopy
 	return nil
 }
 
 // PutSD stores an SD blob in the store
-func (m *MemoryStore) PutSD(hash string, data []byte) error {
+// Respects context cancellation during validation, lock acquisition, and data copying.
+func (m *MemoryStore) PutSD(ctx context.Context, hash string, data []byte) error {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if err := m.validate(hash, data, "SD"); err != nil {
 		return err
 	}
 
-	// Create defensive copy of the data
-	dataCopy := make([]byte, len(data))
-	copy(dataCopy, data)
-
-	m.mutex.Lock()
+	// Acquire write lock with context awareness
+	if err := m.acquireWriteLock(ctx); err != nil {
+		return err
+	}
 	defer m.mutex.Unlock()
+
+	// Create defensive copy of the data with context awareness
+	dataCopy, err := m.copyWithContext(ctx, data)
+	if err != nil {
+		return err
+	}
 
 	m.sdBlobs[hash] = dataCopy
 	return nil
@@ -143,7 +230,13 @@ func (m *MemoryStore) Name() string {
 }
 
 // List returns a list of blob hashes with pagination support
-func (m *MemoryStore) List(offset, limit int) ([]string, error) {
+// Respects context cancellation during validation, lock acquisition, and sorting.
+func (m *MemoryStore) List(ctx context.Context, offset, limit int) ([]string, error) {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	if offset < 0 {
 		return nil, liblbryerrors.ErrInvalidOffset
 	}
@@ -151,24 +244,48 @@ func (m *MemoryStore) List(offset, limit int) ([]string, error) {
 		return nil, liblbryerrors.ErrInvalidLimit
 	}
 
-	m.mutex.RLock()
+	// Acquire read lock with context awareness
+	if err := m.acquireReadLock(ctx); err != nil {
+		return nil, err
+	}
 	defer m.mutex.RUnlock()
 
 	// Collect all blob hashes with deduplication
 	allHashes := make(map[string]struct{})
 	for hash := range m.blobs {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		allHashes[hash] = struct{}{}
 	}
 	for hash := range m.sdBlobs {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		allHashes[hash] = struct{}{}
 	}
 
 	// Convert to slice and sort for deterministic ordering
 	hashSlice := make([]string, 0, len(allHashes))
 	for hash := range allHashes {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		hashSlice = append(hashSlice, hash)
 	}
-	sort.Strings(hashSlice)
+
+	// Sort with context cancellation checks
+	sort.Slice(hashSlice, func(i, j int) bool {
+		if err := ctx.Err(); err != nil {
+			return false // This will be caught by the outer context check
+		}
+		return hashSlice[i] < hashSlice[j]
+	})
+
+	// Final context check before pagination
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	// Apply pagination
 	start := offset
@@ -188,13 +305,22 @@ func (m *MemoryStore) List(offset, limit int) ([]string, error) {
 // If the blob exists in both regular and SD blob stores, it removes both.
 // If the blob is not found, it returns nil (no-op).
 // Only returns an error for invalid hash format or other unknown errors.
-func (m *MemoryStore) Delete(hash string) error {
+// Respects context cancellation during validation and lock acquisition.
+func (m *MemoryStore) Delete(ctx context.Context, hash string) error {
+	// Check context before validation
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	// Validate hash format
 	if !stream.ValidateHash(hash) {
 		return liblbryerrors.ErrInvalidHash
 	}
 
-	m.mutex.Lock()
+	// Acquire write lock with context awareness
+	if err := m.acquireWriteLock(ctx); err != nil {
+		return err
+	}
 	defer m.mutex.Unlock()
 
 	// Delete from regular blobs if it exists

--- a/storage/memory/memory_test.go
+++ b/storage/memory/memory_test.go
@@ -107,11 +107,11 @@ func TestMemoryStore_Has(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewMemoryStore()
 			if tt.setup {
-				err := store.Put(tt.hash, tt.data)
+				err := store.Put(t.Context(), tt.hash, tt.data)
 				require.NoError(t, err)
 			}
 
-			exists, err := store.Has(tt.hash)
+			exists, err := store.Has(t.Context(), tt.hash)
 			require.NoError(t, err)
 			assert.Equal(t, tt.expected, exists)
 		})
@@ -145,11 +145,11 @@ func TestMemoryStore_Get(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewMemoryStore()
 			if tt.setup {
-				err := store.Put(tt.hash, tt.data)
+				err := store.Put(t.Context(), tt.hash, tt.data)
 				require.NoError(t, err)
 			}
 
-			data, err := store.Get(tt.hash)
+			data, err := store.Get(t.Context(), tt.hash)
 			if tt.expectError {
 				assert.Error(t, err)
 				assert.Nil(t, data)
@@ -206,14 +206,14 @@ func TestMemoryStore_Put(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewMemoryStore()
-			err := store.Put(tt.hash, tt.data)
+			err := store.Put(t.Context(), tt.hash, tt.data)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 
 				// Verify the data was stored
-				data, err := store.Get(tt.hash)
+				data, err := store.Get(t.Context(), tt.hash)
 				require.NoError(t, err)
 				assert.Equal(t, tt.data, data)
 			}
@@ -266,14 +266,14 @@ func TestMemoryStore_PutSD(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := NewMemoryStore()
-			err := store.PutSD(tt.hash, tt.data)
+			err := store.PutSD(t.Context(), tt.hash, tt.data)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 
 				// Verify the SD data was stored
-				data, err := store.Get(tt.hash)
+				data, err := store.Get(t.Context(), tt.hash)
 				require.NoError(t, err)
 				assert.Equal(t, tt.data, data)
 			}
@@ -290,28 +290,28 @@ func TestMemoryStore_BlobSDIntegration(t *testing.T) {
 	sdData := []byte("sd data")
 
 	// Put regular blob
-	err := store.Put(regularHash, regularData)
+	err := store.Put(t.Context(), regularHash, regularData)
 	require.NoError(t, err)
 
 	// Put SD blob
-	err = store.PutSD(sdHash, sdData)
+	err = store.PutSD(t.Context(), sdHash, sdData)
 	require.NoError(t, err)
 
 	// Verify both exist
-	exists, err := store.Has(regularHash)
+	exists, err := store.Has(t.Context(), regularHash)
 	require.NoError(t, err)
 	assert.True(t, exists)
 
-	exists, err = store.Has(sdHash)
+	exists, err = store.Has(t.Context(), sdHash)
 	require.NoError(t, err)
 	assert.True(t, exists)
 
 	// Verify data is correct
-	data, err := store.Get(regularHash)
+	data, err := store.Get(t.Context(), regularHash)
 	require.NoError(t, err)
 	assert.Equal(t, regularData, data)
 
-	data, err = store.Get(sdHash)
+	data, err = store.Get(t.Context(), sdHash)
 	require.NoError(t, err)
 	assert.Equal(t, sdData, data)
 }
@@ -324,54 +324,54 @@ func TestMemoryStore_HashCollisionBehavior(t *testing.T) {
 	sdData := []byte("sd blob data")
 
 	// Test case 1: Regular blob stored first, then SD blob with same hash
-	err := store.Put(collisionHash, regularData)
+	err := store.Put(t.Context(), collisionHash, regularData)
 	require.NoError(t, err)
 
-	err = store.PutSD(collisionHash, sdData)
+	err = store.PutSD(t.Context(), collisionHash, sdData)
 	require.NoError(t, err)
 
 	// Has should return true (blob exists)
-	exists, err := store.Has(collisionHash)
+	exists, err := store.Has(t.Context(), collisionHash)
 	require.NoError(t, err)
 	assert.True(t, exists)
 
 	// Get should return regular blob data (priority over SD)
-	data, err := store.Get(collisionHash)
+	data, err := store.Get(t.Context(), collisionHash)
 	require.NoError(t, err)
 	assert.Equal(t, regularData, data, "Get should prioritize regular blob over SD blob")
 
 	// Test case 2: SD blob stored first, then regular blob with same hash
 	store = NewMemoryStore() // Fresh store
 
-	err = store.PutSD(collisionHash, sdData)
+	err = store.PutSD(t.Context(), collisionHash, sdData)
 	require.NoError(t, err)
 
-	err = store.Put(collisionHash, regularData)
+	err = store.Put(t.Context(), collisionHash, regularData)
 	require.NoError(t, err)
 
 	// Has should return true (blob exists)
-	exists, err = store.Has(collisionHash)
+	exists, err = store.Has(t.Context(), collisionHash)
 	require.NoError(t, err)
 	assert.True(t, exists)
 
 	// Get should still return regular blob data (priority over SD)
-	data, err = store.Get(collisionHash)
+	data, err = store.Get(t.Context(), collisionHash)
 	require.NoError(t, err)
 	assert.Equal(t, regularData, data, "Get should prioritize regular blob over SD blob regardless of storage order")
 
 	// Test case 3: Only SD blob exists
 	store = NewMemoryStore() // Fresh store
 
-	err = store.PutSD(collisionHash, sdData)
+	err = store.PutSD(t.Context(), collisionHash, sdData)
 	require.NoError(t, err)
 
 	// Has should return true
-	exists, err = store.Has(collisionHash)
+	exists, err = store.Has(t.Context(), collisionHash)
 	require.NoError(t, err)
 	assert.True(t, exists)
 
 	// Get should return SD blob data (no regular blob to prioritize)
-	data, err = store.Get(collisionHash)
+	data, err = store.Get(t.Context(), collisionHash)
 	require.NoError(t, err)
 	assert.Equal(t, sdData, data, "Get should return SD blob when no regular blob exists")
 }
@@ -432,15 +432,15 @@ func TestMemoryStore_DefensiveCopies(t *testing.T) {
 	hash := "7c9675ad7f40f29dcd41883ed9cf7e145bbb13976d9b83ab9354f4f61a87f0f7771a56724c2aa7a5ab43c68d7942e5d2"
 	original := []byte("original")
 	data := append([]byte(nil), original...) // make a separate slice to mutate later
-	require.NoError(t, store.Put(hash, data))
+	require.NoError(t, store.Put(t.Context(), hash, data))
 	// Mutate caller's slice after Put; store should be unaffected
 	data[0] = 'X'
-	got1, err := store.Get(hash)
+	got1, err := store.Get(t.Context(), hash)
 	require.NoError(t, err)
 	assert.Equal(t, original, got1)
 	// Mutate result of Get; store should still be unaffected
 	got1[1] = 'Y'
-	got2, err := store.Get(hash)
+	got2, err := store.Get(t.Context(), hash)
 	require.NoError(t, err)
 	assert.Equal(t, original, got2)
 }
@@ -449,17 +449,17 @@ func TestMemoryStore_List(t *testing.T) {
 	store := NewMemoryStore()
 
 	// Test with empty store
-	hashes, err := store.List(0, 10)
+	hashes, err := store.List(t.Context(), 0, 10)
 	require.NoError(t, err)
 	assert.Empty(t, hashes)
 
 	for _, blob := range testBlobs {
-		err := store.Put(blob.hash, blob.data)
+		err := store.Put(t.Context(), blob.hash, blob.data)
 		require.NoError(t, err)
 	}
 
 	// Test listing all blobs
-	hashes, err = store.List(0, 10)
+	hashes, err = store.List(t.Context(), 0, 10)
 	require.NoError(t, err)
 	require.Len(t, hashes, 4)
 
@@ -476,29 +476,29 @@ func TestMemoryStore_List(t *testing.T) {
 	}
 
 	// Test pagination - first page
-	hashes, err = store.List(0, 2)
+	hashes, err = store.List(t.Context(), 0, 2)
 	require.NoError(t, err)
 	require.Len(t, hashes, 2)
 
 	// Test pagination - second page
-	hashes, err = store.List(2, 2)
+	hashes, err = store.List(t.Context(), 2, 2)
 	require.NoError(t, err)
 	require.Len(t, hashes, 2)
 
 	// Test with offset beyond available data
-	hashes, err = store.List(10, 5)
+	hashes, err = store.List(t.Context(), 10, 5)
 	require.Error(t, err)
 	assert.True(t, liblbryerrors.IsEndOfListError(err))
 	assert.Nil(t, hashes)
 
 	// Test error conditions
-	_, err = store.List(-1, 5)
+	_, err = store.List(t.Context(), -1, 5)
 	require.Error(t, err)
 
-	_, err = store.List(0, 0)
+	_, err = store.List(t.Context(), 0, 0)
 	require.Error(t, err)
 
-	_, err = store.List(0, -5)
+	_, err = store.List(t.Context(), 0, -5)
 	require.Error(t, err)
 }
 
@@ -506,13 +506,13 @@ func TestMemoryStore_List_DuplicateHashInBothStores(t *testing.T) {
 	store := NewMemoryStore()
 
 	hash := "a2f1841bb9c5f3b583ac3b8c07ee1a5bf9cc48923721c30d5ca6318615776c284e8936d72fa4db7fdda2e4e9598b1e6c"
-	err := store.Put(hash, []byte("regular data"))
+	err := store.Put(t.Context(), hash, []byte("regular data"))
 	require.NoError(t, err)
 
-	err = store.PutSD(hash, []byte("sd data"))
+	err = store.PutSD(t.Context(), hash, []byte("sd data"))
 	require.NoError(t, err)
 
-	hashes, err := store.List(0, 10)
+	hashes, err := store.List(t.Context(), 0, 10)
 	require.NoError(t, err)
 
 	// Count occurrences of the hash
@@ -531,15 +531,15 @@ func TestMemoryStore_List_OrderingConsistency(t *testing.T) {
 	store := NewMemoryStore()
 
 	for _, blob := range testBlobs {
-		err := store.Put(blob.hash, blob.data)
+		err := store.Put(t.Context(), blob.hash, blob.data)
 		require.NoError(t, err)
 	}
 
 	// Call List multiple times and verify same order
-	hashes1, err := store.List(0, 10)
+	hashes1, err := store.List(t.Context(), 0, 10)
 	require.NoError(t, err)
 
-	hashes2, err := store.List(0, 10)
+	hashes2, err := store.List(t.Context(), 0, 10)
 	require.NoError(t, err)
 
 	assert.Equal(t, hashes1, hashes2, "List should return hashes in consistent order")
@@ -552,20 +552,20 @@ func TestMemoryStore_Delete(t *testing.T) {
 		hash := "a2f1841bb9c5f3b583ac3b8c07ee1a5bf9cc48923721c30d5ca6318615776c284e8936d72fa4db7fdda2e4e9598b1e6c"
 		data := []byte("test data 1")
 
-		err := store.Put(hash, data)
+		err := store.Put(t.Context(), hash, data)
 		require.NoError(t, err)
 
 		// Verify blob exists
-		exists, err := store.Has(hash)
+		exists, err := store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete the blob
-		err = store.Delete(hash)
+		err = store.Delete(t.Context(), hash)
 		require.NoError(t, err)
 
 		// Verify blob is deleted
-		exists, err = store.Has(hash)
+		exists, err = store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -576,20 +576,20 @@ func TestMemoryStore_Delete(t *testing.T) {
 		hash := "0c9675ad7f40f29dcd41883ed9cf7e145bbb13976d9b83ab9354f4f61a87f0f7771a56724c2aa7a5ab43c68d7942e5cb"
 		data := []byte("test data 2")
 
-		err := store.PutSD(hash, data)
+		err := store.PutSD(t.Context(), hash, data)
 		require.NoError(t, err)
 
 		// Verify blob exists
-		exists, err := store.Has(hash)
+		exists, err := store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete the blob
-		err = store.Delete(hash)
+		err = store.Delete(t.Context(), hash)
 		require.NoError(t, err)
 
 		// Verify blob is deleted
-		exists, err = store.Has(hash)
+		exists, err = store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -601,23 +601,23 @@ func TestMemoryStore_Delete(t *testing.T) {
 		regularData := []byte("regular data")
 		sdData := []byte("sd data")
 
-		err := store.Put(hash, regularData)
+		err := store.Put(t.Context(), hash, regularData)
 		require.NoError(t, err)
 
-		err = store.PutSD(hash, sdData)
+		err = store.PutSD(t.Context(), hash, sdData)
 		require.NoError(t, err)
 
 		// Verify blob exists
-		exists, err := store.Has(hash)
+		exists, err := store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete the blob
-		err = store.Delete(hash)
+		err = store.Delete(t.Context(), hash)
 		require.NoError(t, err)
 
 		// Verify blob is deleted
-		exists, err = store.Has(hash)
+		exists, err = store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -628,11 +628,11 @@ func TestMemoryStore_Delete(t *testing.T) {
 		hash := "dcd2093f4a3eca9f6dd59d785d0bef068fee788481986aa894cf72ed4d992c0ff9d19d1743525de2f5c3c62f5ede1c58"
 
 		// Delete non-existent blob (should be no-op)
-		err := store.Delete(hash)
+		err := store.Delete(t.Context(), hash)
 		require.NoError(t, err)
 
 		// Verify blob still doesn't exist
-		exists, err := store.Has(hash)
+		exists, err := store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -643,7 +643,7 @@ func TestMemoryStore_Delete(t *testing.T) {
 
 		for _, invalidCase := range invalidHashCases {
 			t.Run(invalidCase.name, func(t *testing.T) {
-				err := store.Delete(invalidCase.hash)
+				err := store.Delete(t.Context(), invalidCase.hash)
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "invalid hash")
 			})
@@ -655,7 +655,7 @@ func TestMemoryStore_Delete(t *testing.T) {
 		store := NewMemoryStore()
 
 		// Delete from empty store (should be no-op)
-		err := store.Delete("a2f1841bb9c5f3b583ac3b8c07ee1a5bf9cc48923721c30d5ca6318615776c284e8936d72fa4db7fdda2e4e9598b1e6c")
+		err := store.Delete(t.Context(), "a2f1841bb9c5f3b583ac3b8c07ee1a5bf9cc48923721c30d5ca6318615776c284e8936d72fa4db7fdda2e4e9598b1e6c")
 		require.NoError(t, err)
 	})
 
@@ -668,48 +668,48 @@ func TestMemoryStore_Delete(t *testing.T) {
 		blob2 := "0c9675ad7f40f29dcd41883ed9cf7e145bbb13976d9b83ab9354f4f61a87f0f7771a56724c2aa7a5ab43c68d7942e5cb"
 		blob3 := "a4d07d442b9907036c75b6c92db316a8b8428733bf5ec976627a48a7c862bf84db33075d54125a7c0b297bd2dc445f1c"
 
-		err := store.Put(blob1, []byte("data1"))
+		err := store.Put(t.Context(), blob1, []byte("data1"))
 		require.NoError(t, err)
 
-		err = store.PutSD(blob2, []byte("data2"))
+		err = store.PutSD(t.Context(), blob2, []byte("data2"))
 		require.NoError(t, err)
 
-		err = store.Put(blob3, []byte("data3"))
+		err = store.Put(t.Context(), blob3, []byte("data3"))
 		require.NoError(t, err)
 
 		// Verify all blobs exist
-		exists, err := store.Has(blob1)
+		exists, err := store.Has(t.Context(), blob1)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = store.Has(blob2)
+		exists, err = store.Has(t.Context(), blob2)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = store.Has(blob3)
+		exists, err = store.Has(t.Context(), blob3)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete blobs sequentially
-		err = store.Delete(blob1)
+		err = store.Delete(t.Context(), blob1)
 		require.NoError(t, err)
 
-		err = store.Delete(blob2)
+		err = store.Delete(t.Context(), blob2)
 		require.NoError(t, err)
 
-		err = store.Delete(blob3)
+		err = store.Delete(t.Context(), blob3)
 		require.NoError(t, err)
 
 		// Verify all blobs are deleted
-		exists, err = store.Has(blob1)
+		exists, err = store.Has(t.Context(), blob1)
 		require.NoError(t, err)
 		assert.False(t, exists)
 
-		exists, err = store.Has(blob2)
+		exists, err = store.Has(t.Context(), blob2)
 		require.NoError(t, err)
 		assert.False(t, exists)
 
-		exists, err = store.Has(blob3)
+		exists, err = store.Has(t.Context(), blob3)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -720,20 +720,20 @@ func TestMemoryStore_Delete(t *testing.T) {
 		hash := "dcd2093f4a3eca9f6dd59d785d0bef068fee788481986aa894cf72ed4d992c0ff9d19d1743525de2f5c3c62f5ede1c58"
 		data := []byte("test data")
 
-		err := store.Put(hash, data)
+		err := store.Put(t.Context(), hash, data)
 		require.NoError(t, err)
 
 		// Verify blob exists before deletion
-		exists, err := store.Has(hash)
+		exists, err := store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete the blob
-		err = store.Delete(hash)
+		err = store.Delete(t.Context(), hash)
 		require.NoError(t, err)
 
 		// Verify blob is actually deleted
-		exists, err = store.Has(hash)
+		exists, err = store.Has(t.Context(), hash)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})
@@ -747,43 +747,43 @@ func TestMemoryStore_Delete(t *testing.T) {
 		blob2 := "0c9675ad7f40f29dcd41883ed9cf7e145bbb13976d9b83ab9354f4f61a87f0f7771a56724c2aa7a5ab43c68d7942e5cb"
 		blob3 := "a4d07d442b9907036c75b6c92db316a8b8428733bf5ec976627a48a7c862bf84db33075d54125a7c0b297bd2dc445f1c"
 
-		err := store.Put(blob1, []byte("data1"))
+		err := store.Put(t.Context(), blob1, []byte("data1"))
 		require.NoError(t, err)
 
-		err = store.PutSD(blob2, []byte("data2"))
+		err = store.PutSD(t.Context(), blob2, []byte("data2"))
 		require.NoError(t, err)
 
-		err = store.Put(blob3, []byte("data3"))
+		err = store.Put(t.Context(), blob3, []byte("data3"))
 		require.NoError(t, err)
 
 		// Verify all blobs exist
-		exists, err := store.Has(blob1)
+		exists, err := store.Has(t.Context(), blob1)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = store.Has(blob2)
+		exists, err = store.Has(t.Context(), blob2)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = store.Has(blob3)
+		exists, err = store.Has(t.Context(), blob3)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Delete one blob
-		err = store.Delete(blob2)
+		err = store.Delete(t.Context(), blob2)
 		require.NoError(t, err)
 
 		// Verify other blobs still exist
-		exists, err = store.Has(blob1)
+		exists, err = store.Has(t.Context(), blob1)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
-		exists, err = store.Has(blob3)
+		exists, err = store.Has(t.Context(), blob3)
 		require.NoError(t, err)
 		assert.True(t, exists)
 
 		// Verify deleted blob doesn't exist
-		exists, err = store.Has(blob2)
+		exists, err = store.Has(t.Context(), blob2)
 		require.NoError(t, err)
 		assert.False(t, exists)
 	})

--- a/storage/mocks/BlobStore.go
+++ b/storage/mocks/BlobStore.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,16 +38,16 @@ func (_m *MockBlobStore) EXPECT() *MockBlobStore_Expecter {
 }
 
 // Delete provides a mock function for the type MockBlobStore
-func (_mock *MockBlobStore) Delete(hash string) error {
-	ret := _mock.Called(hash)
+func (_mock *MockBlobStore) Delete(ctx context.Context, hash string) error {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -58,19 +60,25 @@ type MockBlobStore_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockBlobStore_Expecter) Delete(hash interface{}) *MockBlobStore_Delete_Call {
-	return &MockBlobStore_Delete_Call{Call: _e.mock.On("Delete", hash)}
+func (_e *MockBlobStore_Expecter) Delete(ctx interface{}, hash interface{}) *MockBlobStore_Delete_Call {
+	return &MockBlobStore_Delete_Call{Call: _e.mock.On("Delete", ctx, hash)}
 }
 
-func (_c *MockBlobStore_Delete_Call) Run(run func(hash string)) *MockBlobStore_Delete_Call {
+func (_c *MockBlobStore_Delete_Call) Run(run func(ctx context.Context, hash string)) *MockBlobStore_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -81,14 +89,14 @@ func (_c *MockBlobStore_Delete_Call) Return(err error) *MockBlobStore_Delete_Cal
 	return _c
 }
 
-func (_c *MockBlobStore_Delete_Call) RunAndReturn(run func(hash string) error) *MockBlobStore_Delete_Call {
+func (_c *MockBlobStore_Delete_Call) RunAndReturn(run func(ctx context.Context, hash string) error) *MockBlobStore_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Get provides a mock function for the type MockBlobStore
-func (_mock *MockBlobStore) Get(hash string) ([]byte, error) {
-	ret := _mock.Called(hash)
+func (_mock *MockBlobStore) Get(ctx context.Context, hash string) ([]byte, error) {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -96,18 +104,18 @@ func (_mock *MockBlobStore) Get(hash string) ([]byte, error) {
 
 	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) ([]byte, error)); ok {
-		return returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]byte, error)); ok {
+		return returnFunc(ctx, hash)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) []byte); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, hash)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -120,19 +128,25 @@ type MockBlobStore_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockBlobStore_Expecter) Get(hash interface{}) *MockBlobStore_Get_Call {
-	return &MockBlobStore_Get_Call{Call: _e.mock.On("Get", hash)}
+func (_e *MockBlobStore_Expecter) Get(ctx interface{}, hash interface{}) *MockBlobStore_Get_Call {
+	return &MockBlobStore_Get_Call{Call: _e.mock.On("Get", ctx, hash)}
 }
 
-func (_c *MockBlobStore_Get_Call) Run(run func(hash string)) *MockBlobStore_Get_Call {
+func (_c *MockBlobStore_Get_Call) Run(run func(ctx context.Context, hash string)) *MockBlobStore_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -143,14 +157,14 @@ func (_c *MockBlobStore_Get_Call) Return(bytes []byte, err error) *MockBlobStore
 	return _c
 }
 
-func (_c *MockBlobStore_Get_Call) RunAndReturn(run func(hash string) ([]byte, error)) *MockBlobStore_Get_Call {
+func (_c *MockBlobStore_Get_Call) RunAndReturn(run func(ctx context.Context, hash string) ([]byte, error)) *MockBlobStore_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Has provides a mock function for the type MockBlobStore
-func (_mock *MockBlobStore) Has(hash string) (bool, error) {
-	ret := _mock.Called(hash)
+func (_mock *MockBlobStore) Has(ctx context.Context, hash string) (bool, error) {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Has")
@@ -158,16 +172,16 @@ func (_mock *MockBlobStore) Has(hash string) (bool, error) {
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, hash)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, hash)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -180,19 +194,25 @@ type MockBlobStore_Has_Call struct {
 }
 
 // Has is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockBlobStore_Expecter) Has(hash interface{}) *MockBlobStore_Has_Call {
-	return &MockBlobStore_Has_Call{Call: _e.mock.On("Has", hash)}
+func (_e *MockBlobStore_Expecter) Has(ctx interface{}, hash interface{}) *MockBlobStore_Has_Call {
+	return &MockBlobStore_Has_Call{Call: _e.mock.On("Has", ctx, hash)}
 }
 
-func (_c *MockBlobStore_Has_Call) Run(run func(hash string)) *MockBlobStore_Has_Call {
+func (_c *MockBlobStore_Has_Call) Run(run func(ctx context.Context, hash string)) *MockBlobStore_Has_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -203,14 +223,14 @@ func (_c *MockBlobStore_Has_Call) Return(b bool, err error) *MockBlobStore_Has_C
 	return _c
 }
 
-func (_c *MockBlobStore_Has_Call) RunAndReturn(run func(hash string) (bool, error)) *MockBlobStore_Has_Call {
+func (_c *MockBlobStore_Has_Call) RunAndReturn(run func(ctx context.Context, hash string) (bool, error)) *MockBlobStore_Has_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // List provides a mock function for the type MockBlobStore
-func (_mock *MockBlobStore) List(offset int, limit int) ([]string, error) {
-	ret := _mock.Called(offset, limit)
+func (_mock *MockBlobStore) List(ctx context.Context, offset int, limit int) ([]string, error) {
+	ret := _mock.Called(ctx, offset, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for List")
@@ -218,18 +238,18 @@ func (_mock *MockBlobStore) List(offset int, limit int) ([]string, error) {
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]string, error)); ok {
-		return returnFunc(offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]string, error)); ok {
+		return returnFunc(ctx, offset, limit)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []string); ok {
-		r0 = returnFunc(offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []string); ok {
+		r0 = returnFunc(ctx, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(offset, limit)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, offset, limit)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -242,25 +262,31 @@ type MockBlobStore_List_Call struct {
 }
 
 // List is a helper method to define mock.On call
+//   - ctx context.Context
 //   - offset int
 //   - limit int
-func (_e *MockBlobStore_Expecter) List(offset interface{}, limit interface{}) *MockBlobStore_List_Call {
-	return &MockBlobStore_List_Call{Call: _e.mock.On("List", offset, limit)}
+func (_e *MockBlobStore_Expecter) List(ctx interface{}, offset interface{}, limit interface{}) *MockBlobStore_List_Call {
+	return &MockBlobStore_List_Call{Call: _e.mock.On("List", ctx, offset, limit)}
 }
 
-func (_c *MockBlobStore_List_Call) Run(run func(offset int, limit int)) *MockBlobStore_List_Call {
+func (_c *MockBlobStore_List_Call) Run(run func(ctx context.Context, offset int, limit int)) *MockBlobStore_List_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -271,7 +297,7 @@ func (_c *MockBlobStore_List_Call) Return(strings []string, err error) *MockBlob
 	return _c
 }
 
-func (_c *MockBlobStore_List_Call) RunAndReturn(run func(offset int, limit int) ([]string, error)) *MockBlobStore_List_Call {
+func (_c *MockBlobStore_List_Call) RunAndReturn(run func(ctx context.Context, offset int, limit int) ([]string, error)) *MockBlobStore_List_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -321,16 +347,16 @@ func (_c *MockBlobStore_Name_Call) RunAndReturn(run func() string) *MockBlobStor
 }
 
 // Put provides a mock function for the type MockBlobStore
-func (_mock *MockBlobStore) Put(hash string, data []byte) error {
-	ret := _mock.Called(hash, data)
+func (_mock *MockBlobStore) Put(ctx context.Context, hash string, data []byte) error {
+	ret := _mock.Called(ctx, hash, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Put")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
-		r0 = returnFunc(hash, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte) error); ok {
+		r0 = returnFunc(ctx, hash, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -343,25 +369,31 @@ type MockBlobStore_Put_Call struct {
 }
 
 // Put is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
 //   - data []byte
-func (_e *MockBlobStore_Expecter) Put(hash interface{}, data interface{}) *MockBlobStore_Put_Call {
-	return &MockBlobStore_Put_Call{Call: _e.mock.On("Put", hash, data)}
+func (_e *MockBlobStore_Expecter) Put(ctx interface{}, hash interface{}, data interface{}) *MockBlobStore_Put_Call {
+	return &MockBlobStore_Put_Call{Call: _e.mock.On("Put", ctx, hash, data)}
 }
 
-func (_c *MockBlobStore_Put_Call) Run(run func(hash string, data []byte)) *MockBlobStore_Put_Call {
+func (_c *MockBlobStore_Put_Call) Run(run func(ctx context.Context, hash string, data []byte)) *MockBlobStore_Put_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []byte
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]byte)
+			arg1 = args[1].(string)
+		}
+		var arg2 []byte
+		if args[2] != nil {
+			arg2 = args[2].([]byte)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -372,22 +404,22 @@ func (_c *MockBlobStore_Put_Call) Return(err error) *MockBlobStore_Put_Call {
 	return _c
 }
 
-func (_c *MockBlobStore_Put_Call) RunAndReturn(run func(hash string, data []byte) error) *MockBlobStore_Put_Call {
+func (_c *MockBlobStore_Put_Call) RunAndReturn(run func(ctx context.Context, hash string, data []byte) error) *MockBlobStore_Put_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // PutSD provides a mock function for the type MockBlobStore
-func (_mock *MockBlobStore) PutSD(hash string, data []byte) error {
-	ret := _mock.Called(hash, data)
+func (_mock *MockBlobStore) PutSD(ctx context.Context, hash string, data []byte) error {
+	ret := _mock.Called(ctx, hash, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PutSD")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
-		r0 = returnFunc(hash, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte) error); ok {
+		r0 = returnFunc(ctx, hash, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -400,25 +432,31 @@ type MockBlobStore_PutSD_Call struct {
 }
 
 // PutSD is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
 //   - data []byte
-func (_e *MockBlobStore_Expecter) PutSD(hash interface{}, data interface{}) *MockBlobStore_PutSD_Call {
-	return &MockBlobStore_PutSD_Call{Call: _e.mock.On("PutSD", hash, data)}
+func (_e *MockBlobStore_Expecter) PutSD(ctx interface{}, hash interface{}, data interface{}) *MockBlobStore_PutSD_Call {
+	return &MockBlobStore_PutSD_Call{Call: _e.mock.On("PutSD", ctx, hash, data)}
 }
 
-func (_c *MockBlobStore_PutSD_Call) Run(run func(hash string, data []byte)) *MockBlobStore_PutSD_Call {
+func (_c *MockBlobStore_PutSD_Call) Run(run func(ctx context.Context, hash string, data []byte)) *MockBlobStore_PutSD_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []byte
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]byte)
+			arg1 = args[1].(string)
+		}
+		var arg2 []byte
+		if args[2] != nil {
+			arg2 = args[2].([]byte)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -429,7 +467,7 @@ func (_c *MockBlobStore_PutSD_Call) Return(err error) *MockBlobStore_PutSD_Call 
 	return _c
 }
 
-func (_c *MockBlobStore_PutSD_Call) RunAndReturn(run func(hash string, data []byte) error) *MockBlobStore_PutSD_Call {
+func (_c *MockBlobStore_PutSD_Call) RunAndReturn(run func(ctx context.Context, hash string, data []byte) error) *MockBlobStore_PutSD_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/storage/mocks/DummyBlocklistBlobStore.go
+++ b/storage/mocks/DummyBlocklistBlobStore.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,16 +38,16 @@ func (_m *MockDummyBlocklistBlobStore) EXPECT() *MockDummyBlocklistBlobStore_Exp
 }
 
 // Delete provides a mock function for the type MockDummyBlocklistBlobStore
-func (_mock *MockDummyBlocklistBlobStore) Delete(hash string) error {
-	ret := _mock.Called(hash)
+func (_mock *MockDummyBlocklistBlobStore) Delete(ctx context.Context, hash string) error {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -58,19 +60,25 @@ type MockDummyBlocklistBlobStore_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockDummyBlocklistBlobStore_Expecter) Delete(hash interface{}) *MockDummyBlocklistBlobStore_Delete_Call {
-	return &MockDummyBlocklistBlobStore_Delete_Call{Call: _e.mock.On("Delete", hash)}
+func (_e *MockDummyBlocklistBlobStore_Expecter) Delete(ctx interface{}, hash interface{}) *MockDummyBlocklistBlobStore_Delete_Call {
+	return &MockDummyBlocklistBlobStore_Delete_Call{Call: _e.mock.On("Delete", ctx, hash)}
 }
 
-func (_c *MockDummyBlocklistBlobStore_Delete_Call) Run(run func(hash string)) *MockDummyBlocklistBlobStore_Delete_Call {
+func (_c *MockDummyBlocklistBlobStore_Delete_Call) Run(run func(ctx context.Context, hash string)) *MockDummyBlocklistBlobStore_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -81,14 +89,14 @@ func (_c *MockDummyBlocklistBlobStore_Delete_Call) Return(err error) *MockDummyB
 	return _c
 }
 
-func (_c *MockDummyBlocklistBlobStore_Delete_Call) RunAndReturn(run func(hash string) error) *MockDummyBlocklistBlobStore_Delete_Call {
+func (_c *MockDummyBlocklistBlobStore_Delete_Call) RunAndReturn(run func(ctx context.Context, hash string) error) *MockDummyBlocklistBlobStore_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Get provides a mock function for the type MockDummyBlocklistBlobStore
-func (_mock *MockDummyBlocklistBlobStore) Get(hash string) ([]byte, error) {
-	ret := _mock.Called(hash)
+func (_mock *MockDummyBlocklistBlobStore) Get(ctx context.Context, hash string) ([]byte, error) {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -96,18 +104,18 @@ func (_mock *MockDummyBlocklistBlobStore) Get(hash string) ([]byte, error) {
 
 	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) ([]byte, error)); ok {
-		return returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]byte, error)); ok {
+		return returnFunc(ctx, hash)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) []byte); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, hash)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -120,19 +128,25 @@ type MockDummyBlocklistBlobStore_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockDummyBlocklistBlobStore_Expecter) Get(hash interface{}) *MockDummyBlocklistBlobStore_Get_Call {
-	return &MockDummyBlocklistBlobStore_Get_Call{Call: _e.mock.On("Get", hash)}
+func (_e *MockDummyBlocklistBlobStore_Expecter) Get(ctx interface{}, hash interface{}) *MockDummyBlocklistBlobStore_Get_Call {
+	return &MockDummyBlocklistBlobStore_Get_Call{Call: _e.mock.On("Get", ctx, hash)}
 }
 
-func (_c *MockDummyBlocklistBlobStore_Get_Call) Run(run func(hash string)) *MockDummyBlocklistBlobStore_Get_Call {
+func (_c *MockDummyBlocklistBlobStore_Get_Call) Run(run func(ctx context.Context, hash string)) *MockDummyBlocklistBlobStore_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -143,14 +157,14 @@ func (_c *MockDummyBlocklistBlobStore_Get_Call) Return(bytes []byte, err error) 
 	return _c
 }
 
-func (_c *MockDummyBlocklistBlobStore_Get_Call) RunAndReturn(run func(hash string) ([]byte, error)) *MockDummyBlocklistBlobStore_Get_Call {
+func (_c *MockDummyBlocklistBlobStore_Get_Call) RunAndReturn(run func(ctx context.Context, hash string) ([]byte, error)) *MockDummyBlocklistBlobStore_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Has provides a mock function for the type MockDummyBlocklistBlobStore
-func (_mock *MockDummyBlocklistBlobStore) Has(hash string) (bool, error) {
-	ret := _mock.Called(hash)
+func (_mock *MockDummyBlocklistBlobStore) Has(ctx context.Context, hash string) (bool, error) {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Has")
@@ -158,16 +172,16 @@ func (_mock *MockDummyBlocklistBlobStore) Has(hash string) (bool, error) {
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, hash)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, hash)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -180,19 +194,25 @@ type MockDummyBlocklistBlobStore_Has_Call struct {
 }
 
 // Has is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockDummyBlocklistBlobStore_Expecter) Has(hash interface{}) *MockDummyBlocklistBlobStore_Has_Call {
-	return &MockDummyBlocklistBlobStore_Has_Call{Call: _e.mock.On("Has", hash)}
+func (_e *MockDummyBlocklistBlobStore_Expecter) Has(ctx interface{}, hash interface{}) *MockDummyBlocklistBlobStore_Has_Call {
+	return &MockDummyBlocklistBlobStore_Has_Call{Call: _e.mock.On("Has", ctx, hash)}
 }
 
-func (_c *MockDummyBlocklistBlobStore_Has_Call) Run(run func(hash string)) *MockDummyBlocklistBlobStore_Has_Call {
+func (_c *MockDummyBlocklistBlobStore_Has_Call) Run(run func(ctx context.Context, hash string)) *MockDummyBlocklistBlobStore_Has_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -203,14 +223,14 @@ func (_c *MockDummyBlocklistBlobStore_Has_Call) Return(b bool, err error) *MockD
 	return _c
 }
 
-func (_c *MockDummyBlocklistBlobStore_Has_Call) RunAndReturn(run func(hash string) (bool, error)) *MockDummyBlocklistBlobStore_Has_Call {
+func (_c *MockDummyBlocklistBlobStore_Has_Call) RunAndReturn(run func(ctx context.Context, hash string) (bool, error)) *MockDummyBlocklistBlobStore_Has_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // List provides a mock function for the type MockDummyBlocklistBlobStore
-func (_mock *MockDummyBlocklistBlobStore) List(offset int, limit int) ([]string, error) {
-	ret := _mock.Called(offset, limit)
+func (_mock *MockDummyBlocklistBlobStore) List(ctx context.Context, offset int, limit int) ([]string, error) {
+	ret := _mock.Called(ctx, offset, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for List")
@@ -218,18 +238,18 @@ func (_mock *MockDummyBlocklistBlobStore) List(offset int, limit int) ([]string,
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]string, error)); ok {
-		return returnFunc(offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]string, error)); ok {
+		return returnFunc(ctx, offset, limit)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []string); ok {
-		r0 = returnFunc(offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []string); ok {
+		r0 = returnFunc(ctx, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(offset, limit)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, offset, limit)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -242,25 +262,31 @@ type MockDummyBlocklistBlobStore_List_Call struct {
 }
 
 // List is a helper method to define mock.On call
+//   - ctx context.Context
 //   - offset int
 //   - limit int
-func (_e *MockDummyBlocklistBlobStore_Expecter) List(offset interface{}, limit interface{}) *MockDummyBlocklistBlobStore_List_Call {
-	return &MockDummyBlocklistBlobStore_List_Call{Call: _e.mock.On("List", offset, limit)}
+func (_e *MockDummyBlocklistBlobStore_Expecter) List(ctx interface{}, offset interface{}, limit interface{}) *MockDummyBlocklistBlobStore_List_Call {
+	return &MockDummyBlocklistBlobStore_List_Call{Call: _e.mock.On("List", ctx, offset, limit)}
 }
 
-func (_c *MockDummyBlocklistBlobStore_List_Call) Run(run func(offset int, limit int)) *MockDummyBlocklistBlobStore_List_Call {
+func (_c *MockDummyBlocklistBlobStore_List_Call) Run(run func(ctx context.Context, offset int, limit int)) *MockDummyBlocklistBlobStore_List_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -271,7 +297,7 @@ func (_c *MockDummyBlocklistBlobStore_List_Call) Return(strings []string, err er
 	return _c
 }
 
-func (_c *MockDummyBlocklistBlobStore_List_Call) RunAndReturn(run func(offset int, limit int) ([]string, error)) *MockDummyBlocklistBlobStore_List_Call {
+func (_c *MockDummyBlocklistBlobStore_List_Call) RunAndReturn(run func(ctx context.Context, offset int, limit int) ([]string, error)) *MockDummyBlocklistBlobStore_List_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -321,16 +347,16 @@ func (_c *MockDummyBlocklistBlobStore_Name_Call) RunAndReturn(run func() string)
 }
 
 // Put provides a mock function for the type MockDummyBlocklistBlobStore
-func (_mock *MockDummyBlocklistBlobStore) Put(hash string, data []byte) error {
-	ret := _mock.Called(hash, data)
+func (_mock *MockDummyBlocklistBlobStore) Put(ctx context.Context, hash string, data []byte) error {
+	ret := _mock.Called(ctx, hash, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Put")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
-		r0 = returnFunc(hash, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte) error); ok {
+		r0 = returnFunc(ctx, hash, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -343,25 +369,31 @@ type MockDummyBlocklistBlobStore_Put_Call struct {
 }
 
 // Put is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
 //   - data []byte
-func (_e *MockDummyBlocklistBlobStore_Expecter) Put(hash interface{}, data interface{}) *MockDummyBlocklistBlobStore_Put_Call {
-	return &MockDummyBlocklistBlobStore_Put_Call{Call: _e.mock.On("Put", hash, data)}
+func (_e *MockDummyBlocklistBlobStore_Expecter) Put(ctx interface{}, hash interface{}, data interface{}) *MockDummyBlocklistBlobStore_Put_Call {
+	return &MockDummyBlocklistBlobStore_Put_Call{Call: _e.mock.On("Put", ctx, hash, data)}
 }
 
-func (_c *MockDummyBlocklistBlobStore_Put_Call) Run(run func(hash string, data []byte)) *MockDummyBlocklistBlobStore_Put_Call {
+func (_c *MockDummyBlocklistBlobStore_Put_Call) Run(run func(ctx context.Context, hash string, data []byte)) *MockDummyBlocklistBlobStore_Put_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []byte
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]byte)
+			arg1 = args[1].(string)
+		}
+		var arg2 []byte
+		if args[2] != nil {
+			arg2 = args[2].([]byte)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -372,22 +404,22 @@ func (_c *MockDummyBlocklistBlobStore_Put_Call) Return(err error) *MockDummyBloc
 	return _c
 }
 
-func (_c *MockDummyBlocklistBlobStore_Put_Call) RunAndReturn(run func(hash string, data []byte) error) *MockDummyBlocklistBlobStore_Put_Call {
+func (_c *MockDummyBlocklistBlobStore_Put_Call) RunAndReturn(run func(ctx context.Context, hash string, data []byte) error) *MockDummyBlocklistBlobStore_Put_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // PutSD provides a mock function for the type MockDummyBlocklistBlobStore
-func (_mock *MockDummyBlocklistBlobStore) PutSD(hash string, data []byte) error {
-	ret := _mock.Called(hash, data)
+func (_mock *MockDummyBlocklistBlobStore) PutSD(ctx context.Context, hash string, data []byte) error {
+	ret := _mock.Called(ctx, hash, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PutSD")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
-		r0 = returnFunc(hash, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte) error); ok {
+		r0 = returnFunc(ctx, hash, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -400,25 +432,31 @@ type MockDummyBlocklistBlobStore_PutSD_Call struct {
 }
 
 // PutSD is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
 //   - data []byte
-func (_e *MockDummyBlocklistBlobStore_Expecter) PutSD(hash interface{}, data interface{}) *MockDummyBlocklistBlobStore_PutSD_Call {
-	return &MockDummyBlocklistBlobStore_PutSD_Call{Call: _e.mock.On("PutSD", hash, data)}
+func (_e *MockDummyBlocklistBlobStore_Expecter) PutSD(ctx interface{}, hash interface{}, data interface{}) *MockDummyBlocklistBlobStore_PutSD_Call {
+	return &MockDummyBlocklistBlobStore_PutSD_Call{Call: _e.mock.On("PutSD", ctx, hash, data)}
 }
 
-func (_c *MockDummyBlocklistBlobStore_PutSD_Call) Run(run func(hash string, data []byte)) *MockDummyBlocklistBlobStore_PutSD_Call {
+func (_c *MockDummyBlocklistBlobStore_PutSD_Call) Run(run func(ctx context.Context, hash string, data []byte)) *MockDummyBlocklistBlobStore_PutSD_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []byte
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]byte)
+			arg1 = args[1].(string)
+		}
+		var arg2 []byte
+		if args[2] != nil {
+			arg2 = args[2].([]byte)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -429,7 +467,7 @@ func (_c *MockDummyBlocklistBlobStore_PutSD_Call) Return(err error) *MockDummyBl
 	return _c
 }
 
-func (_c *MockDummyBlocklistBlobStore_PutSD_Call) RunAndReturn(run func(hash string, data []byte) error) *MockDummyBlocklistBlobStore_PutSD_Call {
+func (_c *MockDummyBlocklistBlobStore_PutSD_Call) RunAndReturn(run func(ctx context.Context, hash string, data []byte) error) *MockDummyBlocklistBlobStore_PutSD_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/storage/mocks/DummyMissingBlobStore.go
+++ b/storage/mocks/DummyMissingBlobStore.go
@@ -5,6 +5,8 @@
 package mocks
 
 import (
+	"context"
+
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -36,16 +38,16 @@ func (_m *MockDummyMissingBlobStore) EXPECT() *MockDummyMissingBlobStore_Expecte
 }
 
 // Delete provides a mock function for the type MockDummyMissingBlobStore
-func (_mock *MockDummyMissingBlobStore) Delete(hash string) error {
-	ret := _mock.Called(hash)
+func (_mock *MockDummyMissingBlobStore) Delete(ctx context.Context, hash string) error {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Delete")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string) error); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -58,19 +60,25 @@ type MockDummyMissingBlobStore_Delete_Call struct {
 }
 
 // Delete is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockDummyMissingBlobStore_Expecter) Delete(hash interface{}) *MockDummyMissingBlobStore_Delete_Call {
-	return &MockDummyMissingBlobStore_Delete_Call{Call: _e.mock.On("Delete", hash)}
+func (_e *MockDummyMissingBlobStore_Expecter) Delete(ctx interface{}, hash interface{}) *MockDummyMissingBlobStore_Delete_Call {
+	return &MockDummyMissingBlobStore_Delete_Call{Call: _e.mock.On("Delete", ctx, hash)}
 }
 
-func (_c *MockDummyMissingBlobStore_Delete_Call) Run(run func(hash string)) *MockDummyMissingBlobStore_Delete_Call {
+func (_c *MockDummyMissingBlobStore_Delete_Call) Run(run func(ctx context.Context, hash string)) *MockDummyMissingBlobStore_Delete_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -81,14 +89,14 @@ func (_c *MockDummyMissingBlobStore_Delete_Call) Return(err error) *MockDummyMis
 	return _c
 }
 
-func (_c *MockDummyMissingBlobStore_Delete_Call) RunAndReturn(run func(hash string) error) *MockDummyMissingBlobStore_Delete_Call {
+func (_c *MockDummyMissingBlobStore_Delete_Call) RunAndReturn(run func(ctx context.Context, hash string) error) *MockDummyMissingBlobStore_Delete_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Get provides a mock function for the type MockDummyMissingBlobStore
-func (_mock *MockDummyMissingBlobStore) Get(hash string) ([]byte, error) {
-	ret := _mock.Called(hash)
+func (_mock *MockDummyMissingBlobStore) Get(ctx context.Context, hash string) ([]byte, error) {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -96,18 +104,18 @@ func (_mock *MockDummyMissingBlobStore) Get(hash string) ([]byte, error) {
 
 	var r0 []byte
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) ([]byte, error)); ok {
-		return returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) ([]byte, error)); ok {
+		return returnFunc(ctx, hash)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) []byte); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) []byte); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, hash)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -120,19 +128,25 @@ type MockDummyMissingBlobStore_Get_Call struct {
 }
 
 // Get is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockDummyMissingBlobStore_Expecter) Get(hash interface{}) *MockDummyMissingBlobStore_Get_Call {
-	return &MockDummyMissingBlobStore_Get_Call{Call: _e.mock.On("Get", hash)}
+func (_e *MockDummyMissingBlobStore_Expecter) Get(ctx interface{}, hash interface{}) *MockDummyMissingBlobStore_Get_Call {
+	return &MockDummyMissingBlobStore_Get_Call{Call: _e.mock.On("Get", ctx, hash)}
 }
 
-func (_c *MockDummyMissingBlobStore_Get_Call) Run(run func(hash string)) *MockDummyMissingBlobStore_Get_Call {
+func (_c *MockDummyMissingBlobStore_Get_Call) Run(run func(ctx context.Context, hash string)) *MockDummyMissingBlobStore_Get_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -143,14 +157,14 @@ func (_c *MockDummyMissingBlobStore_Get_Call) Return(bytes []byte, err error) *M
 	return _c
 }
 
-func (_c *MockDummyMissingBlobStore_Get_Call) RunAndReturn(run func(hash string) ([]byte, error)) *MockDummyMissingBlobStore_Get_Call {
+func (_c *MockDummyMissingBlobStore_Get_Call) RunAndReturn(run func(ctx context.Context, hash string) ([]byte, error)) *MockDummyMissingBlobStore_Get_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // Has provides a mock function for the type MockDummyMissingBlobStore
-func (_mock *MockDummyMissingBlobStore) Has(hash string) (bool, error) {
-	ret := _mock.Called(hash)
+func (_mock *MockDummyMissingBlobStore) Has(ctx context.Context, hash string) (bool, error) {
+	ret := _mock.Called(ctx, hash)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Has")
@@ -158,16 +172,16 @@ func (_mock *MockDummyMissingBlobStore) Has(hash string) (bool, error) {
 
 	var r0 bool
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(string) (bool, error)); ok {
-		return returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) (bool, error)); ok {
+		return returnFunc(ctx, hash)
 	}
-	if returnFunc, ok := ret.Get(0).(func(string) bool); ok {
-		r0 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string) bool); ok {
+		r0 = returnFunc(ctx, hash)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
-	if returnFunc, ok := ret.Get(1).(func(string) error); ok {
-		r1 = returnFunc(hash)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = returnFunc(ctx, hash)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -180,19 +194,25 @@ type MockDummyMissingBlobStore_Has_Call struct {
 }
 
 // Has is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
-func (_e *MockDummyMissingBlobStore_Expecter) Has(hash interface{}) *MockDummyMissingBlobStore_Has_Call {
-	return &MockDummyMissingBlobStore_Has_Call{Call: _e.mock.On("Has", hash)}
+func (_e *MockDummyMissingBlobStore_Expecter) Has(ctx interface{}, hash interface{}) *MockDummyMissingBlobStore_Has_Call {
+	return &MockDummyMissingBlobStore_Has_Call{Call: _e.mock.On("Has", ctx, hash)}
 }
 
-func (_c *MockDummyMissingBlobStore_Has_Call) Run(run func(hash string)) *MockDummyMissingBlobStore_Has_Call {
+func (_c *MockDummyMissingBlobStore_Has_Call) Run(run func(ctx context.Context, hash string)) *MockDummyMissingBlobStore_Has_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
 		}
 		run(
 			arg0,
+			arg1,
 		)
 	})
 	return _c
@@ -203,14 +223,14 @@ func (_c *MockDummyMissingBlobStore_Has_Call) Return(b bool, err error) *MockDum
 	return _c
 }
 
-func (_c *MockDummyMissingBlobStore_Has_Call) RunAndReturn(run func(hash string) (bool, error)) *MockDummyMissingBlobStore_Has_Call {
+func (_c *MockDummyMissingBlobStore_Has_Call) RunAndReturn(run func(ctx context.Context, hash string) (bool, error)) *MockDummyMissingBlobStore_Has_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // List provides a mock function for the type MockDummyMissingBlobStore
-func (_mock *MockDummyMissingBlobStore) List(offset int, limit int) ([]string, error) {
-	ret := _mock.Called(offset, limit)
+func (_mock *MockDummyMissingBlobStore) List(ctx context.Context, offset int, limit int) ([]string, error) {
+	ret := _mock.Called(ctx, offset, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for List")
@@ -218,18 +238,18 @@ func (_mock *MockDummyMissingBlobStore) List(offset int, limit int) ([]string, e
 
 	var r0 []string
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(int, int) ([]string, error)); ok {
-		return returnFunc(offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) ([]string, error)); ok {
+		return returnFunc(ctx, offset, limit)
 	}
-	if returnFunc, ok := ret.Get(0).(func(int, int) []string); ok {
-		r0 = returnFunc(offset, limit)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, int, int) []string); ok {
+		r0 = returnFunc(ctx, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(int, int) error); ok {
-		r1 = returnFunc(offset, limit)
+	if returnFunc, ok := ret.Get(1).(func(context.Context, int, int) error); ok {
+		r1 = returnFunc(ctx, offset, limit)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -242,25 +262,31 @@ type MockDummyMissingBlobStore_List_Call struct {
 }
 
 // List is a helper method to define mock.On call
+//   - ctx context.Context
 //   - offset int
 //   - limit int
-func (_e *MockDummyMissingBlobStore_Expecter) List(offset interface{}, limit interface{}) *MockDummyMissingBlobStore_List_Call {
-	return &MockDummyMissingBlobStore_List_Call{Call: _e.mock.On("List", offset, limit)}
+func (_e *MockDummyMissingBlobStore_Expecter) List(ctx interface{}, offset interface{}, limit interface{}) *MockDummyMissingBlobStore_List_Call {
+	return &MockDummyMissingBlobStore_List_Call{Call: _e.mock.On("List", ctx, offset, limit)}
 }
 
-func (_c *MockDummyMissingBlobStore_List_Call) Run(run func(offset int, limit int)) *MockDummyMissingBlobStore_List_Call {
+func (_c *MockDummyMissingBlobStore_List_Call) Run(run func(ctx context.Context, offset int, limit int)) *MockDummyMissingBlobStore_List_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 int
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(int)
+			arg0 = args[0].(context.Context)
 		}
 		var arg1 int
 		if args[1] != nil {
 			arg1 = args[1].(int)
 		}
+		var arg2 int
+		if args[2] != nil {
+			arg2 = args[2].(int)
+		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -271,7 +297,7 @@ func (_c *MockDummyMissingBlobStore_List_Call) Return(strings []string, err erro
 	return _c
 }
 
-func (_c *MockDummyMissingBlobStore_List_Call) RunAndReturn(run func(offset int, limit int) ([]string, error)) *MockDummyMissingBlobStore_List_Call {
+func (_c *MockDummyMissingBlobStore_List_Call) RunAndReturn(run func(ctx context.Context, offset int, limit int) ([]string, error)) *MockDummyMissingBlobStore_List_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -383,16 +409,16 @@ func (_c *MockDummyMissingBlobStore_Name_Call) RunAndReturn(run func() string) *
 }
 
 // Put provides a mock function for the type MockDummyMissingBlobStore
-func (_mock *MockDummyMissingBlobStore) Put(hash string, data []byte) error {
-	ret := _mock.Called(hash, data)
+func (_mock *MockDummyMissingBlobStore) Put(ctx context.Context, hash string, data []byte) error {
+	ret := _mock.Called(ctx, hash, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Put")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
-		r0 = returnFunc(hash, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte) error); ok {
+		r0 = returnFunc(ctx, hash, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -405,25 +431,31 @@ type MockDummyMissingBlobStore_Put_Call struct {
 }
 
 // Put is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
 //   - data []byte
-func (_e *MockDummyMissingBlobStore_Expecter) Put(hash interface{}, data interface{}) *MockDummyMissingBlobStore_Put_Call {
-	return &MockDummyMissingBlobStore_Put_Call{Call: _e.mock.On("Put", hash, data)}
+func (_e *MockDummyMissingBlobStore_Expecter) Put(ctx interface{}, hash interface{}, data interface{}) *MockDummyMissingBlobStore_Put_Call {
+	return &MockDummyMissingBlobStore_Put_Call{Call: _e.mock.On("Put", ctx, hash, data)}
 }
 
-func (_c *MockDummyMissingBlobStore_Put_Call) Run(run func(hash string, data []byte)) *MockDummyMissingBlobStore_Put_Call {
+func (_c *MockDummyMissingBlobStore_Put_Call) Run(run func(ctx context.Context, hash string, data []byte)) *MockDummyMissingBlobStore_Put_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []byte
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]byte)
+			arg1 = args[1].(string)
+		}
+		var arg2 []byte
+		if args[2] != nil {
+			arg2 = args[2].([]byte)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -434,22 +466,22 @@ func (_c *MockDummyMissingBlobStore_Put_Call) Return(err error) *MockDummyMissin
 	return _c
 }
 
-func (_c *MockDummyMissingBlobStore_Put_Call) RunAndReturn(run func(hash string, data []byte) error) *MockDummyMissingBlobStore_Put_Call {
+func (_c *MockDummyMissingBlobStore_Put_Call) RunAndReturn(run func(ctx context.Context, hash string, data []byte) error) *MockDummyMissingBlobStore_Put_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // PutSD provides a mock function for the type MockDummyMissingBlobStore
-func (_mock *MockDummyMissingBlobStore) PutSD(hash string, data []byte) error {
-	ret := _mock.Called(hash, data)
+func (_mock *MockDummyMissingBlobStore) PutSD(ctx context.Context, hash string, data []byte) error {
+	ret := _mock.Called(ctx, hash, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PutSD")
 	}
 
 	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(string, []byte) error); ok {
-		r0 = returnFunc(hash, data)
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, []byte) error); ok {
+		r0 = returnFunc(ctx, hash, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -462,25 +494,31 @@ type MockDummyMissingBlobStore_PutSD_Call struct {
 }
 
 // PutSD is a helper method to define mock.On call
+//   - ctx context.Context
 //   - hash string
 //   - data []byte
-func (_e *MockDummyMissingBlobStore_Expecter) PutSD(hash interface{}, data interface{}) *MockDummyMissingBlobStore_PutSD_Call {
-	return &MockDummyMissingBlobStore_PutSD_Call{Call: _e.mock.On("PutSD", hash, data)}
+func (_e *MockDummyMissingBlobStore_Expecter) PutSD(ctx interface{}, hash interface{}, data interface{}) *MockDummyMissingBlobStore_PutSD_Call {
+	return &MockDummyMissingBlobStore_PutSD_Call{Call: _e.mock.On("PutSD", ctx, hash, data)}
 }
 
-func (_c *MockDummyMissingBlobStore_PutSD_Call) Run(run func(hash string, data []byte)) *MockDummyMissingBlobStore_PutSD_Call {
+func (_c *MockDummyMissingBlobStore_PutSD_Call) Run(run func(ctx context.Context, hash string, data []byte)) *MockDummyMissingBlobStore_PutSD_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 string
+		var arg0 context.Context
 		if args[0] != nil {
-			arg0 = args[0].(string)
+			arg0 = args[0].(context.Context)
 		}
-		var arg1 []byte
+		var arg1 string
 		if args[1] != nil {
-			arg1 = args[1].([]byte)
+			arg1 = args[1].(string)
+		}
+		var arg2 []byte
+		if args[2] != nil {
+			arg2 = args[2].([]byte)
 		}
 		run(
 			arg0,
 			arg1,
+			arg2,
 		)
 	})
 	return _c
@@ -491,7 +529,7 @@ func (_c *MockDummyMissingBlobStore_PutSD_Call) Return(err error) *MockDummyMiss
 	return _c
 }
 
-func (_c *MockDummyMissingBlobStore_PutSD_Call) RunAndReturn(run func(hash string, data []byte) error) *MockDummyMissingBlobStore_PutSD_Call {
+func (_c *MockDummyMissingBlobStore_PutSD_Call) RunAndReturn(run func(ctx context.Context, hash string, data []byte) error) *MockDummyMissingBlobStore_PutSD_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
- Updated BlobStore interface and implementations (disk, memory) to accept context in Has, Get, Put, PutSD, List, and Delete methods
- Added context cancellation support to disk storage operations (atomicWrite, readWithContext, writeWithContext, walkWithContext)
- Added context cancellation support to memory storage operations (acquireReadLock, acquireWriteLock, copyWithContext)
- Modified peer and reflector protocols to propagate context through request handling
- Updated tests to pass context in mock expectations and calls
---
* Tests can be run with `go test -race ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage operations are now context-aware across backends, enabling cancellation and timeouts.
  * Connection context now carries source (peer/reflector) and IP information; peer/reflector handlers use per-request timeouts.

* **Tests**
  * Test suites and mocks updated for context-aware storage APIs.
  * Added tests exercising context cancellation and timeout behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->