### PR TITLE
refactor(stream): simplify stream metadata handling and fix existing SD blob processing

### DIFF
--- a/stream/config.go
+++ b/stream/config.go
@@ -2,12 +2,14 @@ package stream
 
 // StreamConfig holds configuration for stream creation
 type StreamConfig struct {
-	ChunkHandler   func(Chunk) error
-	ChunkSize      int
-	ExistingSDBlob []byte
-	SDHandler      func(*SDBlob, []byte) error
-	Concurrency    int
-	Progress       func(float64)
+	ChunkHandler      func(Chunk) error
+	ChunkSize         int
+	ExistingSDBlob    []byte
+	SDHandler         func(*SDBlob, []byte) error
+	Concurrency       int
+	Progress          func(float64)
+	StreamName        string
+	SuggestedFileName string
 }
 
 // StreamOption is a functional option for stream creation
@@ -52,5 +54,19 @@ func WithConcurrency(workers int) StreamOption {
 func WithProgress(callback func(float64)) StreamOption {
 	return func(config *StreamConfig) {
 		config.Progress = callback
+	}
+}
+
+// WithStreamName sets the stream name
+func WithStreamName(name string) StreamOption {
+	return func(config *StreamConfig) {
+		config.StreamName = name
+	}
+}
+
+// WithSuggestedFileName sets the suggested file name
+func WithSuggestedFileName(name string) StreamOption {
+	return func(config *StreamConfig) {
+		config.SuggestedFileName = name
 	}
 }

--- a/stream/creator.go
+++ b/stream/creator.go
@@ -154,47 +154,11 @@ func (sc *DefaultStreamCreator) CreateStreamFromPath(path string, opts ...Stream
 
 // createStreamWithMetadata is a helper that creates a stream with file metadata
 func (sc *DefaultStreamCreator) createStreamWithMetadata(source io.Reader, size int64, filename string, opts ...StreamOption) (*StreamResult, error) {
-	// Apply options to config
-	config := &StreamConfig{}
-	applyOpts(config, opts)
+	// Add stream name and suggested file name to options
+	newOpts := appendOption(opts, WithStreamName(filename))
+	newOpts = appendOption(newOpts, WithSuggestedFileName(filename))
 
-	// If no existing SD blob is provided, create a manifest-based one
-	if len(config.ExistingSDBlob) == 0 {
-		// Create manifest from source
-		sdBlob, sdBlobData, err := sc.manifestCreator.CreateManifest(source, size)
-		if err != nil {
-			return nil, liblbryerrors.Err("failed to create manifest: %w", err)
-		}
-
-		// Set stream name and suggested file name
-		sdBlob.StreamName = filename
-		sdBlob.SuggestedFileName = filename
-
-		// Convert to blob data
-		sdBlobData, err = sdBlob.ToBlob()
-		if err != nil {
-			return nil, liblbryerrors.Err("failed to convert SD blob to data: %w", err)
-		}
-
-		config.ExistingSDBlob = sdBlobData
-
-		// Reset source since we consumed it for manifest creation
-		if resetter, ok := source.(io.Seeker); ok {
-			_, err = resetter.Seek(0, io.SeekStart)
-			if err != nil {
-				return nil, liblbryerrors.Err("failed to reset source reader: %w", err)
-			}
-		} else {
-			return nil, liblbryerrors.Err("source reader does not support seeking")
-		}
-	}
-
-	// Create stream with existing SD blob
-	// We need to propagate the SD blob through options since CreateStream doesn't have direct access to the config
-	newOpts := appendOption(opts, func(c *StreamConfig) {
-		c.ExistingSDBlob = config.ExistingSDBlob
-	})
-
+	// Create stream directly with metadata
 	return sc.CreateStream(source, size, newOpts...)
 }
 
@@ -215,12 +179,12 @@ func appendOption(opts []StreamOption, opt StreamOption) []StreamOption {
 
 // generateStreamID generates a unique identifier for a stream
 func (sc *DefaultStreamCreator) generateStreamID() (string, error) {
-	bytes := make([]byte, 16)
-	_, err := rand.Read(bytes)
+	_bytes := make([]byte, 16)
+	_, err := rand.Read(_bytes)
 	if err != nil {
 		return "", err
 	}
-	return hex.EncodeToString(bytes), nil
+	return hex.EncodeToString(_bytes), nil
 }
 
 // progressTrackingReader wraps an io.Reader to track read progress

--- a/stream/creator_test.go
+++ b/stream/creator_test.go
@@ -182,6 +182,7 @@ func TestDefaultStreamCreator_WithExistingSDBlob(t *testing.T) {
 	streamCreator := NewStreamCreator(manifestCreator)
 
 	// Create stream with existing SD blob
+	// Since the SD blob has blob infos, stream processing should be skipped
 	result, err := streamCreator.CreateStream(reader, int64(len(testData)), WithExistingSDBlob(sdBlobData))
 	require.NoError(t, err)
 	assert.NotNil(t, result)
@@ -189,7 +190,10 @@ func TestDefaultStreamCreator_WithExistingSDBlob(t *testing.T) {
 	assert.NotNil(t, result.SDBlobData)
 	assert.NotEmpty(t, result.SDBlobHash)
 	assert.NotEmpty(t, result.StreamHash)
-	assert.Equal(t, int64(len(testData)), result.SourceSize)
+	// SourceSize should be 0 because stream processing is skipped when using existing SD blob with blob infos
+	assert.Equal(t, int64(0), result.SourceSize)
+	// TotalChunks should match the number of blobs in the SD blob (excluding terminating blob)
+	assert.Equal(t, len(sdBlob.BlobInfos)-1, result.TotalChunks)
 }
 
 func TestDefaultStreamCreator_EmptyData(t *testing.T) {

--- a/stream/encoder.go
+++ b/stream/encoder.go
@@ -246,11 +246,17 @@ func (e *Encoder) Encode(config *StreamConfig) (*StreamResult, error) {
 	}
 
 	// If using existing SD blob, parse it and use its data
+	existingSDBlobHasBlobInfos := false
 	if len(config.ExistingSDBlob) > 0 {
 		sdBlob := &SDBlob{}
 		err := sdBlob.FromBlob(config.ExistingSDBlob)
 		if err != nil {
 			return nil, liblbryerrors.Err("failed to parse existing SD blob: %w", err)
+		}
+
+		// Check if existing SD blob has blob infos - if so, skip stream processing
+		if len(sdBlob.BlobInfos) > 0 {
+			existingSDBlobHasBlobInfos = true
 		}
 
 		// Generate a new key if the existing SD blob has an empty key
@@ -288,8 +294,21 @@ func (e *Encoder) Encode(config *StreamConfig) (*StreamResult, error) {
 	var contentBlobs [][]byte
 	var contentHashes []string
 
-	// If using chunk handler, process chunks individually
-	if config.ChunkHandler != nil {
+	// If existing SD blob has blob infos, skip stream processing and use existing data
+	if existingSDBlobHasBlobInfos {
+		// Extract chunk sizes and hashes from existing blob infos
+		for _, blobInfo := range e.sd.BlobInfos {
+			// Skip terminating blob (zero-length blob at the end)
+			if blobInfo.Length == 0 {
+				continue
+			}
+			chunkSizes = append(chunkSizes, blobInfo.Length)
+			if len(blobInfo.BlobHash) > 0 {
+				contentHashes = append(contentHashes, hex.EncodeToString(blobInfo.BlobHash))
+			}
+		}
+	} else {
+		// Process stream chunks
 		chunkNumber := 0
 		for {
 			b, err := e.Next()
@@ -300,43 +319,41 @@ func (e *Encoder) Encode(config *StreamConfig) (*StreamResult, error) {
 				return nil, err
 			}
 
-			chunk := Chunk{
-				Number: chunkNumber,
-				Hash:   b.HashHex(),
-				Data:   []byte(b),
-				Size:   len(b),
-			}
-
-			// Call chunk handler
-			err = config.ChunkHandler(chunk)
-			if err != nil {
-				if err == io.ErrUnexpectedEOF {
-					return nil, err
-				}
-				return nil, liblbryerrors.Err("chunk handler failed for chunk %d: %w", chunkNumber, err)
-			}
-
 			// Store chunk info for result
-			chunkSizes = append(chunkSizes, chunk.Size)
-			contentHashes = append(contentHashes, chunk.Hash)
+			chunkSizes = append(chunkSizes, len(b))
+			contentHashes = append(contentHashes, b.HashHex())
+
+			// Call chunk handler if provided
+			if config.ChunkHandler != nil {
+				chunk := Chunk{
+					Number: chunkNumber,
+					Hash:   b.HashHex(),
+					Data:   []byte(b),
+					Size:   len(b),
+				}
+
+				err = config.ChunkHandler(chunk)
+				if err != nil {
+					if err == io.ErrUnexpectedEOF {
+						return nil, err
+					}
+					return nil, liblbryerrors.Err("chunk handler failed for chunk %d: %w", chunkNumber, err)
+				}
+			} else {
+				// Store content blobs only if not using chunk handler
+				contentBlobs = append(contentBlobs, b)
+			}
 
 			chunkNumber++
 		}
-	} else {
-		// Process all chunks in memory
-		for {
-			b, err := e.Next()
-			if err != nil {
-				if liblbryerrors.Is(err, io.EOF) {
-					break
-				}
-				return nil, err
-			}
+	}
 
-			contentBlobs = append(contentBlobs, b)
-			contentHashes = append(contentHashes, b.HashHex())
-			chunkSizes = append(chunkSizes, len(b))
-		}
+	// Set stream metadata from config if provided
+	if config.StreamName != "" {
+		e.sd.StreamName = config.StreamName
+	}
+	if config.SuggestedFileName != "" {
+		e.sd.SuggestedFileName = config.SuggestedFileName
 	}
 
 	// Generate final SD blob data

--- a/stream/encoder_test.go
+++ b/stream/encoder_test.go
@@ -391,3 +391,140 @@ func TestEncoderChunkHandler_DifferentDataSizes(t *testing.T) {
 		})
 	}
 }
+
+func TestEncoderEncode_WithExistingSDBlobWithBlobInfos(t *testing.T) {
+	// First, create a stream and get its SD blob
+	testData := make([]byte, maxBlobDataSize*2+5000)
+	_, err := rand.Read(testData)
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(testData)
+	enc := NewEncoder(buf)
+	result, err := enc.Encode(nil)
+	require.NoError(t, err)
+
+	// Now encode again using the existing SD blob
+	// This should skip stream processing since the SD blob has blob infos
+	buf2 := bytes.NewBuffer(testData)
+	enc2 := NewEncoder(buf2)
+	config := &StreamConfig{
+		ExistingSDBlob: result.SDBlobData,
+	}
+
+	result2, err := enc2.Encode(config)
+	require.NoError(t, err)
+
+	// Verify the SD blob is reused
+	require.Equal(t, result.SDBlobHash, result2.SDBlobHash)
+	require.Equal(t, result.StreamHash, result2.StreamHash)
+	require.Equal(t, len(result.SDBlob.BlobInfos), len(result2.SDBlob.BlobInfos))
+
+	// Verify chunk sizes match
+	require.Equal(t, result.ChunkSizes, result2.ChunkSizes)
+	require.Equal(t, result.ContentHashes, result2.ContentHashes)
+	require.Equal(t, result.TotalChunks, result2.TotalChunks)
+
+	// Verify that the source reader was NOT processed (source length should be 0)
+	require.Equal(t, 0, enc2.SourceLen())
+}
+
+func TestEncoderEncode_WithExistingSDBlobWithoutBlobInfos(t *testing.T) {
+	// Create an SD blob with no blob infos (empty stream)
+	sdBlob := &SDBlob{
+		StreamType:        StreamTypeLBRYFile,
+		StreamName:        "test",
+		SuggestedFileName: "test.txt",
+	}
+	sdBlobData, err := sdBlob.ToBlob()
+	require.NoError(t, err)
+
+	// Encode with existing SD blob that has no blob infos
+	testData := make([]byte, 1000)
+	_, err = rand.Read(testData)
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(testData)
+	enc := NewEncoder(buf)
+	config := &StreamConfig{
+		ExistingSDBlob: sdBlobData,
+	}
+
+	result, err := enc.Encode(config)
+	require.NoError(t, err)
+
+	// Verify that stream was processed (source length should be > 0)
+	require.Equal(t, 1000, enc.SourceLen())
+
+	// Verify result is valid
+	require.NotNil(t, result.SDBlob)
+	require.Equal(t, 1, result.TotalChunks) // One chunk for 1000 bytes + terminating blob
+}
+
+func TestEncoderEncode_WithExistingSDBlobAndChunkHandler(t *testing.T) {
+	// First, create a stream and get its SD blob
+	testData := make([]byte, maxBlobDataSize*2+5000)
+	_, err := rand.Read(testData)
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(testData)
+	enc := NewEncoder(buf)
+	result, err := enc.Encode(nil)
+	require.NoError(t, err)
+
+	// Now encode again using the existing SD blob with a chunk handler
+	// The chunk handler should not be called since we skip processing
+	buf2 := bytes.NewBuffer(testData)
+	enc2 := NewEncoder(buf2)
+
+	chunkHandlerCalled := false
+	config := &StreamConfig{
+		ExistingSDBlob: result.SDBlobData,
+		ChunkHandler: func(chunk Chunk) error {
+			chunkHandlerCalled = true
+			return nil
+		},
+	}
+
+	result2, err := enc2.Encode(config)
+	require.NoError(t, err)
+
+	// Verify chunk handler was NOT called
+	require.False(t, chunkHandlerCalled, "chunk handler should not be called when using existing SD blob with blob infos")
+
+	// Verify the SD blob is reused
+	require.Equal(t, result.SDBlobHash, result2.SDBlobHash)
+	require.Equal(t, result.TotalChunks, result2.TotalChunks)
+}
+
+func TestEncoderEncode_ExistingSDBlobExtractsCorrectInfo(t *testing.T) {
+	// Create a stream with a specific number of chunks
+	testData := make([]byte, maxBlobDataSize*3+1000)
+	_, err := rand.Read(testData)
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(testData)
+	enc := NewEncoder(buf)
+	result, err := enc.Encode(nil)
+	require.NoError(t, err)
+
+	// Re-encode using existing SD blob
+	buf2 := bytes.NewBuffer(testData)
+	enc2 := NewEncoder(buf2)
+	config := &StreamConfig{
+		ExistingSDBlob: result.SDBlobData,
+	}
+
+	result2, err := enc2.Encode(config)
+	require.NoError(t, err)
+
+	// Verify that chunk sizes and hashes were extracted correctly
+	require.Equal(t, len(result.ChunkSizes), len(result2.ChunkSizes))
+	for i := 0; i < len(result.ChunkSizes); i++ {
+		require.Equal(t, result.ChunkSizes[i], result2.ChunkSizes[i], "chunk size mismatch at index %d", i)
+		require.Equal(t, result.ContentHashes[i], result2.ContentHashes[i], "content hash mismatch at index %d", i)
+	}
+
+	// Verify terminating blob is excluded from count
+	expectedChunks := len(result.SDBlob.BlobInfos) - 1 // Exclude terminating blob
+	require.Equal(t, expectedChunks, result2.TotalChunks)
+}


### PR DESCRIPTION
- Add StreamName and SuggestedFileName fields to StreamConfig
- Add WithStreamName() and WithSuggestedFileName() functional options
- Skip stream processing and extract chunk data from existing blob infos
- Simplify createStreamWithMetadata by removing duplicate manifest creation
- Add comprehensive tests for existing SD blob scenarios


---

<!-- kody-pr-summary:start -->
This pull request simplifies stream metadata handling and fixes the processing of existing SD blobs. The changes include:

**Stream Metadata Handling:**
- Added `StreamName` and `SuggestedFileName` fields to `StreamConfig` with corresponding functional options (`WithStreamName`, `WithSuggestedFileName`)
- Simplified `createStreamWithMetadata` by removing complex manifest creation logic; now passes metadata directly through configuration options instead of manipulating the SD blob internally

**Existing SD Blob Processing:**
- Fixed the encoder to skip stream processing when an existing SD blob already contains blob information
- When using an existing SD blob with blob infos, the encoder now extracts chunk sizes and hashes directly from the blob infos rather than re-processing the source stream
- The chunk handler is no longer called when reusing an existing SD blob with blob infos, as the stream data has already been processed

**Test Updates:**
- Updated test expectations to reflect that `SourceSize` is 0 when stream processing is skipped with existing SD blobs
- Added comprehensive tests covering scenarios with existing SD blobs both with and without blob infos, verifying that chunk handlers are not called unnecessarily and that metadata is correctly extracted

These changes improve efficiency by avoiding redundant stream processing when reusing existing SD blobs and provide a cleaner API for setting stream metadata.
<!-- kody-pr-summary:end -->

---
* Testing `go test ./stream/...`