### PR TITLE
refactor(client): improve SD blob validation and error messaging

### DIFF
--- a/client/errors.go
+++ b/client/errors.go
@@ -20,6 +20,7 @@ var (
 	ErrInvalidHash      = liblbryerrors.Err("invalid blob hash")
 	ErrDecryptionFailed = liblbryerrors.Err("blob decryption failed")
 	ErrContextCancelled = liblbryerrors.Err("operation cancelled by context")
+	ErrNotSDBlob        = liblbryerrors.Err("blob is not an SD blob (appears to be binary content data)")
 )
 
 // Stream operation types for error reporting

--- a/client/errors.go
+++ b/client/errors.go
@@ -67,6 +67,7 @@ func isRetryableError(err error) bool {
 
 	// Don't retry invalid data errors
 	if errors.Is(err, stream.ErrInvalidSDBlob) ||
+		errors.Is(err, ErrNotSDBlob) ||
 		errors.Is(err, ErrStreamCorrupted) ||
 		errors.Is(err, ErrInvalidHash) ||
 		errors.Is(err, ErrDecryptionFailed) ||

--- a/client/stream_acquirer.go
+++ b/client/stream_acquirer.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -32,8 +33,12 @@ func verifyAndValidateSDBlob(data []byte, expectedHash string, verificationEnabl
 		}
 	}
 
-	// Validate SD blob structure
+	// Validate SD blob structure - this includes json.Valid() check
 	if err := stream.ValidateSDBlob(data); err != nil {
+		// Check if the error is specifically due to invalid JSON (likely binary content)
+		if !json.Valid(data) {
+			return NewStreamError(OperationValidateSDBlob, expectedHash, "", ErrNotSDBlob, 1)
+		}
 		return fmt.Errorf("invalid SD blob %s: %w", expectedHash, err)
 	}
 
@@ -1250,6 +1255,15 @@ func (sa *DefaultStreamAcquirer) GetStream(ctx context.Context, sdHash string, o
 
 	// Verify SD blob hash and validate structure
 	if err := verifyAndValidateSDBlob(sdBlobData, sdHash, config.VerificationEnabled); err != nil {
+		// Provide enhanced error message for non-SD blob cases
+		if errors.Is(err, ErrNotSDBlob) {
+			sa.logger.Error("Requested hash appears to be content blob, not SD blob",
+				zap.String("sdHash", sdHash),
+				zap.Int("dataSize", len(sdBlobData)),
+				zap.Error(err),
+			)
+			return nil, fmt.Errorf("hash %s appears to be content blob data, not an SD blob manifest. SD blobs should be JSON manifests, but this data appears to be binary content", sdHash)
+		}
 		return nil, err
 	}
 
@@ -1604,6 +1618,15 @@ func (sa *DefaultStreamAcquirer) GetSDBlob(ctx context.Context, sdHash string) (
 	}
 
 	if err := verifyAndValidateSDBlob(sdBlobData, sdHash, true); err != nil {
+		// Provide enhanced error message for non-SD blob cases
+		if errors.Is(err, ErrNotSDBlob) {
+			sa.logger.Error("Requested hash appears to be content blob, not SD blob",
+				zap.String("sdHash", sdHash),
+				zap.Int("dataSize", len(sdBlobData)),
+				zap.Error(err),
+			)
+			return nil, nil, fmt.Errorf("hash %s appears to be content blob data, not an SD blob manifest. SD blobs should be JSON manifests, but this data appears to be binary content", sdHash)
+		}
 		return nil, nil, err
 	}
 

--- a/client/stream_acquirer.go
+++ b/client/stream_acquirer.go
@@ -33,12 +33,13 @@ func verifyAndValidateSDBlob(data []byte, expectedHash string, verificationEnabl
 		}
 	}
 
+	// Check if data is valid JSON - if not, it's likely binary content
+	if !json.Valid(data) {
+		return NewStreamError(OperationValidateSDBlob, expectedHash, "", ErrNotSDBlob, 1)
+	}
+
 	// Validate SD blob structure - this includes json.Valid() check
 	if err := stream.ValidateSDBlob(data); err != nil {
-		// Check if the error is specifically due to invalid JSON (likely binary content)
-		if !json.Valid(data) {
-			return NewStreamError(OperationValidateSDBlob, expectedHash, "", ErrNotSDBlob, 1)
-		}
 		return fmt.Errorf("invalid SD blob %s: %w", expectedHash, err)
 	}
 

