### PR TITLE
fix(client): handle EOF gracefully in stream reader

### DIFF
--- a/client/stream_acquirer.go
+++ b/client/stream_acquirer.go
@@ -375,11 +375,19 @@ func (r *streamingReader) Read(p []byte) (int, error) {
 
 	// Ensure we have current blob data
 	if err := r.ensureCurrentBlob(); err != nil {
-		r.logger.Error("Failed to ensure current blob data",
-			zap.String("sdHash", r.sdHash),
-			zap.Int("currentBlob", r.currentBlob),
-			zap.Error(err),
-		)
+		// EOF is expected when reaching the end of stream - don't log as error
+		if errors.Is(err, io.EOF) {
+			r.logger.Debug("Reached end of stream",
+				zap.String("sdHash", r.sdHash),
+				zap.Int("currentBlob", r.currentBlob),
+			)
+		} else {
+			r.logger.Error("Failed to ensure current blob data",
+				zap.String("sdHash", r.sdHash),
+				zap.Int("currentBlob", r.currentBlob),
+				zap.Error(err),
+			)
+		}
 		return 0, err
 	}
 


### PR DESCRIPTION
- Updated `streamingReader.Read` to distinguish between expected EOF and actual errors
- EOF is now logged at DEBUG level instead of ERROR level
- Preserved existing error logging behavior for non-EOF errors

---
* Tests can be run with `go test  ./...`
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for stream operations by properly distinguishing between normal stream completion and actual errors. End-of-stream conditions are now logged as debug information rather than errors, reducing false error signals.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->