### PR TITLE
feat(stream): add multi-profile JSON serialization support for SD blobs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,9 +22,11 @@ require (
 
 require (
 	github.com/avast/retry-go/v4 v4.7.0 // indirect
+	github.com/aybabtme/flatjson v0.1.3-0.20230505062430-1fbd38670561 // indirect
 	github.com/btcsuite/btcutil v1.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gammazero/deque v0.2.0 // indirect
+	github.com/glopal/orderedjson v0.0.0-20240326211827-f9de45c5f0bb // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
 	github.com/gorilla/rpc v1.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBA
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/avast/retry-go/v4 v4.7.0 h1:yjDs35SlGvKwRNSykujfjdMxMhMQQM0TnIjJaHB+Zio=
 github.com/avast/retry-go/v4 v4.7.0/go.mod h1:ZMPDa3sY2bKgpLtap9JRUgk2yTAba7cgiFhqxY2Sg6Q=
+github.com/aybabtme/flatjson v0.1.3-0.20230505062430-1fbd38670561 h1:OJSSCO2uWlTmbBLz80UAPhYO2Y9YwkUgcIU22kM65d4=
+github.com/aybabtme/flatjson v0.1.3-0.20230505062430-1fbd38670561/go.mod h1:K/m47J+fcCStsYr0JSKS+SOOrJnf3cXM+H9WUn1V+/0=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.20.1-beta/go.mod h1:wVuoA8VJLEcwgqHBwHmzLRazpKxTv13Px/pDuV7OomQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
@@ -29,6 +31,8 @@ github.com/gammazero/deque v0.2.0 h1:SkieyNB4bg2/uZZLxvya0Pq6diUlwx7m2TeT7GAIWaA
 github.com/gammazero/deque v0.2.0/go.mod h1:LFroj8x4cMYCukHJDbxFCkT+r9AndaJnFMuZDV34tuU=
 github.com/gammazero/workerpool v1.1.3 h1:WixN4xzukFoN0XSeXF6puqEqFTl2mECI9S6W44HWy9Q=
 github.com/gammazero/workerpool v1.1.3/go.mod h1:wPjyBLDbyKnUn2XwwyD3EEwo9dHutia9/fwNmSHWACc=
+github.com/glopal/orderedjson v0.0.0-20240326211827-f9de45c5f0bb h1:iHLpzusx3vzogrXphsVvFfNCnKL8FJJ+cYVTXlB5RsE=
+github.com/glopal/orderedjson v0.0.0-20240326211827-f9de45c5f0bb/go.mod h1:9gqTk6HCRtqSoPve+lzOKk4+6vpgT2YjahBJ6h1e/Z4=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8bk=
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=

--- a/stream/encoder.go
+++ b/stream/encoder.go
@@ -99,8 +99,6 @@ type Encoder struct {
 	// an optionals hint about the total size of the source data
 	// encoder will use this to preallocate space for blobs
 	srcSizeHint int
-	// serialization profile for JSON field ordering
-	serializationProfile serializationProfile
 
 	// buffer for reading bytes from reader
 	buf []byte
@@ -160,7 +158,7 @@ func NewEncoderFromSD(src io.Reader, sdBlob *SDBlob) *Encoder {
 	e := NewEncoderWithIVs(src, sdBlob.Key, ivs)
 	e.sd.StreamName = sdBlob.StreamName
 	e.sd.SuggestedFileName = sdBlob.SuggestedFileName
-	e.serializationProfile = sdBlob.profile
+	e.sd.SetProfile(sdBlob.GetProfile())
 	return e
 }
 
@@ -400,7 +398,6 @@ func (e *Encoder) Encode(config *StreamConfig) (*StreamResult, error) {
 // SDBlob returns the sd blob so far
 func (e *Encoder) SDBlob() *SDBlob {
 	e.sd.UpdateStreamHash()
-	e.sd.SetProfile(e.serializationProfile)
 	return e.sd
 }
 
@@ -419,12 +416,6 @@ func (e *Encoder) SourceHash() []byte {
 // If the hint is wrong, it still works fine but there will be a small performance penalty.
 func (e *Encoder) SourceSizeHint(size int) *Encoder {
 	e.srcSizeHint = size
-	return e
-}
-
-// SetSerializationProfile sets the JSON serialization profile for the encoder
-func (e *Encoder) SetSerializationProfile(profile serializationProfile) *Encoder {
-	e.serializationProfile = profile
 	return e
 }
 

--- a/stream/encoder.go
+++ b/stream/encoder.go
@@ -99,6 +99,8 @@ type Encoder struct {
 	// an optionals hint about the total size of the source data
 	// encoder will use this to preallocate space for blobs
 	srcSizeHint int
+	// serialization profile for JSON field ordering
+	serializationProfile serializationProfile
 
 	// buffer for reading bytes from reader
 	buf []byte
@@ -158,6 +160,7 @@ func NewEncoderFromSD(src io.Reader, sdBlob *SDBlob) *Encoder {
 	e := NewEncoderWithIVs(src, sdBlob.Key, ivs)
 	e.sd.StreamName = sdBlob.StreamName
 	e.sd.SuggestedFileName = sdBlob.SuggestedFileName
+	e.serializationProfile = sdBlob.profile
 	return e
 }
 
@@ -397,6 +400,7 @@ func (e *Encoder) Encode(config *StreamConfig) (*StreamResult, error) {
 // SDBlob returns the sd blob so far
 func (e *Encoder) SDBlob() *SDBlob {
 	e.sd.UpdateStreamHash()
+	e.sd.SetProfile(e.serializationProfile)
 	return e.sd
 }
 
@@ -415,6 +419,12 @@ func (e *Encoder) SourceHash() []byte {
 // If the hint is wrong, it still works fine but there will be a small performance penalty.
 func (e *Encoder) SourceSizeHint(size int) *Encoder {
 	e.srcSizeHint = size
+	return e
+}
+
+// SetSerializationProfile sets the JSON serialization profile for the encoder
+func (e *Encoder) SetSerializationProfile(profile serializationProfile) *Encoder {
+	e.serializationProfile = profile
 	return e
 }
 

--- a/stream/manifest.go
+++ b/stream/manifest.go
@@ -94,6 +94,14 @@ func WithEncoderChunkSize(size int) EncoderOption {
 	}
 }
 
+// WithSerializationProfile sets the JSON serialization profile for the encoder
+// Use profileOldSort for compatibility with legacy Python SDK SD blobs
+func WithSerializationProfile(profile serializationProfile) EncoderOption {
+	return func(e *Encoder) {
+		e.serializationProfile = profile
+	}
+}
+
 // CreateManifestFromSource creates a manifest from a source reader using the encoder
 // This is a convenience function for the common use case of creating a manifest from data
 func CreateManifestFromSource(source io.Reader, size int64, opts ...EncoderOption) (*SDBlob, []byte, error) {

--- a/stream/manifest.go
+++ b/stream/manifest.go
@@ -98,7 +98,7 @@ func WithEncoderChunkSize(size int) EncoderOption {
 // Use profileOldSort for compatibility with legacy Python SDK SD blobs
 func WithSerializationProfile(profile serializationProfile) EncoderOption {
 	return func(e *Encoder) {
-		e.serializationProfile = profile
+		e.sd.SetProfile(profile)
 	}
 }
 

--- a/stream/sdblob.go
+++ b/stream/sdblob.go
@@ -450,6 +450,11 @@ func (s *SDBlob) SetProfile(profile serializationProfile) {
 	}
 }
 
+// GetProfile returns the serialization profile for the SDBlob
+func (s *SDBlob) GetProfile() serializationProfile {
+	return s.profile
+}
+
 // Hash returns a hash of the SD blob data
 func (s SDBlob) Hash() []byte {
 	blobData, _ := s.ToBlob()
@@ -583,10 +588,16 @@ func newSortProfileHandler() *profileHandler {
 			}
 
 			s.StreamType = tmp.StreamType
-			s.BlobInfos = lo.Map(tmp.Blobs, func(bi JSONBlobInfoNewSort, _ int) BlobInfo {
-				result, _ := decodeBlobInfoFromNewSort(bi, profileNewSort)
-				return result
-			})
+
+			blobInfos := make([]BlobInfo, len(tmp.Blobs))
+			for i, bi := range tmp.Blobs {
+				result, err := decodeBlobInfoFromNewSort(bi, profileNewSort)
+				if err != nil {
+					return nil, err
+				}
+				blobInfos[i] = result
+			}
+			s.BlobInfos = blobInfos
 
 			return s, nil
 		},
@@ -676,10 +687,16 @@ func oldSortProfileHandler() *profileHandler {
 			}
 
 			s.StreamType = tmp.StreamType
-			s.BlobInfos = lo.Map(tmp.Blobs, func(bi JSONBlobInfoOldSort, _ int) BlobInfo {
-				result, _ := decodeBlobInfoFromOldSort(bi, profileOldSort)
-				return result
-			})
+
+			blobInfos := make([]BlobInfo, len(tmp.Blobs))
+			for i, bi := range tmp.Blobs {
+				result, err := decodeBlobInfoFromOldSort(bi, profileOldSort)
+				if err != nil {
+					return nil, err
+				}
+				blobInfos[i] = result
+			}
+			s.BlobInfos = blobInfos
 
 			return s, nil
 		},

--- a/stream/sdblob.go
+++ b/stream/sdblob.go
@@ -20,6 +20,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/glopal/orderedjson"
+	"github.com/samber/lo"
 	"go.lumeweb.com/liblbry/blob"
 	lbrycrypto "go.lumeweb.com/liblbry/crypto"
 	liblbryerrors "go.lumeweb.com/liblbry/errors"
@@ -33,22 +35,51 @@ var (
 	ErrInvalidSDBlob = liblbryerrors.Err("invalid SD blob")
 )
 
+// serializationProfile represents the JSON field ordering profile for SD blobs
+type serializationProfile int
+
+const (
+	profileNewSort serializationProfile = iota // New sort: alphabetical field ordering
+	profileOldSort                             // Old sort: legacy Python SDK field ordering
+)
+
+// profileHandler defines encoding/decoding operations for a serialization profile
+type profileHandler struct {
+	name string
+
+	marshalBlobInfo   func(BlobInfo) ([]byte, error)
+	unmarshalBlobInfo func([]byte) (BlobInfo, error)
+
+	marshalSDBlob   func(SDBlob) ([]byte, error)
+	unmarshalSDBlob func([]byte) (*SDBlob, error)
+
+	predicates []profilePredicate
+}
+
+// profileRegistry maps profile IDs to their handlers
+var profileRegistry = map[serializationProfile]*profileHandler{
+	profileNewSort: newSortProfileHandler(),
+	profileOldSort: oldSortProfileHandler(),
+}
+
 // BlobInfo contains information about a content blob
 type BlobInfo struct {
-	Length   int    `json:"length"`
-	BlobNum  int    `json:"blob_num"`
-	BlobHash []byte `json:"-"`
-	IV       []byte `json:"-"`
+	Length   int                  `json:"length"`
+	BlobNum  int                  `json:"blob_num"`
+	BlobHash []byte               `json:"-"`
+	IV       []byte               `json:"-"`
+	profile  serializationProfile // private field to track serialization profile
 }
 
 // SDBlob represents stream descriptor blob metadata
 type SDBlob struct {
-	StreamName        string     `json:"-"`
-	BlobInfos         []BlobInfo `json:"blobs"`
-	StreamType        string     `json:"stream_type"`
-	Key               []byte     `json:"-"`
-	SuggestedFileName string     `json:"-"`
-	StreamHash        []byte     `json:"-"`
+	StreamName        string               `json:"-"`
+	BlobInfos         []BlobInfo           `json:"blobs"`
+	StreamType        string               `json:"stream_type"`
+	Key               []byte               `json:"-"`
+	SuggestedFileName string               `json:"-"`
+	StreamHash        []byte               `json:"-"`
+	profile           serializationProfile // private field to track serialization profile
 }
 
 // --- JSON serialization for BlobInfo ---
@@ -63,17 +94,48 @@ type JSONBlobInfo struct {
 	IV       string `json:"iv"`
 }
 
+// JSONBlobInfoNewSort represents BlobInfo with new sort (alphabetical) field ordering
+// Field order: blob_hash, blob_num, iv, length
+type JSONBlobInfoNewSort struct {
+	BlobHash string `json:"blob_hash,omitempty"`
+	BlobNum  int    `json:"blob_num"`
+	IV       string `json:"iv"`
+	Length   int    `json:"length"`
+}
+
+// JSONBlobInfoOldSort represents BlobInfo with old SDK field ordering
+// Field order: length, blob_num, blob_hash (optional), iv
+type JSONBlobInfoOldSort struct {
+	Length   int    `json:"length"`
+	BlobNum  int    `json:"blob_num"`
+	BlobHash string `json:"blob_hash,omitempty"`
+	IV       string `json:"iv"`
+}
+
+// encodeBlobInfoCommon encodes common BlobInfo fields to hex strings
+func encodeBlobInfoCommon(bi BlobInfo) (string, string) {
+	ivHex := hex.EncodeToString(bi.IV)
+	blobHashHex := ""
+	if len(bi.BlobHash) > 0 {
+		blobHashHex = hex.EncodeToString(bi.BlobHash)
+	}
+	return ivHex, blobHashHex
+}
+
 // MarshalJSON implements custom JSON marshaling for BlobInfo
 func (bi BlobInfo) MarshalJSON() ([]byte, error) {
-	var tmp JSONBlobInfo
-
-	tmp.IV = hex.EncodeToString(bi.IV)
-	if len(bi.BlobHash) > 0 {
-		tmp.BlobHash = hex.EncodeToString(bi.BlobHash)
+	if handler, ok := profileRegistry[bi.profile]; ok && handler.marshalBlobInfo != nil {
+		return handler.marshalBlobInfo(bi)
 	}
 
-	tmp.BlobInfoAlias = BlobInfoAlias(bi)
+	ivHex, blobHashHex := encodeBlobInfoCommon(bi)
 
+	tmp := JSONBlobInfoNewSort{
+		BlobHash: blobHashHex,
+		BlobNum:  bi.BlobNum,
+		IV:       ivHex,
+		Length:   bi.Length,
+	}
 	return json.Marshal(tmp)
 }
 
@@ -131,66 +193,195 @@ type JSONSDBlob struct {
 	StreamHash        string     `json:"stream_hash"`
 }
 
+// JSONSDBlobNewSort represents SDBlob with new sort (alphabetical) field ordering
+// Field order: blobs, key, stream_hash, stream_name, stream_type, suggested_file_name
+type JSONSDBlobNewSort struct {
+	Blobs             []JSONBlobInfoNewSort `json:"blobs"`
+	Key               string                `json:"key"`
+	StreamHash        string                `json:"stream_hash"`
+	StreamName        string                `json:"stream_name"`
+	StreamType        string                `json:"stream_type"`
+	SuggestedFileName string                `json:"suggested_file_name"`
+}
+
+// JSONSDBlobOldSort represents SDBlob with old SDK field ordering
+// Field order: stream_name, blobs, stream_type, key, suggested_file_name, stream_hash
+type JSONSDBlobOldSort struct {
+	StreamName        string                `json:"stream_name"`
+	Blobs             []JSONBlobInfoOldSort `json:"blobs"`
+	StreamType        string                `json:"stream_type"`
+	Key               string                `json:"key"`
+	SuggestedFileName string                `json:"suggested_file_name"`
+	StreamHash        string                `json:"stream_hash"`
+}
+
+// encodeSDBlobCommon encodes common SDBlob fields to hex strings
+func encodeSDBlobCommon(s SDBlob) (string, string, string, string) {
+	streamNameHex := hex.EncodeToString([]byte(s.StreamName))
+	keyHex := hex.EncodeToString(s.Key)
+	suggestedFileNameHex := hex.EncodeToString([]byte(s.SuggestedFileName))
+	streamHashHex := hex.EncodeToString(s.StreamHash)
+	return streamNameHex, keyHex, suggestedFileNameHex, streamHashHex
+}
+
+// encodeBlobInfosAsOldSort converts BlobInfos to JSONBlobInfoOldSort slice
+func encodeBlobInfosAsOldSort(blobs []BlobInfo) []JSONBlobInfoOldSort {
+	return lo.Map(blobs, func(bi BlobInfo, _ int) JSONBlobInfoOldSort {
+		ivHex, blobHashHex := encodeBlobInfoCommon(bi)
+		return JSONBlobInfoOldSort{
+			Length:   bi.Length,
+			BlobNum:  bi.BlobNum,
+			IV:       ivHex,
+			BlobHash: blobHashHex,
+		}
+	})
+}
+
+// encodeBlobInfosAsNewSort converts BlobInfos to JSONBlobInfoNewSort slice
+func encodeBlobInfosAsNewSort(blobs []BlobInfo) []JSONBlobInfoNewSort {
+	return lo.Map(blobs, func(bi BlobInfo, _ int) JSONBlobInfoNewSort {
+		ivHex, blobHashHex := encodeBlobInfoCommon(bi)
+		return JSONBlobInfoNewSort{
+			BlobHash: blobHashHex,
+			BlobNum:  bi.BlobNum,
+			IV:       ivHex,
+			Length:   bi.Length,
+		}
+	})
+}
+
 // MarshalJSON implements custom JSON marshaling for SDBlob
 func (s SDBlob) MarshalJSON() ([]byte, error) {
-	var tmp JSONSDBlob
+	if handler, ok := profileRegistry[s.profile]; ok && handler.marshalSDBlob != nil {
+		return handler.marshalSDBlob(s)
+	}
 
-	tmp.StreamName = hex.EncodeToString([]byte(s.StreamName))
-	tmp.Blobs = s.BlobInfos
-	tmp.StreamType = s.StreamType
-	tmp.Key = hex.EncodeToString(s.Key)
-	tmp.SuggestedFileName = hex.EncodeToString([]byte(s.SuggestedFileName))
-	tmp.StreamHash = hex.EncodeToString(s.StreamHash)
+	streamNameHex, keyHex, suggestedFileNameHex, streamHashHex := encodeSDBlobCommon(s)
 
+	tmp := JSONSDBlobNewSort{
+		Blobs:             encodeBlobInfosAsNewSort(s.BlobInfos),
+		Key:               keyHex,
+		StreamHash:        streamHashHex,
+		StreamName:        streamNameHex,
+		StreamType:        s.StreamType,
+		SuggestedFileName: suggestedFileNameHex,
+	}
 	return json.Marshal(tmp)
+}
+
+// decodeHex decodes a hex string to bytes, returning nil if empty
+func decodeHex(s string) ([]byte, error) {
+	if s == "" {
+		return nil, nil
+	}
+	return hex.DecodeString(s)
+}
+
+// decodeHexString decodes a hex string to string, returning empty string if input is empty
+func decodeHexString(s string) (string, error) {
+	if s == "" {
+		return "", nil
+	}
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// decodeSDBlobFields decodes common SDBlob fields from hex
+func decodeSDBlobFields(streamNameHex, keyHex, suggestedFileNameHex, streamHashHex string) (string, []byte, string, []byte, error) {
+	streamName, err := decodeHexString(streamNameHex)
+	if err != nil {
+		return "", nil, "", nil, err
+	}
+
+	key, err := decodeHex(keyHex)
+	if err != nil {
+		return "", nil, "", nil, err
+	}
+
+	suggestedFileName, err := decodeHexString(suggestedFileNameHex)
+	if err != nil {
+		return "", nil, "", nil, err
+	}
+
+	streamHash, err := decodeHex(streamHashHex)
+	if err != nil {
+		return "", nil, "", nil, err
+	}
+
+	return streamName, key, suggestedFileName, streamHash, nil
+}
+
+// decodeBlobInfoFromNewSort decodes JSONBlobInfoNewSort to BlobInfo
+func decodeBlobInfoFromNewSort(tmp JSONBlobInfoNewSort, profile serializationProfile) (BlobInfo, error) {
+	bi := BlobInfo{
+		Length:  tmp.Length,
+		BlobNum: tmp.BlobNum,
+		profile: profile,
+	}
+
+	if tmp.BlobHash != "" {
+		blobHash, err := hex.DecodeString(tmp.BlobHash)
+		if err != nil {
+			return BlobInfo{}, err
+		}
+		bi.BlobHash = blobHash
+	}
+
+	if tmp.IV != "" {
+		iv, err := hex.DecodeString(tmp.IV)
+		if err != nil {
+			return BlobInfo{}, err
+		}
+		bi.IV = iv
+	}
+
+	return bi, nil
+}
+
+// decodeBlobInfoFromOldSort decodes JSONBlobInfoOldSort to BlobInfo
+func decodeBlobInfoFromOldSort(tmp JSONBlobInfoOldSort, profile serializationProfile) (BlobInfo, error) {
+	bi := BlobInfo{
+		Length:  tmp.Length,
+		BlobNum: tmp.BlobNum,
+		profile: profile,
+	}
+
+	if tmp.BlobHash != "" {
+		blobHash, err := hex.DecodeString(tmp.BlobHash)
+		if err != nil {
+			return BlobInfo{}, err
+		}
+		bi.BlobHash = blobHash
+	}
+
+	if tmp.IV != "" {
+		iv, err := hex.DecodeString(tmp.IV)
+		if err != nil {
+			return BlobInfo{}, err
+		}
+		bi.IV = iv
+	}
+
+	return bi, nil
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for SDBlob
 func (s *SDBlob) UnmarshalJSON(b []byte) error {
-	var tmp JSONSDBlob
-	err := json.Unmarshal(b, &tmp)
-	if err != nil {
-		return err
-	}
+	s.profile = detectSerializationProfile(b)
 
-	s.StreamName = ""
-	if tmp.StreamName != "" {
-		str, err := hex.DecodeString(tmp.StreamName)
+	if handler, ok := profileRegistry[s.profile]; ok && handler.unmarshalSDBlob != nil {
+		result, err := handler.unmarshalSDBlob(b)
 		if err != nil {
 			return err
 		}
-		s.StreamName = string(str)
+		*s = *result
+		return nil
 	}
 
-	s.BlobInfos = tmp.Blobs
-	s.StreamType = tmp.StreamType
-
-	s.Key = nil
-	if tmp.Key != "" {
-		s.Key, err = hex.DecodeString(tmp.Key)
-		if err != nil {
-			return err
-		}
-	}
-
-	s.SuggestedFileName = ""
-	if tmp.SuggestedFileName != "" {
-		str, err := hex.DecodeString(tmp.SuggestedFileName)
-		if err != nil {
-			return err
-		}
-		s.SuggestedFileName = string(str)
-	}
-
-	s.StreamHash = nil
-	if tmp.StreamHash != "" {
-		s.StreamHash, err = hex.DecodeString(tmp.StreamHash)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
+	return fmt.Errorf("no unmarshal handler for profile: %d", s.profile)
 }
 
 // ToJson returns the SD blob as JSON with indentation
@@ -223,9 +414,40 @@ func (s SDBlob) IsValid() bool {
 	return bytes.Equal(computedHash, s.StreamHash)
 }
 
+// profilePredicate checks if the JSON matches a specific serialization profile
+type profilePredicate func(orderedjson.Map) (serializationProfile, bool)
+
+// detectSerializationProfile analyzes JSON bytes to determine the serialization profile
+// by applying predicates from registered profile handlers in order and returning the first match
+func detectSerializationProfile(b []byte) serializationProfile {
+	var orderedMap orderedjson.Map
+	if err := json.Unmarshal(b, &orderedMap); err != nil {
+		return profileNewSort
+	}
+
+	for _, handler := range profileRegistry {
+		for _, predicate := range handler.predicates {
+			if detectedProfile, detected := predicate(orderedMap); detected {
+				return detectedProfile
+			}
+		}
+	}
+
+	return profileNewSort
+}
+
 // FromBlob unmarshals a data Blob that should contain SDBlob data
 func (s *SDBlob) FromBlob(b []byte) error {
+	s.profile = detectSerializationProfile(b)
 	return json.Unmarshal(b, s)
+}
+
+// SetProfile sets the serialization profile for the SDBlob and all its BlobInfos
+func (s *SDBlob) SetProfile(profile serializationProfile) {
+	s.profile = profile
+	for i := range s.BlobInfos {
+		s.BlobInfos[i].profile = profile
+	}
 }
 
 // Hash returns a hash of the SD blob data
@@ -288,6 +510,192 @@ func (s *SDBlob) computeStreamHash() []byte {
 		hex.EncodeToString([]byte(s.SuggestedFileName)),
 		s.BlobInfos,
 	)
+}
+
+// newSortProfileHandler creates a handler for new sort (alphabetical) serialization
+func newSortProfileHandler() *profileHandler {
+	return &profileHandler{
+		name: "new_sort",
+		marshalBlobInfo: func(bi BlobInfo) ([]byte, error) {
+			ivHex, blobHashHex := encodeBlobInfoCommon(bi)
+			tmp := JSONBlobInfoNewSort{
+				BlobHash: blobHashHex,
+				BlobNum:  bi.BlobNum,
+				IV:       ivHex,
+				Length:   bi.Length,
+			}
+			return json.Marshal(tmp)
+		},
+		unmarshalBlobInfo: func(b []byte) (BlobInfo, error) {
+			var tmp JSONBlobInfoNewSort
+			if err := json.Unmarshal(b, &tmp); err != nil {
+				return BlobInfo{}, err
+			}
+
+			bi := BlobInfo{
+				Length:  tmp.Length,
+				BlobNum: tmp.BlobNum,
+				profile: profileNewSort,
+			}
+
+			if tmp.BlobHash != "" {
+				blobHash, err := hex.DecodeString(tmp.BlobHash)
+				if err != nil {
+					return BlobInfo{}, err
+				}
+				bi.BlobHash = blobHash
+			}
+
+			if tmp.IV != "" {
+				iv, err := hex.DecodeString(tmp.IV)
+				if err != nil {
+					return BlobInfo{}, err
+				}
+				bi.IV = iv
+			}
+
+			return bi, nil
+		},
+		marshalSDBlob: func(s SDBlob) ([]byte, error) {
+			streamNameHex, keyHex, suggestedFileNameHex, streamHashHex := encodeSDBlobCommon(s)
+			tmp := JSONSDBlobNewSort{
+				Blobs:             encodeBlobInfosAsNewSort(s.BlobInfos),
+				Key:               keyHex,
+				StreamHash:        streamHashHex,
+				StreamName:        streamNameHex,
+				StreamType:        s.StreamType,
+				SuggestedFileName: suggestedFileNameHex,
+			}
+			return json.Marshal(tmp)
+		},
+		unmarshalSDBlob: func(b []byte) (*SDBlob, error) {
+			var tmp JSONSDBlobNewSort
+			if err := json.Unmarshal(b, &tmp); err != nil {
+				return nil, err
+			}
+
+			s := &SDBlob{profile: profileNewSort}
+
+			var err error
+			s.StreamName, s.Key, s.SuggestedFileName, s.StreamHash, err = decodeSDBlobFields(tmp.StreamName, tmp.Key, tmp.SuggestedFileName, tmp.StreamHash)
+			if err != nil {
+				return nil, err
+			}
+
+			s.StreamType = tmp.StreamType
+			s.BlobInfos = lo.Map(tmp.Blobs, func(bi JSONBlobInfoNewSort, _ int) BlobInfo {
+				result, _ := decodeBlobInfoFromNewSort(bi, profileNewSort)
+				return result
+			})
+
+			return s, nil
+		},
+		predicates: []profilePredicate{
+			func(m orderedjson.Map) (serializationProfile, bool) {
+				if len(m) == 0 {
+					return profileNewSort, false
+				}
+				firstKey := string(m[0].Key)
+				if firstKey == `"blobs"` {
+					return profileNewSort, true
+				}
+				return profileNewSort, false
+			},
+		},
+	}
+}
+
+// oldSortProfileHandler creates a handler for old sort (legacy Python SDK) serialization
+func oldSortProfileHandler() *profileHandler {
+	return &profileHandler{
+		name: "old_sort",
+		marshalBlobInfo: func(bi BlobInfo) ([]byte, error) {
+			ivHex, blobHashHex := encodeBlobInfoCommon(bi)
+			tmp := JSONBlobInfoOldSort{
+				Length:   bi.Length,
+				BlobNum:  bi.BlobNum,
+				IV:       ivHex,
+				BlobHash: blobHashHex,
+			}
+			return json.Marshal(tmp)
+		},
+		unmarshalBlobInfo: func(b []byte) (BlobInfo, error) {
+			var tmp JSONBlobInfoOldSort
+			if err := json.Unmarshal(b, &tmp); err != nil {
+				return BlobInfo{}, err
+			}
+
+			bi := BlobInfo{
+				Length:  tmp.Length,
+				BlobNum: tmp.BlobNum,
+				profile: profileOldSort,
+			}
+
+			if tmp.BlobHash != "" {
+				blobHash, err := hex.DecodeString(tmp.BlobHash)
+				if err != nil {
+					return BlobInfo{}, err
+				}
+				bi.BlobHash = blobHash
+			}
+
+			if tmp.IV != "" {
+				iv, err := hex.DecodeString(tmp.IV)
+				if err != nil {
+					return BlobInfo{}, err
+				}
+				bi.IV = iv
+			}
+
+			return bi, nil
+		},
+		marshalSDBlob: func(s SDBlob) ([]byte, error) {
+			streamNameHex, keyHex, suggestedFileNameHex, streamHashHex := encodeSDBlobCommon(s)
+			tmp := JSONSDBlobOldSort{
+				StreamName:        streamNameHex,
+				StreamType:        s.StreamType,
+				Key:               keyHex,
+				SuggestedFileName: suggestedFileNameHex,
+				StreamHash:        streamHashHex,
+				Blobs:             encodeBlobInfosAsOldSort(s.BlobInfos),
+			}
+			return json.Marshal(tmp)
+		},
+		unmarshalSDBlob: func(b []byte) (*SDBlob, error) {
+			var tmp JSONSDBlobOldSort
+			if err := json.Unmarshal(b, &tmp); err != nil {
+				return nil, err
+			}
+
+			s := &SDBlob{profile: profileOldSort}
+
+			var err error
+			s.StreamName, s.Key, s.SuggestedFileName, s.StreamHash, err = decodeSDBlobFields(tmp.StreamName, tmp.Key, tmp.SuggestedFileName, tmp.StreamHash)
+			if err != nil {
+				return nil, err
+			}
+
+			s.StreamType = tmp.StreamType
+			s.BlobInfos = lo.Map(tmp.Blobs, func(bi JSONBlobInfoOldSort, _ int) BlobInfo {
+				result, _ := decodeBlobInfoFromOldSort(bi, profileOldSort)
+				return result
+			})
+
+			return s, nil
+		},
+		predicates: []profilePredicate{
+			func(m orderedjson.Map) (serializationProfile, bool) {
+				if len(m) == 0 {
+					return profileNewSort, false
+				}
+				firstKey := string(m[0].Key)
+				if firstKey == `"stream_name"` {
+					return profileOldSort, true
+				}
+				return profileNewSort, false
+			},
+		},
+	}
 }
 
 // ValidateSDBlob validates an SDBlob struct's structure and content

--- a/stream/sdblob_test.go
+++ b/stream/sdblob_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 	"testing"
 
@@ -26,6 +27,7 @@ func TestBlobInfoMarshalJSON(t *testing.T) {
 		BlobHash: blobHash,
 		IV:       iv,
 	}
+	bi.profile = profileOldSort
 
 	data, err := json.Marshal(bi)
 	require.NoError(t, err)
@@ -83,6 +85,7 @@ func TestSDBlobMarshalJSON(t *testing.T) {
 		SuggestedFileName: suggestedFileName,
 		StreamHash:        streamHash,
 	}
+	sd.SetProfile(profileOldSort)
 
 	data, err := json.Marshal(sd)
 	require.NoError(t, err)
@@ -242,6 +245,7 @@ func TestSDBlobEdgeCases(t *testing.T) {
 		SuggestedFileName: "",
 		StreamHash:        nil,
 	}
+	sd.SetProfile(profileOldSort)
 
 	data, err := json.Marshal(sd)
 	require.NoError(t, err)
@@ -370,6 +374,7 @@ func TestSDBlobToJson(t *testing.T) {
 		SuggestedFileName: suggestedFileName,
 		StreamHash:        streamHash,
 	}
+	sd.SetProfile(profileOldSort)
 
 	// Test ToJson()
 	jsonStr, err := sd.ToJson()
@@ -579,4 +584,185 @@ func TestValidateSDBlob_TerminatingBlobScenarios(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBlobInfoMarshalJSONOldSort tests BlobInfo MarshalJSON with old sort field ordering
+func TestBlobInfoMarshalJSONOldSort(t *testing.T) {
+	blobHash, _ := hex.DecodeString("e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8")
+	iv, _ := hex.DecodeString("30303030303030303030303030303031")
+
+	bi := BlobInfo{
+		Length:   2097152,
+		BlobNum:  0,
+		BlobHash: blobHash,
+		IV:       iv,
+		profile:  profileOldSort,
+	}
+
+	data, err := json.Marshal(bi)
+	require.NoError(t, err)
+
+	// Old sort order: length, blob_num, blob_hash, iv
+	expected := `{"length":2097152,"blob_num":0,"blob_hash":"e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8","iv":"30303030303030303030303030303031"}`
+	if string(data) != expected {
+		t.Errorf("MarshalJSON with old sort failed. Expected: %s, Got: %s", expected, string(data))
+	}
+}
+
+// TestBlobInfoMarshalJSONOldSortNullBlob tests BlobInfo MarshalJSON with old sort for null blob (no blob_hash)
+func TestBlobInfoMarshalJSONOldSortNullBlob(t *testing.T) {
+	iv, _ := hex.DecodeString("30303030303030303030303030303036")
+
+	bi := BlobInfo{
+		Length:  0,
+		BlobNum: 25,
+		IV:      iv,
+		profile: profileOldSort,
+	}
+
+	data, err := json.Marshal(bi)
+	require.NoError(t, err)
+
+	// Old sort order for null blob: length, blob_num, iv (no blob_hash)
+	expected := `{"length":0,"blob_num":25,"iv":"30303030303030303030303030303036"}`
+	if string(data) != expected {
+		t.Errorf("MarshalJSON with old sort (null blob) failed. Expected: %s, Got: %s", expected, string(data))
+	}
+}
+
+// TestSDBlobMarshalJSONOldSort tests SDBlob MarshalJSON with old sort field ordering
+func TestSDBlobMarshalJSONOldSort(t *testing.T) {
+	streamName := "test_file"
+	key, _ := hex.DecodeString("30313233343536373031323334353637")
+	suggestedFileName := "test_file"
+	streamHash, _ := hex.DecodeString("4fcd4064713bf639362248d3ac0c0ee527a93a08ce4991954d6e11b0317e79b6beedb6833e18e7ae8b0f14ddf258e386")
+
+	sd := SDBlob{
+		StreamName:        streamName,
+		BlobInfos:         []BlobInfo{},
+		StreamType:        StreamTypeLBRYFile,
+		Key:               key,
+		SuggestedFileName: suggestedFileName,
+		StreamHash:        streamHash,
+		profile:           profileOldSort,
+	}
+
+	data, err := json.Marshal(sd)
+	require.NoError(t, err)
+
+	// Old sort order: stream_name, blobs, stream_type, key, suggested_file_name, stream_hash
+	expected := `{"stream_name":"746573745f66696c65","blobs":[],"stream_type":"lbryfile","key":"30313233343536373031323334353637","suggested_file_name":"746573745f66696c65","stream_hash":"4fcd4064713bf639362248d3ac0c0ee527a93a08ce4991954d6e11b0317e79b6beedb6833e18e7ae8b0f14ddf258e386"}`
+	if string(data) != expected {
+		t.Errorf("MarshalJSON with old sort failed. Expected: %s, Got: %s", expected, string(data))
+	}
+}
+
+// TestSDBlobProfileDetection tests automatic profile detection from JSON
+func TestSDBlobProfileDetection(t *testing.T) {
+	// New sort JSON (alphabetical) - valid hex strings
+	newSortJSON := `{"blobs":[{"blob_hash":"e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8","blob_num":0,"iv":"30303030303030303030303030303031","length":100}],"key":"30313233343536373031323334353637","suggested_file_name":"746573745f66696c65","stream_hash":"4fcd4064713bf639362248d3ac0c0ee527a93a08ce4991954d6e11b0317e79b6beedb6833e18e7ae8b0f14ddf258e386","stream_name":"746573745f66696c65","stream_type":"lbryfile"}`
+
+	var sd1 SDBlob
+	err := json.Unmarshal([]byte(newSortJSON), &sd1)
+	require.NoError(t, err)
+	assert.Equal(t, profileNewSort, sd1.profile, "Should detect new sort profile")
+
+	// Old sort JSON - valid hex strings
+	oldSortJSON := `{"stream_name":"746573745f66696c65","blobs":[{"length":100,"blob_num":0,"blob_hash":"e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8","iv":"30303030303030303030303030303031"}],"stream_type":"lbryfile","key":"30313233343536373031323334353637","suggested_file_name":"746573745f66696c65","stream_hash":"4fcd4064713bf639362248d3ac0c0ee527a93a08ce4991954d6e11b0317e79b6beedb6833e18e7ae8b0f14ddf258e386"}`
+
+	var sd2 SDBlob
+	err = json.Unmarshal([]byte(oldSortJSON), &sd2)
+	require.NoError(t, err)
+	assert.Equal(t, profileOldSort, sd2.profile, "Should detect old sort profile")
+}
+
+// TestSDBlobSetProfile tests setting profile explicitly
+func TestSDBlobSetProfile(t *testing.T) {
+	streamName := "test_file"
+	key, _ := hex.DecodeString("30313233343536373031323334353637")
+	suggestedFileName := "test_file"
+	streamHash, _ := hex.DecodeString("4fcd4064713bf639362248d3ac0c0ee527a93a08ce4991954d6e11b0317e79b6beedb6833e18e7ae8b0f14ddf258e386")
+
+	blobHash, _ := hex.DecodeString("e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8")
+	iv, _ := hex.DecodeString("30303030303030303030303030303031")
+
+	sd := SDBlob{
+		StreamName:        streamName,
+		BlobInfos:         []BlobInfo{{Length: 2097152, BlobNum: 0, BlobHash: blobHash, IV: iv}},
+		StreamType:        StreamTypeLBRYFile,
+		Key:               key,
+		SuggestedFileName: suggestedFileName,
+		StreamHash:        streamHash,
+		profile:           profileNewSort,
+	}
+
+	// Marshal with new sort
+	dataNew, err := json.Marshal(sd)
+	require.NoError(t, err)
+	assert.Contains(t, string(dataNew), `"blobs"`, "New sort should have blobs first")
+
+	// Set to old sort
+	sd.SetProfile(profileOldSort)
+
+	// Marshal with old sort
+	dataOld, err := json.Marshal(sd)
+	require.NoError(t, err)
+	assert.Contains(t, string(dataOld), `"stream_name"`, "Old sort should have stream_name first")
+
+	// Verify all BlobInfos also have old sort profile
+	assert.Equal(t, profileOldSort, sd.BlobInfos[0].profile, "BlobInfo should have old sort profile")
+}
+
+// TestFromBlobWithProfileDetection tests that FromBlob correctly detects and preserves profile
+func TestFromBlobWithProfileDetection(t *testing.T) {
+	// Old sort SD blob
+	oldSortBlob := `{"stream_name":"746573745f66696c65","blobs":[{"length":2097152,"blob_num":0,"blob_hash":"e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8","iv":"30303030303030303030303030303031"},{"length":0,"blob_num":1,"iv":"30303030303030303030303030303036"}],"stream_type":"lbryfile","key":"30313233343536373031323334353637","suggested_file_name":"746573745f66696c65","stream_hash":"4fcd4064713bf639362248d3ac0c0ee527a93a08ce4991954d6e11b0317e79b6beedb6833e18e7ae8b0f14ddf258e386"}`
+
+	var sd SDBlob
+	err := sd.FromBlob([]byte(oldSortBlob))
+	require.NoError(t, err)
+	assert.Equal(t, profileOldSort, sd.profile, "FromBlob should detect old sort profile")
+	assert.Equal(t, profileOldSort, sd.BlobInfos[0].profile, "BlobInfos should have old sort profile")
+
+	// Marshal again and verify it maintains old sort
+	data, err := json.Marshal(sd)
+	require.NoError(t, err)
+	jsonStr := string(data)
+
+	// Verify old sort ordering
+	streamNameIdx := strings.Index(jsonStr, `"stream_name"`)
+	blobsIdx := strings.Index(jsonStr, `"blobs"`)
+	assert.True(t, streamNameIdx < blobsIdx, "Re-marshaled blob should maintain old sort ordering")
+}
+
+// TestEncoderWithOldSortProfile tests encoder with old sort profile
+func TestEncoderWithOldSortProfile(t *testing.T) {
+	testData := []byte("Hello, world! This is a test file for encoding.")
+
+	encoder := NewEncoder(bytes.NewReader(testData))
+	encoder.SetSerializationProfile(profileOldSort)
+
+	// Encode the stream
+	for {
+		_, err := encoder.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err, "Should complete encoding without errors")
+	}
+
+	sd := encoder.SDBlob()
+
+	// Verify profile is set
+	assert.Equal(t, profileOldSort, sd.profile, "Encoder should set old sort profile")
+
+	// Marshal and verify old sort ordering
+	data, err := json.Marshal(sd)
+	require.NoError(t, err)
+	jsonStr := string(data)
+
+	// Verify old sort ordering
+	streamNameIdx := strings.Index(jsonStr, `"stream_name"`)
+	blobsIdx := strings.Index(jsonStr, `"blobs"`)
+	assert.True(t, streamNameIdx < blobsIdx, "Encoded SD blob should use old sort ordering")
 }

--- a/stream/sdblob_test.go
+++ b/stream/sdblob_test.go
@@ -18,7 +18,7 @@ import (
 
 // TestBlobInfoMarshalJSON tests BlobInfo MarshalJSON with hex encoding
 func TestBlobInfoMarshalJSON(t *testing.T) {
-	blobHash, _ := hex.DecodeString("e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8")
+	blobHash, _ := hex.DecodeString(lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1])
 	iv, _ := hex.DecodeString("30303030303030303030303030303031")
 
 	bi := BlobInfo{
@@ -32,7 +32,7 @@ func TestBlobInfoMarshalJSON(t *testing.T) {
 	data, err := json.Marshal(bi)
 	require.NoError(t, err)
 
-	expected := `{"length":2097152,"blob_num":0,"blob_hash":"e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8","iv":"30303030303030303030303030303031"}`
+	expected := `{"length":2097152,"blob_num":0,"blob_hash":"` + lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1] + `","iv":"30303030303030303030303030303031"}`
 	if string(data) != expected {
 		t.Errorf("MarshalJSON failed. Expected: %s, Got: %s", expected, string(data))
 	}
@@ -40,13 +40,13 @@ func TestBlobInfoMarshalJSON(t *testing.T) {
 
 // TestBlobInfoUnmarshalJSON tests BlobInfo UnmarshalJSON with hex decoding
 func TestBlobInfoUnmarshalJSON(t *testing.T) {
-	jsonData := `{"length":2097152,"blob_num":0,"blob_hash":"e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8","iv":"30303030303030303030303030303031"}`
+	jsonData := `{"length":2097152,"blob_num":0,"blob_hash":"` + lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1] + `","iv":"30303030303030303030303030303031"}`
 
 	var bi BlobInfo
 	err := json.Unmarshal([]byte(jsonData), &bi)
 	require.NoError(t, err)
 
-	expectedBlobHash, _ := hex.DecodeString("e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8")
+	expectedBlobHash, _ := hex.DecodeString(lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1])
 	expectedIV, _ := hex.DecodeString("30303030303030303030303030303031")
 
 	if bi.Length != 2097152 {
@@ -588,7 +588,7 @@ func TestValidateSDBlob_TerminatingBlobScenarios(t *testing.T) {
 
 // TestBlobInfoMarshalJSONOldSort tests BlobInfo MarshalJSON with old sort field ordering
 func TestBlobInfoMarshalJSONOldSort(t *testing.T) {
-	blobHash, _ := hex.DecodeString("e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8")
+	blobHash, _ := hex.DecodeString(lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1])
 	iv, _ := hex.DecodeString("30303030303030303030303030303031")
 
 	bi := BlobInfo{
@@ -603,7 +603,7 @@ func TestBlobInfoMarshalJSONOldSort(t *testing.T) {
 	require.NoError(t, err)
 
 	// Old sort order: length, blob_num, blob_hash, iv
-	expected := `{"length":2097152,"blob_num":0,"blob_hash":"e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8","iv":"30303030303030303030303030303031"}`
+	expected := `{"length":2097152,"blob_num":0,"blob_hash":"` + lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1] + `","iv":"30303030303030303030303030303031"}`
 	if string(data) != expected {
 		t.Errorf("MarshalJSON with old sort failed. Expected: %s, Got: %s", expected, string(data))
 	}
@@ -683,7 +683,7 @@ func TestSDBlobSetProfile(t *testing.T) {
 	suggestedFileName := "test_file"
 	streamHash, _ := hex.DecodeString("4fcd4064713bf639362248d3ac0c0ee527a93a08ce4991954d6e11b0317e79b6beedb6833e18e7ae8b0f14ddf258e386")
 
-	blobHash, _ := hex.DecodeString("e6063cf9656e3ff24a197c5abdc2e5832d166de3b045d789b3f61526f1e82ff64e863a96dced804078dccc65bda6f7b8")
+	blobHash, _ := hex.DecodeString(lbryTesting.LBRYTestHashes[lbryTesting.LBRYHashKey1])
 	iv, _ := hex.DecodeString("30303030303030303030303030303031")
 
 	sd := SDBlob{
@@ -740,7 +740,7 @@ func TestEncoderWithOldSortProfile(t *testing.T) {
 	testData := []byte("Hello, world! This is a test file for encoding.")
 
 	encoder := NewEncoder(bytes.NewReader(testData))
-	encoder.SetSerializationProfile(profileOldSort)
+	encoder.SDBlob().SetProfile(profileOldSort)
 
 	// Encode the stream
 	for {


### PR DESCRIPTION
- Add serializationProfile type with profileNewSort (alphabetical) and profileOldSort (legacy Python SDK) constants
- Implement profile handler registry system for extensible encoding/decoding
- Add automatic profile detection using orderedjson to identify field ordering from JSON
- Add SetProfile() method for explicit profile control
- Update Encoder to preserve SD blob profile when reconstructing streams
- Add WithSerializationProfile() EncoderOption for manifest creation
- Add comprehensive tests for both serialization profiles and profile detection
- Add dependencies: github.com/glopal/orderedjson, github.com/samber/lo


---
* Test: `go test ./stream/...`

<!-- kody-pr-summary:start -->
This pull request adds support for dual serialization profiles for SD (Stream Descriptor) blobs, enabling compatibility with both the new alphabetical field ordering and the legacy Python SDK field ordering.

Key changes:
- Added serialization profile system with two modes: `profileNewSort` (alphabetical ordering) and `profileOldSort` (legacy Python SDK ordering)
- Implemented automatic profile detection when unmarshaling JSON by analyzing field order
- Added `SetSerializationProfile()` method to explicitly set the desired profile
- Enhanced JSON marshaling/unmarshaling to handle both field orderings correctly
- Updated encoder to support profile configuration and preserve it when creating SD blobs
- Added comprehensive test coverage for both serialization profiles

The implementation ensures backward compatibility with existing SD blobs while providing flexibility for new implementations to choose the preferred field ordering.
<!-- kody-pr-summary:end -->