### PR TITLE
fix(stream): validate terminating blob uniqueness and end position

### DIFF
--- a/stream/sdblob.go
+++ b/stream/sdblob.go
@@ -316,6 +316,9 @@ func ValidateSDBlob(sdBlobData []byte) error {
 	}
 
 	// Validate each blob info
+	terminatingBlobFound := false
+	terminatingBlobIndex := -1
+	totalBlobs := len(sdBlob.BlobInfos)
 	for i, blobInfo := range sdBlob.BlobInfos {
 		// Zero-length blobs (terminating blobs) are allowed to have missing hashes
 		if blobInfo.Length > 0 {
@@ -329,6 +332,20 @@ func ValidateSDBlob(sdBlobData []byte) error {
 		if blobInfo.Length < 0 {
 			return fmt.Errorf("%w: blob %d has invalid length", ErrInvalidSDBlob, i)
 		}
+
+		// Track terminating blobs (zero-length blobs)
+		if blobInfo.Length == 0 {
+			if terminatingBlobFound {
+				return fmt.Errorf("%w: terminating blob can only appear once", ErrInvalidSDBlob)
+			}
+			terminatingBlobFound = true
+			terminatingBlobIndex = i
+		}
+	}
+
+	// After validating all blobs, check if terminating blob is at the end (if present)
+	if terminatingBlobFound && terminatingBlobIndex != totalBlobs-1 {
+		return fmt.Errorf("%w: terminating blob must be at the end", ErrInvalidSDBlob)
 	}
 
 	return nil

--- a/stream/sdblob_test.go
+++ b/stream/sdblob_test.go
@@ -523,6 +523,46 @@ func TestValidateSDBlob_TerminatingBlobScenarios(t *testing.T) {
 			expectError: true,
 			errorMsg:    "invalid length",
 		},
+		{
+			name: "invalid terminating blob appears twice",
+			blobInfos: []BlobInfo{
+				createTestBlobInfo(t, 2097152, 0, lbryTesting.LBRYHashKey1, "30303030303030303030303030303031"),
+				createTestBlobInfo(t, 0, 1, "", "30303030303030303030303030303032"), // First terminating blob
+				createTestBlobInfo(t, 0, 2, "", "30303030303030303030303030303033"), // Second terminating blob - invalid
+			},
+			expectError: true,
+			errorMsg:    "terminating blob can only appear once",
+		},
+		{
+			name: "invalid terminating blob not at end",
+			blobInfos: []BlobInfo{
+				createTestBlobInfo(t, 2097152, 0, lbryTesting.LBRYHashKey1, "30303030303030303030303030303031"),
+				createTestBlobInfo(t, 0, 1, "", "30303030303030303030303030303032"),                             // Terminating blob in middle - invalid
+				createTestBlobInfo(t, 2097152, 2, lbryTesting.LBRYHashKey2, "30303030303030303030303030303033"), // Regular blob after terminating
+			},
+			expectError: true,
+			errorMsg:    "terminating blob must be at the end",
+		},
+		{
+			name: "invalid multiple terminating blobs",
+			blobInfos: []BlobInfo{
+				createTestBlobInfo(t, 0, 0, "", "30303030303030303030303030303031"), // First terminating blob - invalid
+				createTestBlobInfo(t, 2097152, 1, lbryTesting.LBRYHashKey1, "30303030303030303030303030303032"),
+				createTestBlobInfo(t, 0, 2, "", "30303030303030303030303030303033"), // Second terminating blob
+			},
+			expectError: true,
+			errorMsg:    "terminating blob can only appear once",
+		},
+		{
+			name: "valid terminating blob at end with multiple regular blobs",
+			blobInfos: []BlobInfo{
+				createTestBlobInfo(t, 2097152, 0, lbryTesting.LBRYHashKey1, "30303030303030303030303030303031"),
+				createTestBlobInfo(t, 2097152, 1, lbryTesting.LBRYHashKey2, "30303030303030303030303030303032"),
+				createTestBlobInfo(t, 2097152, 2, lbryTesting.LBRYHashKey1, "30303030303030303030303030303033"),
+				createTestBlobInfo(t, 0, 3, "", "30303030303030303030303030303034"), // Terminating blob at end - valid
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
- Ensure terminating blob (zero-length blob) can only appear once
- Ensure terminating blob must be at the end of blob infos
- Add test cases for invalid terminating blob scenarios


---

<!-- kody-pr-summary:start -->
This pull request implements validation for terminating blobs (zero-length blobs) in Stream Descriptor (SD) blobs to ensure stream integrity.

**Changes Summary:**

1. **Terminating Blob Uniqueness Validation**: Added logic to ensure that a terminating blob can only appear once in a stream. If multiple terminating blobs are detected, the validation now returns an error.

2. **Terminating Blob Position Validation**: Added validation to ensure that if a terminating blob is present, it must be located at the end of the stream (last position). Any terminating blob found before the final position will result in a validation error.

3. **Test Coverage**: Added comprehensive test cases covering:
   - Invalid scenarios with multiple terminating blobs
   - Invalid scenarios where the terminating blob appears in the middle of the stream
   - Valid scenarios with a terminating blob correctly positioned at the end

**Functional Impact:**
These changes prevent malformed stream descriptors from being accepted by enforcing strict rules on terminating blob placement and uniqueness. Streams that previously might have been accepted with invalid terminating blob configurations will now be properly rejected with descriptive error messages.
<!-- kody-pr-summary:end -->
---
* Testing `go test ./stream/...`