--- a/client/stream_acquirer_test.go
+++ b/client/stream_acquirer_test.go
@@ -1098,7 +1098,7 @@ func TestStreamAcquirer_WithRetryNonRetryableError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, streamReader)
-	assert.Contains(t, err.Error(), "invalid SD blob")
+	assert.Contains(t, err.Error(), "appears to be content blob data, not an SD blob manifest")
 }
 
 func TestStreamAcquirer_WithRetryMaxAttemptsExhausted(t *testing.T) {
@@ -1235,16 +1235,16 @@ func TestStreamReader_WithRetryOnStorageFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	// Mock SD blob storage - always succeed
-	mockStore.On("Has", sdHash).Return(true, nil)
-	mockStore.On("Get", sdHash).Return(sdBlobData, nil)
+	mockStore.On("Has", mock.Anything, sdHash).Return(true, nil)
+	mockStore.On("Get", mock.Anything, sdHash).Return(sdBlobData, nil)
 
 	// Mock blob storage Has check to fail initially, then succeed
 	// First call fails with temporary error
-	mockStore.On("Has", blobHashHex).Return(false, errors.New("storage temporarily unavailable")).Once()
+	mockStore.On("Has", mock.Anything, blobHashHex).Return(false, errors.New("storage temporarily unavailable")).Once()
 	// Subsequent calls succeed (use Maybe() to handle multiple retry attempts)
-	mockStore.On("Has", blobHashHex).Return(true, nil).Maybe()
+	mockStore.On("Has", mock.Anything, blobHashHex).Return(true, nil).Maybe()
 	// Get call succeeds when Has returns true
-	mockStore.On("Get", blobHashHex).Return(encryptedBlobData, nil).Maybe()
+	mockStore.On("Get", mock.Anything, blobHashHex).Return(encryptedBlobData, nil).Maybe()
 
 	// Create mock transfer for blob acquisition as fallback (may not be called if storage succeeds)
 	mockTransfer := transferMocks.NewMockTransfer(t)

--- a/stream/sdblob.go
+++ b/stream/sdblob.go
@@ -295,23 +295,28 @@ func ValidateSDBlob(sdBlobData []byte) error {
 		return ErrInvalidSDBlob
 	}
 
+	if !json.Valid(sdBlobData) {
+		return ErrInvalidSDBlob
+	}
+
 	// Parse JSON to validate structure
-	var jsonSDBlob JSONSDBlob
-	if err := json.Unmarshal(sdBlobData, &jsonSDBlob); err != nil {
+	var sdBlob SDBlob
+
+	if err := sdBlob.FromBlob(sdBlobData); err != nil {
 		return fmt.Errorf("%w: %v", ErrInvalidSDBlob, err)
 	}
 
 	// Validate required fields
-	if jsonSDBlob.StreamType == "" {
+	if sdBlob.StreamType == "" {
 		return fmt.Errorf("%w: missing stream_type", ErrInvalidSDBlob)
 	}
 
-	if len(jsonSDBlob.Blobs) == 0 {
+	if len(sdBlob.BlobInfos) == 0 {
 		return fmt.Errorf("%w: no blobs found", ErrInvalidSDBlob)
 	}
 
 	// Validate each blob info
-	for i, blobInfo := range jsonSDBlob.Blobs {
+	for i, blobInfo := range sdBlob.BlobInfos {
 		// Zero-length blobs (terminating blobs) are allowed to have missing hashes
 		if blobInfo.Length > 0 {
 			if len(blobInfo.BlobHash) == 0 {


### PR DESCRIPTION
- Added `ErrNotSDBlob` error for better distinction between SD blobs and content blobs
- Enhanced `verifyAndValidateSDBlob` to detect and handle non-JSON data as binary content
- Improved error messages for invalid SD blob cases to indicate when a hash refers to content data rather than an SD blob manifest
- Updated `ValidateSDBlob` to use `json.Valid()` check before unmarshaling
- Modified test assertions to reflect new error message content
---
* Tests can be run with `go test  ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and messaging when binary/content blobs are provided instead of SD blob manifests.
  * Added non-retryable handling for detected non-SD-blob cases to avoid unnecessary retries.
  * Strengthened SD blob validation with a JSON validity check and more robust blob integrity verification.

* **Tests**
  * Updated tests to reflect new error messages and adjusted mock expectations for context-aware calls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->