### PR TITLE
feat(transfer): add blob hash verification for peer downloads

### DIFF
--- a/blob/blob.go
+++ b/blob/blob.go
@@ -12,7 +12,9 @@ import (
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/sha512"
+	"crypto/subtle"
 	"encoding/hex"
+	"errors"
 	"fmt"
 
 	liblbcrypto "go.lumeweb.com/liblbry/crypto"
@@ -24,6 +26,30 @@ const (
 	BlobHashSize      = sha512.Size384
 	BlobHashHexLength = BlobHashSize * 2 // in hex, each byte is 2 chars
 )
+
+// VerifyBlobHash verifies that blob data matches the expected hash
+func VerifyBlobHash(data []byte, expectedHash string) error {
+	if len(data) == 0 {
+		return errors.New("empty blob data")
+	}
+
+	computedHash, err := ComputeBlobHashBytes(data)
+	if err != nil {
+		return fmt.Errorf("failed to compute blob hash: %w", err)
+	}
+
+	expectedHashBytes, err := hex.DecodeString(expectedHash)
+	if err != nil {
+		return fmt.Errorf("invalid expected hash format: %w", err)
+	}
+
+	if subtle.ConstantTimeCompare(computedHash, expectedHashBytes) != 1 {
+		return fmt.Errorf("hash mismatch: expected %s, got %s",
+			expectedHash, hex.EncodeToString(computedHash))
+	}
+
+	return nil
+}
 
 // Blob represents a data blob with encryption capabilities
 type Blob []byte

--- a/blob/transfer/peer_transfer/executor/peer_task_executor.go
+++ b/blob/transfer/peer_transfer/executor/peer_task_executor.go
@@ -2,8 +2,6 @@ package executor
 
 import (
 	"context"
-	"crypto/subtle"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -22,34 +20,6 @@ import (
 
 	peerblob "go.lumeweb.com/liblbry/blob/transfer/peer_transfer/blob"
 )
-
-// verifyBlobHash verifies that blob data matches the expected hash
-// This is a critical security function to ensure peers don't return invalid/malicious data
-func verifyBlobHash(data []byte, expectedHash string) error {
-	if len(data) == 0 {
-		return liblbryerrors.Err("empty blob data received from peer")
-	}
-
-	// Compute hash of the actual data
-	computedHash, err := blob.ComputeBlobHashBytes(data)
-	if err != nil {
-		return liblbryerrors.Err("failed to compute hash of peer blob data: %w", err)
-	}
-
-	// Decode expected hash for constant-time comparison
-	expectedHashBytes, err := hex.DecodeString(expectedHash)
-	if err != nil {
-		return liblbryerrors.Err("invalid expected hash format: %w", err)
-	}
-
-	// Compare computed hash with expected hash using constant-time comparison
-	if subtle.ConstantTimeCompare(computedHash, expectedHashBytes) != 1 {
-		return liblbryerrors.Err("peer blob hash verification failed: expected %s, got %s",
-			expectedHash, hex.EncodeToString(computedHash))
-	}
-
-	return nil
-}
 
 // errorType represents the type of error that occurred during peer transfer
 type errorType string
@@ -261,7 +231,8 @@ func (pte *DefaultPeerTaskExecutor) createPeerTask(ctx context.Context, hash str
 
 		if err == nil {
 			// Verify blob hash before accepting data from peer
-			if verifyErr := verifyBlobHash(data, blobHash); verifyErr != nil {
+			if verifyErr := blob.VerifyBlobHash(data, blobHash); verifyErr != nil {
+				verifyErr = liblbryerrors.Err("peer blob %s", verifyErr)
 				// Hash verification failed - treat as peer failure
 				pte.handlePeerFailure(ctx, req, verifyErr, peerContact, peerHashBitmap, isFixedPeer, peerAddress, blobHash, raceCancelFunc)
 			} else {

--- a/blob/transfer/peer_transfer/executor/peer_task_executor.go
+++ b/blob/transfer/peer_transfer/executor/peer_task_executor.go
@@ -2,6 +2,8 @@ package executor
 
 import (
 	"context"
+	"crypto/subtle"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"net"
@@ -12,12 +14,42 @@ import (
 	"github.com/gammazero/workerpool"
 	"go.lumeweb.com/lbry-dht"
 	"go.lumeweb.com/lbry-dht/bits"
+	"go.lumeweb.com/liblbry/blob"
 	"go.lumeweb.com/liblbry/blob/transfer/peer_transfer/connection"
 	"go.lumeweb.com/liblbry/blob/transfer/peer_transfer/discovery"
+	liblbryerrors "go.lumeweb.com/liblbry/errors"
 	"go.uber.org/zap"
 
-	"go.lumeweb.com/liblbry/blob/transfer/peer_transfer/blob"
+	peerblob "go.lumeweb.com/liblbry/blob/transfer/peer_transfer/blob"
 )
+
+// verifyBlobHash verifies that blob data matches the expected hash
+// This is a critical security function to ensure peers don't return invalid/malicious data
+func verifyBlobHash(data []byte, expectedHash string) error {
+	if len(data) == 0 {
+		return liblbryerrors.Err("empty blob data received from peer")
+	}
+
+	// Compute hash of the actual data
+	computedHash, err := blob.ComputeBlobHashBytes(data)
+	if err != nil {
+		return liblbryerrors.Err("failed to compute hash of peer blob data: %w", err)
+	}
+
+	// Decode expected hash for constant-time comparison
+	expectedHashBytes, err := hex.DecodeString(expectedHash)
+	if err != nil {
+		return liblbryerrors.Err("invalid expected hash format: %w", err)
+	}
+
+	// Compare computed hash with expected hash using constant-time comparison
+	if subtle.ConstantTimeCompare(computedHash, expectedHashBytes) != 1 {
+		return liblbryerrors.Err("peer blob hash verification failed: expected %s, got %s",
+			expectedHash, hex.EncodeToString(computedHash))
+	}
+
+	return nil
+}
 
 // errorType represents the type of error that occurred during peer transfer
 type errorType string
@@ -40,7 +72,7 @@ const (
 //     avoid overlapping WaitForCompletionWithContext calls unless this behavior is desired.
 type PeerTaskExecutor interface {
 	// ExecutePeerTasks executes download tasks for all provided peers concurrently
-	ExecutePeerTasks(ctx context.Context, hash string, contacts []dht.Contact, hashBitmap bits.Bitmap, req *blob.BlobRequest, raceCancel context.CancelFunc) error
+	ExecutePeerTasks(ctx context.Context, hash string, contacts []dht.Contact, hashBitmap bits.Bitmap, req *peerblob.BlobRequest, raceCancel context.CancelFunc) error
 
 	// IsStopped checks if the executor is stopped. Returns true only after Stop() has been called.
 	// During Start(), this returns false only after the worker pool is fully initialized.
@@ -137,7 +169,7 @@ func NewPeerTaskExecutor(
 }
 
 // ExecutePeerTasks executes download tasks for all provided peers concurrently
-func (pte *DefaultPeerTaskExecutor) ExecutePeerTasks(ctx context.Context, hash string, contacts []dht.Contact, hashBitmap bits.Bitmap, req *blob.BlobRequest, raceCancel context.CancelFunc) error {
+func (pte *DefaultPeerTaskExecutor) ExecutePeerTasks(ctx context.Context, hash string, contacts []dht.Contact, hashBitmap bits.Bitmap, req *peerblob.BlobRequest, raceCancel context.CancelFunc) error {
 	if pte.IsStopped() {
 		return fmt.Errorf("peer task executor is stopped")
 	}
@@ -198,7 +230,7 @@ func (pte *DefaultPeerTaskExecutor) ExecutePeerTasks(ctx context.Context, hash s
 }
 
 // createPeerTask creates a task function for downloading from a specific peer
-func (pte *DefaultPeerTaskExecutor) createPeerTask(ctx context.Context, hash string, contact dht.Contact, hashBitmap bits.Bitmap, req *blob.BlobRequest, raceCancel context.CancelFunc) func() {
+func (pte *DefaultPeerTaskExecutor) createPeerTask(ctx context.Context, hash string, contact dht.Contact, hashBitmap bits.Bitmap, req *peerblob.BlobRequest, raceCancel context.CancelFunc) func() {
 	// Check if this is a fixed peer
 	isFixed := pte.discovery.IsFixedPeer(contact)
 
@@ -228,8 +260,14 @@ func (pte *DefaultPeerTaskExecutor) createPeerTask(ctx context.Context, hash str
 		data, err := pte.connMgr.DownloadFromPeer(ctx, peerAddress, blobHash)
 
 		if err == nil {
-			// SUCCESS! Set result and notify all waiters
-			pte.completionHandler.CompleteWithData(req, data, raceCancelFunc, blobHash)
+			// Verify blob hash before accepting data from peer
+			if verifyErr := verifyBlobHash(data, blobHash); verifyErr != nil {
+				// Hash verification failed - treat as peer failure
+				pte.handlePeerFailure(ctx, req, verifyErr, peerContact, peerHashBitmap, isFixedPeer, peerAddress, blobHash, raceCancelFunc)
+			} else {
+				// SUCCESS! Data verified, set result and notify all waiters
+				pte.completionHandler.CompleteWithData(req, data, raceCancelFunc, blobHash)
+			}
 		} else {
 			// Handle peer failure
 			pte.handlePeerFailure(ctx, req, err, peerContact, peerHashBitmap, isFixedPeer, peerAddress, blobHash, raceCancelFunc)
@@ -242,7 +280,7 @@ func (pte *DefaultPeerTaskExecutor) createPeerTask(ctx context.Context, hash str
 }
 
 // handlePeerFailure handles the failure of a peer download attempt
-func (pte *DefaultPeerTaskExecutor) handlePeerFailure(ctx context.Context, req *blob.BlobRequest, err error, contact dht.Contact, hashBitmap bits.Bitmap, isFixed bool, peerAddr string, hash string, raceCancel context.CancelFunc) {
+func (pte *DefaultPeerTaskExecutor) handlePeerFailure(ctx context.Context, req *peerblob.BlobRequest, err error, contact dht.Contact, hashBitmap bits.Bitmap, isFixed bool, peerAddr string, hash string, raceCancel context.CancelFunc) {
 	// Only mark peer as bad for non-context errors (connection failures, protocol errors, etc.)
 	// Context cancellation/timeout errors shouldn't penalize the peer
 	// Also, never remove fixed peers from DHT as they are fallback peers
@@ -350,7 +388,7 @@ func (pte *DefaultPeerTaskExecutor) GetMaxConcurrency() int {
 }
 
 // shouldSkipTask checks if we should skip submitting tasks
-func (pte *DefaultPeerTaskExecutor) shouldSkipTask(req *blob.BlobRequest) bool {
+func (pte *DefaultPeerTaskExecutor) shouldSkipTask(req *peerblob.BlobRequest) bool {
 	// Check if request is already done before submitting tasks
 	select {
 	case <-req.GetDone():
@@ -362,7 +400,7 @@ func (pte *DefaultPeerTaskExecutor) shouldSkipTask(req *blob.BlobRequest) bool {
 }
 
 // shouldProceedWithTask checks if we should proceed with a task
-func (pte *DefaultPeerTaskExecutor) shouldProceedWithTask(ctx context.Context, req *blob.BlobRequest) bool {
+func (pte *DefaultPeerTaskExecutor) shouldProceedWithTask(ctx context.Context, req *peerblob.BlobRequest) bool {
 	// Check if request is already done or context is cancelled before doing any work
 	select {
 	case <-req.GetDone():
@@ -393,7 +431,7 @@ func (pte *DefaultPeerTaskExecutor) handleEarlyTaskExit() {
 // checkEarlyExit checks if the task should exit early due to context cancellation or request completion.
 // If so, it handles the counter adjustments and returns true. Otherwise, returns false.
 // This should only be called after pendingTasks has been incremented for the task.
-func (pte *DefaultPeerTaskExecutor) checkEarlyExit(ctx context.Context, req *blob.BlobRequest) bool {
+func (pte *DefaultPeerTaskExecutor) checkEarlyExit(ctx context.Context, req *peerblob.BlobRequest) bool {
 	select {
 	case <-req.GetDone():
 		// Request already completed, handle counter adjustments and return

--- a/blob/transfer/peer_transfer/executor/peer_task_executor_test.go
+++ b/blob/transfer/peer_transfer/executor/peer_task_executor_test.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"context"
 	"net"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,6 +23,48 @@ import (
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
+
+// testCompletionHandler implements CompletionHandler with proper CompleteOnce semantics for testing
+type testCompletionHandler struct {
+	completed int32
+}
+
+func (tch *testCompletionHandler) CompleteWithData(req *blob.BlobRequest, data []byte, raceCancel context.CancelFunc, hash string) {
+	if atomic.CompareAndSwapInt32(&tch.completed, 0, 1) {
+		// First call - actually complete the request
+		req.SetResult(blob.NewTaskResult(data, nil))
+		req.MarkDone()
+		if raceCancel != nil {
+			raceCancel()
+		}
+	}
+	// Subsequent calls are ignored (simulating CompleteOnce behavior)
+}
+
+func (tch *testCompletionHandler) CompleteWithError(req *blob.BlobRequest, err error) error {
+	if atomic.CompareAndSwapInt32(&tch.completed, 0, 1) {
+		req.SetResult(blob.NewTaskResult(nil, err))
+		req.MarkDone()
+	}
+	return nil
+}
+
+func (tch *testCompletionHandler) CompleteWithErrorAndCancel(req *blob.BlobRequest, err error, raceCancel context.CancelFunc, hash string) {
+	if atomic.CompareAndSwapInt32(&tch.completed, 0, 1) {
+		req.SetResult(blob.NewTaskResult(nil, err))
+		req.MarkDone()
+		if raceCancel != nil {
+			raceCancel()
+		}
+	}
+}
+
+func (tch *testCompletionHandler) TrackFailedPeer(req *blob.BlobRequest, err error) (int32, bool) {
+	completed := req.IncrementCompleted()
+	totalPeers := req.GetTotalPeers()
+	isFinal := completed >= totalPeers
+	return completed, isFinal
+}
 
 // Test helpers and common setup functions
 // These helpers eliminate code duplication across test functions and provide
@@ -182,23 +225,26 @@ func TestNewPeerTaskExecutor(t *testing.T) {
 
 func TestDefaultPeerTaskExecutor_ExecutePeerTasks_Success(t *testing.T) {
 	setup := setupTestWithConcurrency(t, 2)
-	executor := setup.executor
 
 	hash := lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1]
 	contacts := createTestContacts()[:2] // Use first 2 contacts
 	hashBitmap := createTestHashBitmap(2)
 	req := createTestBlobRequest()
 
+	// Get valid test data that matches the hash
+	validTestData := lbryTesting.TestData(t, hash)
+
 	// Mock IsFixedPeer to return false (non-fixed peers)
 	setup.peerDiscovery.EXPECT().IsFixedPeer(contacts[0]).Return(false).Once()
 	setup.peerDiscovery.EXPECT().IsFixedPeer(contacts[1]).Return(false).Once()
 
-	// Mock successful download with peer address string
-	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return([]byte("test data"), nil)
-	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.2:6347", hash).Return([]byte("test data"), nil)
+	// Mock successful download with valid blob data that passes hash verification
+	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return(validTestData, nil)
+	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.2:6347", hash).Return(validTestData, nil)
 
-	// Mock coordinator completion
-	setup.completionHandler.EXPECT().CompleteWithData(req, mock.Anything, mock.AnythingOfType("context.CancelFunc"), hash).Times(2)
+	// Use test completion handler with proper CompleteOnce semantics
+	testCompletionHandler := &testCompletionHandler{}
+	executor := NewPeerTaskExecutor(setup.connMgr, setup.peerDiscovery, testCompletionHandler, setup.maxConcurrency, setup.logger)
 
 	err := executor.ExecutePeerTasks(context.Background(), hash, contacts, hashBitmap, req, func() {})
 
@@ -341,37 +387,42 @@ func TestDefaultPeerTaskExecutor_ExecutePeerTasks_ContextCancellation(t *testing
 
 func TestDefaultPeerTaskExecutor_ExecutePeerTasks_Concurrency(t *testing.T) {
 	setup := setupTestWithConcurrency(t, 2)
-	executor := setup.executor
 
 	hash := lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1]
 	contacts := createTestContacts() // Use all 3 contacts
 	hashBitmap := createTestHashBitmap(3)
 	req := createTestBlobRequest()
 
+	// Get valid test data that matches the hash
+	validTestData := lbryTesting.TestData(t, hash)
+
 	// Mock IsFixedPeer to return false (non-fixed peers)
 	setup.peerDiscovery.EXPECT().IsFixedPeer(contacts[0]).Return(false).Once()
 	setup.peerDiscovery.EXPECT().IsFixedPeer(contacts[1]).Return(false).Once()
 	setup.peerDiscovery.EXPECT().IsFixedPeer(contacts[2]).Return(false).Once()
 
-	// Mock downloads with peer address strings
-	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return([]byte("test data"), nil).Once()
-	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.2:6347", hash).Return([]byte("test data"), nil).Once()
-	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.3:6347", hash).Return([]byte("test data"), nil).Once()
+	// Mock downloads - only first one will actually execute due to CompleteOnce semantics
+	// The other peers will be cancelled before they can download
+	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return(validTestData, nil).Once()
+	// The other downloads may or may not be called depending on timing, so use Maybe()
+	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.2:6347", hash).Return(validTestData, nil).Maybe()
+	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.3:6347", hash).Return(validTestData, nil).Maybe()
 
-	// Mock coordinator completion - all 3 should succeed
-	setup.completionHandler.EXPECT().CompleteWithData(req, mock.Anything, mock.AnythingOfType("context.CancelFunc"), hash).Times(3)
+	// Use test completion handler with proper CompleteOnce semantics
+	testCompletionHandler := &testCompletionHandler{}
+	executor := NewPeerTaskExecutor(setup.connMgr, setup.peerDiscovery, testCompletionHandler, setup.maxConcurrency, setup.logger)
 
 	start := time.Now()
 	err := executor.ExecutePeerTasks(context.Background(), hash, contacts, hashBitmap, req, func() {})
 	require.NoError(t, err)
 
 	// Wait for tasks to complete and measure total execution time
-	err = executor.WaitForCompletion(500 * time.Millisecond)
+	err = executor.WaitForCompletion(1000 * time.Millisecond)
 	require.NoError(t, err)
 	duration := time.Since(start)
 
-	// Should complete quickly due to concurrent execution with race condition
-	assert.Less(t, duration, 500*time.Millisecond)
+	// Should complete quickly due to concurrent execution
+	assert.Less(t, duration, 1*time.Second)
 
 	// Verify task stats
 	assertTaskStats(t, executor, 3, 3, 0)
@@ -410,7 +461,7 @@ func TestDefaultPeerTaskExecutor_ExecutePeerTasks_FinalPeerFailure(t *testing.T)
 	require.NoError(t, err)
 
 	// Wait for tasks to complete
-	err = executor.WaitForCompletion(500 * time.Millisecond)
+	err = executor.WaitForCompletion(2 * time.Second)
 	require.NoError(t, err)
 
 	// Verify task stats
@@ -468,11 +519,14 @@ func TestDefaultPeerTaskExecutor_WaitForCompletionWithContext(t *testing.T) {
 	hashBitmap := createTestHashBitmap(1)
 	req := createTestBlobRequest()
 
+	// Get valid test data that matches the hash
+	validTestData := lbryTesting.TestData(t, hash)
+
 	// Mock IsFixedPeer to return false (non-fixed peer)
 	setup.peerDiscovery.EXPECT().IsFixedPeer(contacts[0]).Return(false).Once()
 
 	// Mock successful download
-	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return([]byte("test data"), nil)
+	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return(validTestData, nil)
 	setup.completionHandler.EXPECT().CompleteWithData(req, mock.Anything, mock.AnythingOfType("context.CancelFunc"), hash)
 
 	err := executor.ExecutePeerTasks(context.Background(), hash, contacts, hashBitmap, req, func() {})
@@ -495,12 +549,15 @@ func TestDefaultPeerTaskExecutor_WaitForCompletionWithContext_Cancelled_LongRunn
 	hashBitmap := createTestHashBitmap(1)
 	req := createTestBlobRequest()
 
+	// Get valid test data that matches the hash
+	validTestData := lbryTesting.TestData(t, hash)
+
 	// Mock IsFixedPeer to return false (non-fixed peer)
 	setup.peerDiscovery.EXPECT().IsFixedPeer(contacts[0]).Return(false).Once()
 
 	// Mock a long-running task that will still be running when context times out
 	// This will complete successfully after 300ms, but the context timeout is 200ms
-	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return([]byte("test data"), nil).After(300 * time.Millisecond)
+	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return(validTestData, nil).After(300 * time.Millisecond)
 
 	// Mock the successful completion that will happen after the context times out
 	setup.completionHandler.EXPECT().CompleteWithData(req, mock.Anything, mock.AnythingOfType("context.CancelFunc"), hash).Maybe()
@@ -531,7 +588,47 @@ func TestDefaultPeerTaskExecutor_GetWorkerPoolStats(t *testing.T) {
 
 func TestDefaultPeerTaskExecutor_WaitAllTasksComplete(t *testing.T) {
 	setup := setupTestWithConcurrency(t, 2)
+
+	hash := lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1]
+	contacts := createTestContacts()[:1] // Use first contact
+	hashBitmap := createTestHashBitmap(1)
+	req := createTestBlobRequest()
+
+	// Get valid test data that matches the hash
+	validTestData := lbryTesting.TestData(t, hash)
+
+	// Mock IsFixedPeer to return false (non-fixed peer)
+	setup.peerDiscovery.EXPECT().IsFixedPeer(contacts[0]).Return(false).Once()
+
+	// Mock successful download
+	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return(validTestData, nil)
+
+	// Use test completion handler with proper CompleteOnce semantics
+	testCompletionHandler := &testCompletionHandler{}
+	executor := NewPeerTaskExecutor(setup.connMgr, setup.peerDiscovery, testCompletionHandler, setup.maxConcurrency, setup.logger)
+
+	err := executor.ExecutePeerTasks(context.Background(), hash, contacts, hashBitmap, req, func() {})
+	require.NoError(t, err)
+
+	// Wait for task to complete naturally first
+	err = executor.WaitForCompletion(2 * time.Second)
+	require.NoError(t, err)
+
+	// Test WaitAllTasksComplete - should work fine even when no tasks are pending
+	err = executor.WaitAllTasksComplete()
+	assert.NoError(t, err)
+
+	// Verify executor is still functional after WaitAllTasksComplete
+	assert.False(t, executor.IsStopped())
+}
+
+func TestDefaultPeerTaskExecutor_ExecutePeerTasks_HashValidationFailure(t *testing.T) {
+	setup := setupTestWithConcurrency(t, 2)
 	executor := setup.executor
+
+	// Create mock DHT node for peer failure handling
+	mockDHTNode := protocolMocks.NewMockDHTNode(t)
+	setup.peerDiscovery.EXPECT().DHTNode().Return(mockDHTNode)
 
 	hash := lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1]
 	contacts := createTestContacts()[:1] // Use first contact
@@ -541,21 +638,25 @@ func TestDefaultPeerTaskExecutor_WaitAllTasksComplete(t *testing.T) {
 	// Mock IsFixedPeer to return false (non-fixed peer)
 	setup.peerDiscovery.EXPECT().IsFixedPeer(contacts[0]).Return(false).Once()
 
-	// Mock successful download
-	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return([]byte("test data"), nil)
-	setup.completionHandler.EXPECT().CompleteWithData(req, mock.Anything, mock.AnythingOfType("context.CancelFunc"), hash)
+	// Mock RemoveBadPeerFromHash to be called when hash validation fails
+	mockDHTNode.EXPECT().RemoveBadPeerFromHash(hashBitmap, contacts[0]).Return().Once()
+
+	// Mock successful download but with mismatching data that will fail hash validation
+	mismatchingData := []byte("this data does not match the expected hash")
+	setup.connMgr.EXPECT().DownloadFromPeer(mock.Anything, "192.168.1.1:6347", hash).Return(mismatchingData, nil)
+
+	// Mock failed peer tracking due to hash validation failure
+	setup.completionHandler.EXPECT().TrackFailedPeer(req, mock.Anything).Return(int32(1), true)
+	setup.completionHandler.EXPECT().CompleteWithErrorAndCancel(req, mock.Anything, mock.AnythingOfType("context.CancelFunc"), hash)
 
 	err := executor.ExecutePeerTasks(context.Background(), hash, contacts, hashBitmap, req, func() {})
+
+	require.NoError(t, err) // Should not return error, just handle the failure
+
+	// Wait for tasks to complete
+	err = executor.WaitForCompletion(2 * time.Second)
 	require.NoError(t, err)
 
-	// Wait for task to complete naturally first
-	err = executor.WaitForCompletion(100 * time.Millisecond)
-	require.NoError(t, err)
-
-	// Test WaitAllTasksComplete - should work fine even when no tasks are pending
-	err = executor.WaitAllTasksComplete()
-	assert.NoError(t, err)
-
-	// Verify executor is still functional after WaitAllTasksComplete
-	assert.False(t, executor.IsStopped())
+	// Verify task stats
+	assertTaskStats(t, executor, 1, 1, 0)
 }

--- a/client/stream_acquirer.go
+++ b/client/stream_acquirer.go
@@ -1324,6 +1324,7 @@ func (sa *DefaultStreamAcquirer) acquireBlobWithFallback(ctx context.Context, co
 							zap.Int("blobIndex", blobIndex),
 							zap.Error(err),
 						)
+						// Fall through to network acquisition since stored data is corrupted
 					} else {
 						sa.logger.Debug("Successfully retrieved content blob from storage",
 							zap.String("sdHash", sdHash),

--- a/client/stream_acquirer.go
+++ b/client/stream_acquirer.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"crypto/subtle"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -20,37 +19,6 @@ import (
 	"go.uber.org/zap"
 )
 
-// verifyBlobHash verifies that the blob data matches the expected hash
-func verifyBlobHash(data []byte, expectedHash string) error {
-	if len(data) == 0 {
-		return NewStreamError(OperationValidation, "", expectedHash, ErrBlobAcquisition, 1)
-	}
-
-	// Compute hash of the actual data
-	computedHash, err := blob.ComputeBlobHashBytes(data)
-	if err != nil {
-		return NewStreamError(OperationValidation, "", expectedHash, err, 1)
-	}
-
-	// Convert to hex string for error reporting
-	computedHashHex := hex.EncodeToString(computedHash)
-
-	// Decode expected hash for constant-time comparison
-	expectedHashBytes, err := hex.DecodeString(expectedHash)
-	if err != nil {
-		return NewStreamError(OperationValidation, "", expectedHash,
-			liblbryerrors.Err("invalid expected hash format: %w", err), 1)
-	}
-
-	// Compare computed hash with expected hash using constant-time comparison
-	if subtle.ConstantTimeCompare(computedHash, expectedHashBytes) != 1 {
-		return NewStreamError(OperationValidation, "", expectedHash,
-			liblbryerrors.Err("blob hash verification failed: expected %s, got %s", expectedHash, computedHashHex), 1)
-	}
-
-	return nil
-}
-
 // verifyAndValidateSDBlob verifies the blob hash (if enabled) and validates SD blob structure
 func verifyAndValidateSDBlob(data []byte, expectedHash string, verificationEnabled bool) error {
 	if len(data) == 0 {
@@ -59,7 +27,7 @@ func verifyAndValidateSDBlob(data []byte, expectedHash string, verificationEnabl
 
 	// Verify blob hash if verification is enabled
 	if verificationEnabled {
-		if err := verifyBlobHash(data, expectedHash); err != nil {
+		if err := blob.VerifyBlobHash(data, expectedHash); err != nil {
 			return fmt.Errorf("SD blob hash verification failed for %s: %w", expectedHash, err)
 		}
 	}
@@ -751,7 +719,7 @@ func (r *streamingReader) ensureCurrentBlob() error {
 
 			// Verify blob hash if verification is enabled
 			if r.config.VerificationEnabled {
-				if err := verifyBlobHash(data, blobHash); err != nil {
+				if err := blob.VerifyBlobHash(data, blobHash); err != nil {
 					return fmt.Errorf("stored blob hash verification failed for %s: %w", blobHash, err)
 				}
 			}
@@ -826,7 +794,7 @@ func (r *streamingReader) ensureCurrentBlob() error {
 
 	// Verify blob hash if verification is enabled
 	if r.config.VerificationEnabled {
-		if err := verifyBlobHash(data, blobHash); err != nil {
+		if err := blob.VerifyBlobHash(data, blobHash); err != nil {
 			return fmt.Errorf("blob hash verification failed for %s: %w", blobHash, err)
 		}
 	}
@@ -1006,7 +974,7 @@ func (r *streamingReader) startPrefetcher() {
 						if err == nil {
 							// Verify blob hash if verification is enabled
 							if r.config.VerificationEnabled {
-								if err := verifyBlobHash(data, blobHash); err != nil {
+								if err := blob.VerifyBlobHash(data, blobHash); err != nil {
 									r.logger.Debug("Prefetch: blob hash verification failed",
 										zap.String("sdHash", r.sdHash),
 										zap.String("blobHash", blobHash),
@@ -1078,7 +1046,7 @@ func (r *streamingReader) startPrefetcher() {
 
 				// Verify blob hash if verification is enabled
 				if r.config.VerificationEnabled {
-					if err := verifyBlobHash(data, blobHash); err != nil {
+					if err := blob.VerifyBlobHash(data, blobHash); err != nil {
 						r.logger.Debug("Prefetch: blob hash verification failed",
 							zap.String("sdHash", r.sdHash),
 							zap.String("blobHash", blobHash),
@@ -1349,7 +1317,7 @@ func (sa *DefaultStreamAcquirer) acquireBlobWithFallback(ctx context.Context, co
 			} else {
 				// Verify blob hash if verification is enabled
 				if config.VerificationEnabled {
-					if err := verifyBlobHash(blobData, blobHash); err != nil {
+					if err := blob.VerifyBlobHash(blobData, blobHash); err != nil {
 						sa.logger.Error("Stored blob hash verification failed",
 							zap.String("sdHash", sdHash),
 							zap.String("blobHash", blobHash),
@@ -1405,7 +1373,7 @@ func (sa *DefaultStreamAcquirer) acquireBlobWithFallback(ctx context.Context, co
 
 	// Verify blob hash if verification is enabled
 	if config.VerificationEnabled {
-		if err := verifyBlobHash(blobData, blobHash); err != nil {
+		if err := blob.VerifyBlobHash(blobData, blobHash); err != nil {
 			sa.logger.Error("Content blob hash verification failed",
 				zap.String("sdHash", sdHash),
 				zap.String("blobHash", blobHash),
@@ -1530,13 +1498,6 @@ func (sa *DefaultStreamAcquirer) GetStreamResult(ctx context.Context, sdHash str
 		zap.String("streamHash", hex.EncodeToString(sdBlob.StreamHash)),
 		zap.Int("blobCount", len(sdBlob.BlobInfos)),
 	)
-
-	// Verify SD blob hash if verification is enabled
-	if config.VerificationEnabled {
-		if err := verifyBlobHash(sdBlobData, sdHash); err != nil {
-			return nil, fmt.Errorf("SD blob hash verification failed for %s: %w", sdHash, err)
-		}
-	}
 
 	// Create the basic stream result
 	result := &stream.StreamResult{

--- a/client/stream_acquirer.go
+++ b/client/stream_acquirer.go
@@ -51,6 +51,27 @@ func verifyBlobHash(data []byte, expectedHash string) error {
 	return nil
 }
 
+// verifyAndValidateSDBlob verifies the blob hash (if enabled) and validates SD blob structure
+func verifyAndValidateSDBlob(data []byte, expectedHash string, verificationEnabled bool) error {
+	if len(data) == 0 {
+		return NewStreamError(OperationValidation, "", expectedHash, ErrBlobAcquisition, 1)
+	}
+
+	// Verify blob hash if verification is enabled
+	if verificationEnabled {
+		if err := verifyBlobHash(data, expectedHash); err != nil {
+			return fmt.Errorf("SD blob hash verification failed for %s: %w", expectedHash, err)
+		}
+	}
+
+	// Validate SD blob structure
+	if err := stream.ValidateSDBlob(data); err != nil {
+		return fmt.Errorf("invalid SD blob %s: %w", expectedHash, err)
+	}
+
+	return nil
+}
+
 // StreamReader provides reading and seeking capabilities for streams with on-demand blob acquisition
 type StreamReader interface {
 	io.Reader
@@ -1259,16 +1280,9 @@ func (sa *DefaultStreamAcquirer) GetStream(ctx context.Context, sdHash string, o
 		zap.Int("dataSize", len(sdBlobData)),
 	)
 
-	// Verify SD blob hash if verification is enabled (before parsing for fail-fast)
-	if config.VerificationEnabled {
-		if err := verifyBlobHash(sdBlobData, sdHash); err != nil {
-			return nil, fmt.Errorf("SD blob hash verification failed for %s: %w", sdHash, err)
-		}
-	}
-
-	// Validate SD blob data
-	if err := stream.ValidateSDBlob(sdBlobData); err != nil {
-		return nil, fmt.Errorf("invalid SD blob %s: %w", sdHash, err)
+	// Verify SD blob hash and validate structure
+	if err := verifyAndValidateSDBlob(sdBlobData, sdHash, config.VerificationEnabled); err != nil {
+		return nil, err
 	}
 
 	// Parse the SD blob
@@ -1489,8 +1503,8 @@ func (sa *DefaultStreamAcquirer) GetStreamResult(ctx context.Context, sdHash str
 	}
 
 	// Validate SD blob data
-	if err := stream.ValidateSDBlob(sdBlobData); err != nil {
-		return nil, fmt.Errorf("invalid SD blob %s: %w", sdHash, err)
+	if err := verifyAndValidateSDBlob(sdBlobData, sdHash, config.VerificationEnabled); err != nil {
+		return nil, err
 	}
 
 	// Parse the SD blob
@@ -1627,9 +1641,8 @@ func (sa *DefaultStreamAcquirer) GetSDBlob(ctx context.Context, sdHash string) (
 		return nil, nil, fmt.Errorf("failed to acquire SD blob %s: %w", sdHash, err)
 	}
 
-	// Validate SD blob data
-	if err := stream.ValidateSDBlob(sdBlobData); err != nil {
-		return nil, nil, fmt.Errorf("invalid SD blob %s: %w", sdHash, err)
+	if err := verifyAndValidateSDBlob(sdBlobData, sdHash, true); err != nil {
+		return nil, nil, err
 	}
 
 	// Parse the SD blob
@@ -1648,15 +1661,6 @@ func (sa *DefaultStreamAcquirer) GetSDBlob(ctx context.Context, sdHash string) (
 			zap.String("sdHash", sdHash),
 		)
 		return nil, nil, fmt.Errorf("invalid SD blob %s: no blob infos found", sdHash)
-	}
-
-	// Verify SD blob hash (always enabled for GetSDBlob for security)
-	if err := verifyBlobHash(sdBlobData, sdHash); err != nil {
-		sa.logger.Error("SD blob metadata hash verification failed",
-			zap.String("sdHash", sdHash),
-			zap.Error(err),
-		)
-		return nil, nil, fmt.Errorf("SD blob hash verification failed for %s: %w", sdHash, err)
 	}
 
 	sa.logger.Info("Successfully retrieved SD blob metadata",


### PR DESCRIPTION
- Introduces `verifyBlobHash` function to ensure downloaded blob data matches the expected hash, enhancing security against invalid/malicious data
- Updates `PeerTaskExecutor` interfaces and implementations to use `peerblob.BlobRequest` for consistent type handling
- Modifies peer task execution to verify blob hashes before accepting data from peers
- Adds comprehensive test coverage for hash validation failures
- Refactors `StreamAcquirer` to consolidate blob verification and validation logic into a unified `verifyAndValidateSDBlob` function
---
* Tests can be run with `go test  ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integrity verification for data retrieved from peers and a centralized validation path for stream metadata.

* **Bug Fixes**
  * Treats hash mismatches as peer failures to improve recovery and prevent corrupted downloads.
  * Consistent error handling and fallback behavior when validation fails.

* **Tests**
  * Expanded tests for hash verification, failure handling, and enforcing single-completion behavior in peer downloads.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->